### PR TITLE
[fixes 13444329] Remove create & update actions for samples.

### DIFF
--- a/app/api/endpoints/samples.rb
+++ b/app/api/endpoints/samples.rb
@@ -1,6 +1,6 @@
 class ::Endpoints::Samples < ::Core::Endpoint::Base
   model do
-    action(:create, :to => :standard_create!)
+
   end
 
   instance do
@@ -8,7 +8,5 @@ class ::Endpoints::Samples < ::Core::Endpoint::Base
       :sample_tubes, :json => 'sample_tubes', :to => 'sample_tubes',
       :include => [ :library_tubes, :sample, :requests ]
     )
-
-    action(:update, :to => :standard_update!)
   end
 end

--- a/features/api/root.feature
+++ b/features/api/root.feature
@@ -32,8 +32,7 @@ Feature: The entry point for the API gives directions to the other actions
 
         "samples": {
           "actions": {
-            "read": "http://www.example.com/api/1/samples",
-            "create": "http://www.example.com/api/1/samples"
+            "read": "http://www.example.com/api/1/samples"
           }
         },
 

--- a/features/api/samples.feature
+++ b/features/api/samples.feature
@@ -2,7 +2,7 @@
 Feature: Access samples through the API
   In order to actually be able to do anything useful
   As an authenticated user of the API
-  I want to be able to create, read and update individual samples through their UUID
+  I want to be able to read individual samples through their UUID
   And I want to be able to perform other operations to individual samples
   And I want to be able to do all of this only knowing the UUID of a sample
   And I understand I will never be able to delete a sample through its UUID
@@ -14,128 +14,6 @@ Feature: Access samples through the API
     And the WTSI single sign-on service recognises "I-am-authenticated" as "John Smith"
 
     Given I am using the latest version of the API
-
-  # "NOTE": we cannot predefine the ID here so we ignore it in the uuids_to_ids map
-  @create
-  Scenario: Creating a sample
-    Given the UUID of the next sample created will be "00000000-1111-2222-3333-444444444444"
-
-    When I POST the following JSON to the API path "/samples":
-      """
-      {
-        "sample": {
-          "name": "testing_the_api"
-        }
-      }
-      """
-    Then the HTTP response should be "201 Created"
-    And the JSON should match the following for the specified fields:
-      """
-      {
-        "sample": {
-          "actions": {
-            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444",
-            "update": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444"
-          },
-
-          "uuid": "00000000-1111-2222-3333-444444444444",
-          "name": "testing_the_api"
-        },
-        "uuids_to_ids": {
-        }
-      }
-      """
-
-  @create @error 
-  Scenario Outline: Creating a sample which results in an error
-    When I POST the following JSON to the API path "/samples":
-      """
-      {
-        "sample": {
-          "<field>": <value>
-        }
-      }
-      """
-    Then the HTTP response should be "422 Unprocessable Entity"
-    And the JSON should match the following for the specified fields:
-      """
-      {
-        "content": {
-          "<field>": [<errors>]
-        }
-      }
-      """
-
-    Scenarios:
-      | field      | value            | errors                                                                    |
-      | name       | null             | "can't be blank", "Sample name can only contain letters, numbers, _ or -" |
-      | name       | ""               | "can't be blank", "Sample name can only contain letters, numbers, _ or -" |
-      | gender     | "Weird"          | "is not included in the list"                                             |
-      | sra_hold   | "Please"         | "is not included in the list"                                             |
-      | dna_source | "Blood donation" | "is not included in the list"                                             |
-
-  @update @error
-  Scenario Outline: Updating the sample associated with the UUID which gives an error
-    Given a sample called "testing_the_api_exists" with ID 1
-    And the UUID for the sample with ID 1 is "00000000-1111-2222-3333-444444444444"
-
-    When I PUT the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
-      """
-      {
-        "sample": {
-          "<field>": <value>
-        }
-      }
-      """
-    Then the HTTP response should be "422 Unprocessable Entity"
-    And the JSON should be:
-      """
-      {
-        "content": {
-          "<field>": [<errors>]
-        }
-      }
-      """
-
-    Scenarios:
-      | field      | value            | errors                                                                                         |
-      | name       | null             | "can't be blank", "cannot be changed", "Sample name can only contain letters, numbers, _ or -" |
-      | name       | ""               | "can't be blank", "cannot be changed", "Sample name can only contain letters, numbers, _ or -" |
-      | name       | "jolly_nice"     | "cannot be changed"                                                                            |
-      | gender     | "Weird"          | "is not included in the list"                                                                  |
-      | sra_hold   | "Please"         | "is not included in the list"                                                                  |
-      | dna_source | "Blood donation" | "is not included in the list"                                                                  |
-
-  @update
-  Scenario: Updating the sample associated with the UUID
-    Given a sample called "testing_the_api_exists" with ID 1
-    And the UUID for the sample with ID 1 is "00000000-1111-2222-3333-444444444444"
-
-    When I PUT the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
-      """
-      {
-        "sample": {
-
-        }
-      }
-      """
-    Then the HTTP response should be "200 OK"
-    And the JSON should match the following for the specified fields:
-      """
-      {
-        "sample": {
-          "actions": {
-            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444",
-            "update": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444"
-          },
-
-          "uuid": "00000000-1111-2222-3333-444444444444"
-        },
-        "uuids_to_ids": {
-          "00000000-1111-2222-3333-444444444444": 1
-        }
-      }
-      """
 
   @read @error
   Scenario: Reading the JSON for a UUID that does not exist
@@ -160,8 +38,7 @@ Feature: Access samples through the API
       {
         "sample": {
           "actions": {
-            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444",
-            "update": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444"
+            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-444444444444"
           },
 
           "uuid": "00000000-1111-2222-3333-444444444444",


### PR DESCRIPTION
These two actions are broken and should not be available to clients of
the API.
