### PR TITLE
when manifest is updated dont create update event on well with no plate

### DIFF
--- a/app/models/sample_manifest/plate_behaviour.rb
+++ b/app/models/sample_manifest/plate_behaviour.rb
@@ -83,7 +83,7 @@ module SampleManifest::PlateBehaviour
     end
 
     def updated_by!(user, samples)
-      samples.map { |s| s.wells.map(&:plate) }.flatten.uniq.each do |plate|
+      samples.map { |s| s.wells.map(&:plate) }.flatten.uniq.select{ |well_container| ! well_container.nil? }.each do |plate|
         plate.events.updated_using_sample_manifest!(user)
       end
     end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -365,19 +365,6 @@ Factory.define :asset_group_asset do |aga|
   aga.asset_group   {|asset_group| asset_group.association(:asset_group)}
 end
 
-Factory.define :well_attribute do |w|
-  w.concentration       23.2
-  w.current_volume      15
-end
-
-Factory.define :well do |a|
-  a.name                {|a| Factory.next :asset_name }
-  a.value               ""
-  a.qc_state            ""
-  a.resource            nil
-  a.barcode             nil
-  a.well_attribute      {|wa| wa.association(:well_attribute)}
-end
 
 Factory.define :fragment do |fragment|
 end

--- a/test/factories/well_factories.rb
+++ b/test/factories/well_factories.rb
@@ -1,0 +1,24 @@
+Factory.define :well do |a|
+  a.name                {|a| Factory.next :asset_name }
+  a.value               ""
+  a.qc_state            ""
+  a.resource            nil
+  a.barcode             nil
+  a.well_attribute      {|wa| wa.association(:well_attribute)}
+end
+
+Factory.define :well_attribute do |w|
+  w.concentration       23.2
+  w.current_volume      15
+end
+
+
+
+Factory.define :well_with_sample_and_without_plate, :class => Well do |a|
+  a.sample { |sample| sample.association(:sample) }
+end
+
+Factory.define :well_with_sample_and_plate, :class => Well do |a|
+  a.sample { |sample| sample.association(:sample) }
+  a.plate  { |plate| plate.association(:plate) }
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,9 +3,11 @@ require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
 #TODO: for rails 3 replace with rails/test_help
 require "test_help"
 
+require File.expand_path(File.join(Rails.root, %w{test factories.rb}))
+ Dir.glob(File.expand_path(File.join(Rails.root, %w{test factories ** *.rb}))) do |factory_filename|
+   require factory_filename
+ end
 
-require "#{Rails.root}/test/factories"
-require "#{Rails.root}/test/factories/pipelines_factories"
 require "#{Rails.root}/test/unit/task_test_base"
 
 # Turn auditing off by default.  If you need it call Audit.enable_auditing

--- a/test/unit/sample_manifest_test.rb
+++ b/test/unit/sample_manifest_test.rb
@@ -116,4 +116,30 @@ class SampleManifestTest < ActiveSupport::TestCase
       end
     end
   end
+  
+  context "update event" do
+    setup do
+      @user = Factory :user
+      @well_with_sample_and_plate = Factory :well_with_sample_and_plate
+    end
+    context "where a well has no plate" do
+      setup do
+        @well_with_sample_and_without_plate = Factory :well_with_sample_and_without_plate
+      end
+      should "not try to add an event to a plate" do
+        assert_nothing_raised do
+          SampleManifest::PlateBehaviour::Core.new(SampleManifest.new).updated_by!(@user,[@well_with_sample_and_plate.sample, @well_with_sample_and_without_plate.sample])
+        end
+      end
+    end
+    context "where a well has a plate" do
+      should "add an event to the plate" do
+        SampleManifest::PlateBehaviour::Core.new(SampleManifest.new).updated_by!(@user,[@well_with_sample_and_plate.sample])
+        assert_equal Event.last, @well_with_sample_and_plate.plate.events.last
+        assert_not_nil @well_with_sample_and_plate.plate.events.last
+      end
+    end
+    
+  end
+  
 end


### PR DESCRIPTION
wells that have been requested for cherrypicking, but not picked dont have a plate, so an event cant be added to say the sample info has been updated.
