### PR TITLE
[fixes 12730645] Requests should be created with the correct class.

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -113,7 +113,7 @@ class Batch < ActiveRecord::Base
   end
 
   def control
-    self.requests.detect { |request| request.asset.try(:resource?) }
+    self.requests.detect { |request| request.try(:asset).try(:resource?) }
   end
 
   def has_control?
@@ -435,8 +435,10 @@ class Batch < ActiveRecord::Base
 
     self.shift_item_positions(first_control+1, control_count)
     1.upto(control_count) do |index|
-      request = self.requests.create(:asset => asset, :study_id => 198, :request_type_id => self.pipeline.request_type_id)
-      request.set_position(self, first_control+index)
+      self.pipeline.request_type.create_control!(:asset => asset, :study_id => 198).tap do |request|
+        request.set_position(self, first_control+index)
+        requests << request
+      end
     end
     control_count
   end

--- a/app/models/batch/pipeline_behaviour.rb
+++ b/app/models/batch/pipeline_behaviour.rb
@@ -14,9 +14,7 @@ module Batch::PipelineBehaviour
         pipeline = batch.pipeline
         unless pipeline.nil?
           batch.errors.add(attr, 'too many requests specified') if not pipeline.max_size.nil? and requests.size > pipeline.max_size
-
-          # DISABLED AS THERE IS CODE THAT DOESN'T OBEY THIS RULE IN CHERRYPICKING
-          #batch.errors.add(attr, 'has incorrect type')          if requests.map(&:request_type_id).uniq != [ pipeline.request_type_id ]
+          batch.errors.add(attr, 'has incorrect type')          if requests.map(&:request_type_id).uniq != [ pipeline.request_type_id ]
         end
       end
 

--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -37,7 +37,7 @@ class CherrypickTask < Task
   def generate_control_request(well)
     # TODO: create a genotyping request for the control request
     #Request.create(:state => "pending", :sample => well.sample, :asset => well, :target_asset => Well.create(:sample => well.sample, :name => well.sample.name))
-    Request.create(:asset => well, :target_asset => Well.create(:sample => well.sample, :name => well.sample.name))
+    workflow.pipeline.request_type.create_control!(:asset => well, :target_asset => Well.create(:sample => well.sample, :name => well.sample.name))
   end
 
   def control_well_required?(partial_plate, template)

--- a/app/models/request_factory.rb
+++ b/app/models/request_factory.rb
@@ -211,13 +211,13 @@ class RequestFactory
   # NOTE: This must remain as taking Asset ID and Study ID values, and not be converted to Assets and Study objects, because
   # delayed job does not work with actual ActiveRecord objects.
   def self.create_assets_requests(asset_ids, study_id)
+    raise StandardError, "Can only accept asset IDs" unless asset_ids.all? { |i| i.is_a?(Fixnum) or i.is_a?(String) }
+    raise StandardError, "Can only accept study ID" unless study_id.is_a?(Fixnum) or study_id.is_a?(String)
+
     # internal requests to link study -> request -> asset -> sample
     # TODO: do this as a submission
-    requests = []
-    request_type = RequestType.find_by_key('create_asset')
-    asset_ids.each do |asset_id|
-      requests << Request.new(:study_id => study_id, :asset_id => asset_id, :request_type => request_type)
-    end
+    request_type = RequestType.find_by_key('create_asset') or raise StandardError, "Cannot find create asset request type"
+    requests = asset_ids.map { |asset_id| request_type.new(:study_id => study_id, :asset_id => asset_id) }
     Request.import requests
   end
 end

