### PR TITLE
display 500 results for some assets in legacy api.

### DIFF
--- a/app/models/lane.rb
+++ b/app/models/lane.rb
@@ -1,6 +1,7 @@
 class Lane < Asset
   include LocationAssociation::Locatable
   named_scope :including_associations_for_json, { :include => [:uuid_object, :barcode_prefix ] }
+  @@per_page = 500
   
 
   LIST_REASONS_NEGATIVE = [

--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -3,6 +3,7 @@ class LibraryTube < Asset
   include LocationAssociation::Locatable
 
   named_scope :including_associations_for_json, { :include => [ :uuid_object, { :tag_instance => { :tag => [ :uuid_object, { :tag_group => :uuid_object } ] } },  {:source_request => [:uuid_object, :request_metadata] }, :barcode_prefix, { :sample => :uuid_object }] }
+  @@per_page = 500
 
   def url_name
     "library_tube"

--- a/app/models/multiplexed_library_tube.rb
+++ b/app/models/multiplexed_library_tube.rb
@@ -1,6 +1,8 @@
 class MultiplexedLibraryTube < Asset
   include LocationAssociation::Locatable
   named_scope :including_associations_for_json, { :include => [:uuid_object, :barcode_prefix ] }
+  @@per_page = 500
+  
   def is_a_pool?
     true
   end

--- a/app/models/sample_tube.rb
+++ b/app/models/sample_tube.rb
@@ -6,6 +6,7 @@ class SampleTube < Asset
   named_scope :including_associations_for_json, { :include => [ :uuid_object, :barcode_prefix, { :sample => :uuid_object } ] }
   named_scope :with_sample_id, lambda { |id| { :conditions => { :sample_id => id } } }
   named_scope :with_sample, lambda { |sample| { :conditions => { :sample_id => sample.id } } }
+  @@per_page = 500
 
   # In theory these two callbacks should ensure that if a 2D barcode is set then the barcode of
   # the SampleTube is properly configured, otherwise it will be set to the ID of the SampleTube

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -6,15 +6,16 @@ class Well < Asset
 
   contained_by :plate
   delegate :location, :to => :container , :allow_nil => true
-  
+  @@per_page = 500
   has_one :well_attribute
 
   # # TODO:  remove asset link and use tag_instance via content
   #contains :tag_instance
   has_one :tag_instance, :through => :links_as_parent, :source => :descendant, :conditions => { :sti_type => 'TagInstance' }
   after_create :create_well_attribute_if_not_exists
-
+  
   named_scope :including_associations_for_json, { :include => [:uuid_object, :map, :well_attribute, :container, { :sample => :uuid_object } ] }
+
   named_scope :with_blank_samples, { :conditions => { :samples => { :empty_supplier_sample_name => true } }, :joins => :sample }
 
   class << self


### PR DESCRIPTION
Theres a constant overhead which means 50 results 
render in about the same amount of time as 500 results.