--- a/db/migrate/20110427101123_fix_control_request_type_in_batches.rb
+++ b/db/migrate/20110427101123_fix_control_request_type_in_batches.rb
@@ -1,0 +1,37 @@
+class FixControlRequestTypeInBatches < ActiveRecord::Migration
+  def self.up
+    ActiveRecord::Base.transaction do
+      done = 0
+      Batch.find_in_batches(:include => [ { :pipeline => :request_type }, { :requests => :asset } ]) do |batches|
+        say_with_time("Doing batches #{done}-#{done+batches.size} ...") do
+          batches.each do |batch|
+            # Some of our batches contain requests that appear to have disappeared!
+            if batch.requests.any?(&:blank?)
+              say("Batch #{batch.id} has requests that have since been deleted")
+            else
+              batch.control.tap do |control|
+                next if control.blank?
+
+                begin
+                  # The control requests are of the Request class and must have the RequestType of the pipeline
+                  control = control.becomes(Request)
+                  control.sti_type        = 'Request'
+                  control.request_type_id = batch.pipeline.request_type_id
+                  control.save!
+                rescue ActiveRecord::RecordInvalid => exception
+                  say("Batch #{batch.id} has control #{control.id} which is invalid: #{exception.record.errors.full_messages.inspect}")
+                end
+              end
+            end
+          end
+        end
+
+        done += batches.size
+      end
+    end
+  end
+
+  def self.down
+    # Nothing to do here, data fix
+  end
+end

--- a/db/migrate/20110430175915_fix_request_metadata_on_broken_batches.rb
+++ b/db/migrate/20110430175915_fix_request_metadata_on_broken_batches.rb
@@ -1,0 +1,63 @@
+class FixRequestMetadataOnBrokenBatches < ActiveRecord::Migration
+  REQUEST_OPTIONS = [ :fragment_size_required_from, :fragment_size_required_to, :library_type ]
+
+  NonUniqueOptionsError = Class.new(StandardError)
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      done, tried, failed = 0, 0, 0
+      Batch.find_in_batches(:include => { :pipeline => :request_type, :requests => :request_metadata }) do |batches|
+        say_with_time("Doing batches #{done}-#{done+batches.size} ...") do
+          batches.each do |batch|
+            # Some of our batches contain requests that appear to have disappeared!
+            if batch.requests.any?(&:blank?)
+              say("Batch #{batch.id} has requests that have since been deleted")
+            elsif batch.valid?
+              # Ignore valid batches, we're only interested in the broken ones
+            else
+              begin
+                # All request options should be identical across all of the requests in a batch.  If they are not, or they
+                # are all nil, then this batch cannot be fixed automatically (and is probably old).
+                request_options = batch.requests.inject(Hash.new { |h,k| h[k] = Set.new }) do |options, request|
+                  options.tap do |options|
+                    REQUEST_OPTIONS.each { |f| options[f].add(request.request_metadata[f]) }
+                  end
+                end
+                REQUEST_OPTIONS.each { |f| request_options[f] = request_options[f].to_a.compact }
+                raise NonUniqueOptionsError, "Batch #{batch.id} has non-unique request options: #{request_options.inspect}" if request_options.values.any? { |o| o.size > 1 }
+
+                # Now that we have the unique options we can assign them to any of the requests that are invalid.  Any
+                # requests that fail to update are invalid for other reasons.  We can also switch the actual request
+                # implementation class at the same time.
+                request_type = batch.pipeline.request_type
+                batch.requests.each do |request|
+                  next if request.valid?
+                  request = request.becomes(request_type.request_class)
+                  request.sti_type = request_type.request_class_name
+                  REQUEST_OPTIONS.each { |f| request.request_metadata[f] = request_options[f].first }
+                  request.save!
+                end
+              rescue NonUniqueOptionsError => exception
+                say(exception.message)
+                failed += 1
+              rescue ActiveRecord::RecordInvalid => exception
+                # There's something very wrong with the request we just tried to update!
+                say("Cannot update requests in batch #{batch.id}: #{exception.record.errors.full_messages.inspect}")
+                failed += 1
+              ensure
+                tried += 1
+              end
+            end
+          end
+
+          done += batches.size
+        end
+      end
+
+      say("Tried #{tried} and failed #{failed}") unless failed.zero?
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/migrate/20110501115345_fix_request_type_for_all_batches.rb
+++ b/db/migrate/20110501115345_fix_request_type_for_all_batches.rb
@@ -1,0 +1,38 @@
+class FixRequestTypeForAllBatches < ActiveRecord::Migration
+  EMPTY_OR_UNIQUE = [0,1]
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      count = 0
+
+      # Cannot eager load the requests as this causes an error during validation
+      Batch.find_in_batches(:include => :pipeline) do |batches|
+        say_with_time("Doing batches #{count}-#{count+batches.size}") do
+          batches.each do |batch|
+            next if batch.valid?
+            next unless Array(batch.errors.on(:requests)).include?('has incorrect type')
+
+            # Determine if we have a unique set of request type IDs, as we can't pick if there are multiple
+            # choices.  We also can't deal with cases where the unique request type isn't the same as the
+            # pipeline.
+            request_type_ids = batch.requests.map(&:request_type_id).compact.uniq
+            if request_type_ids.empty? or ([ batch.pipeline.request_type_id ] == request_type_ids)
+              begin
+                batch.requests.each { |r| r.update_attributes!(:request_type_id => request_type_ids.first) }
+              rescue ActiveRecord::RecordInvalid => exception
+                say("Batch #{batch.id} has requests that fail validation")
+              end
+            else
+              say("Batch #{batch.id} cannot be fixed: requests say #{request_type_ids.inspect} but pipeline is #{batch.pipeline.request_type_id}")
+            end
+          end
+        end
+
+        count += batches.size
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110426154411) do
+ActiveRecord::Schema.define(:version => 20110501115345) do
 
   create_table "archived_properties", :force => true do |t|
     t.text    "value"

--- a/db/seeds/0001_request_types.rb
+++ b/db/seeds/0001_request_types.rb
@@ -1,0 +1,5 @@
+RequestType.create!(
+  :name => 'Create Asset', :key => 'create_asset', :order => 1, 
+  :asset_type => 'Asset', :multiples_allowed => false,
+  :request_class_name => 'CreateAssetRequest', :morphology => RequestType::LINEAR
+)

--- a/features/7711055_new_request_links_broken.feature
+++ b/features/7711055_new_request_links_broken.feature
@@ -100,7 +100,7 @@ Feature: Creating new requests from an asset
       | Library tube             | Request additional sequencing |
       | Multiplexed library tube | Request additional sequencing |
 
-  @sample_tube
+  @sample_tube @foo
   Scenario Outline: Requesting an additional library from a sample tube
     Given user "John Smith" is a manager of "Study testing new request"
       And the asset "Sample tube for testing new request" belongs to study "Study testing new request"
@@ -124,6 +124,7 @@ Feature: Creating new requests from an asset
       | Pulldown library creation      |
       | PacBio Sample Prep             |
 
+  @foo
   Scenario Outline: Requesting more sequencing of an library
     Given user "John Smith" is a manager of "Study testing new request"
       And the asset "<asset type> for testing new request" belongs to study "Study testing new request"
@@ -158,7 +159,7 @@ Feature: Creating new requests from an asset
       | Multiplexed library tube | Paired end sequencing          | 150                         | 400                       |
       | Multiplexed library tube | HiSeq Paired end sequencing    | 150                         | 400                       |
 
-  @library_tube @multiplexed_library_tube @accession
+  @library_tube @multiplexed_library_tube @accession @foo
   Scenario Outline: Requesting more sequencing of a library where the study needs accession numbers
     Given user "John Smith" is a manager of "Study testing new request"
       And study "Study testing new request" has an accession number

--- a/features/api/pipelines.feature
+++ b/features/api/pipelines.feature
@@ -229,7 +229,7 @@ Feature: Access pipelines through the API
       }
       """
 
-  @create @batch @authorised @error @wip
+  @create @batch @authorised @error
   Scenario Outline: Attempting to create a batch with invalid request details
     Given the maximum batch size for the pipeline "Cluster formation PE" is 2
 

--- a/features/step_definitions/6679401_batch_request_recycling_broken_steps.rb
+++ b/features/step_definitions/6679401_batch_request_recycling_broken_steps.rb
@@ -175,7 +175,8 @@ Given /^I have a batch with (\d+) requests for the "(#{LIBRARY_CREATION_PIPELINE
       :asset_type => :sample_tube,
       :request_options => {
         :fragment_size_required_from => 1,
-        :fragment_size_required_to   => 100
+        :fragment_size_required_to   => 100,
+        :library_type                => 'Standard'
       }
     }
   end

--- a/features/step_definitions/study_steps.rb
+++ b/features/step_definitions/study_steps.rb
@@ -316,13 +316,13 @@ end
 Given /^asset with barcode "([^"]*)" belongs to study "([^"]*)"$/ do |raw_barcode, study_name|
   study = Study.find_by_name(study_name) or raise StandardError, "Cannot find study #{study_name.inspect}"
   asset = Asset.find_from_machine_barcode(raw_barcode) or raise StandardError, "Cannot find asset with machine barcode #{raw_barcode.inspect}"
-  RequestFactory.create_assets_requests([asset], study)
+  RequestFactory.create_assets_requests([asset.id], study.id)
 end
 
 Given /^the asset "([^\"]+)" belongs to study "([^\"]+)"$/ do |asset_name, study_name|
   study = Study.find_by_name(study_name) or raise StandardError, "Cannot find study #{study_name.inspect}"
   asset = Asset.find_by_name(asset_name) or raise StandardError, "Cannot find asset #{asset_name.inspect}"
-  RequestFactory.create_assets_requests([asset], study)
+  RequestFactory.create_assets_requests([asset.id], study.id)
 end
 
 Then /^abbreviation for Study "([^"]*)" should be "([^"]*)"$/ do |study_name, abbreviation_regex|

--- a/test/unit/cherrypick_task_test.rb
+++ b/test/unit/cherrypick_task_test.rb
@@ -7,7 +7,8 @@ end
 class CherrypickTaskTest < ActiveSupport::TestCase
   context CherrypickTask do
     setup do
-      @task = CherrypickTask.new
+      pipeline = Pipeline.find_by_name('Cherrypick') or raise StandardError, "Cannot find cherrypick pipeline"
+      @task = CherrypickTask.new(:workflow => pipeline.workflow)
     end 
 
     context "#robot_max_plates with valid inputs" do

--- a/test/unit/sequencing_pipeline_test.rb
+++ b/test/unit/sequencing_pipeline_test.rb
@@ -9,13 +9,20 @@ class SequencingPipelineTest < ActiveSupport::TestCase
     setup do
       @pipeline = SequencingPipeline.new(
         :workflow     => LabInterface::Workflow.new,
-        :request_type => RequestType.new
+        :request_type => RequestType.new(:request_class_name => 'SequencingRequest')
       )
     end
 
     context '#detach_request_from_batch' do
       should 'clone the request and add appropriate comments' do
-        batch, request = @pipeline.batches.build, @pipeline.request_type.new
+        batch   = @pipeline.batches.build
+        request = @pipeline.request_type.new(
+          :request_metadata_attributes => {
+            :fragment_size_required_from => 100,
+            :fragment_size_required_to   => 200,
+            :read_length                 => 76
+          }
+        )
 
         clone = @pipeline.detach_request_from_batch(batch, request)
         assert_equal('pending', clone.state)


### PR DESCRIPTION
It's important that the requests in a batch are of the correct class and
RequestType.  This code refactors the request creation so that it goes
through the RequestType in the appropriate places, and adds a
create_control! method on RequestType for creating control requests.
