### PR TITLE
[fixes 14691821] Plug a potential memory leak in the API GC handling.

### DIFF
--- a/app/api/core/service/endpoint_handling.rb
+++ b/app/api/core/service/endpoint_handling.rb
@@ -1,0 +1,21 @@
+module Core::Service::EndpointHandling
+  def self.included(base)
+    base.class_eval do
+      attr_reader :endpoint
+    end
+  end
+
+  def instance(action, endpoint)
+    benchmark('Instance handling') do
+      @endpoint = endpoint
+      @endpoint.instance_handler.send(action, self, path)
+    end
+  end
+
+  def model(action, endpoint)
+    benchmark('Model handling') do
+      @endpoint = endpoint
+      @endpoint.model_handler.send(action, self, path)
+    end
+  end
+end

--- a/app/api/core/service/error_handling.rb
+++ b/app/api/core/service/error_handling.rb
@@ -23,6 +23,8 @@ module Core::Service::ErrorHandling
 
   module Helpers
     class JsonError
+      include Core::Service::GarbageCollection::Response
+
       def initialize(error)
         @error = error
       end

--- a/app/api/core/service/garbage_collection.rb
+++ b/app/api/core/service/garbage_collection.rb
@@ -1,0 +1,27 @@
+# To improve the performance of the API we can enable and disable the Ruby garbage collector.  By
+# disabling at the start of a request, and re-enabling it after the response has been sent, we can
+# reduce the time spent handling a request.
+module Core::Service::GarbageCollection
+  module Request #:nodoc:
+    def instance(action, endpoint)
+      Rails.logger.debug('Disabling GC')
+      GC.disable
+      super
+    end
+
+    def model(action, endpoint)
+      Rails.logger.debug('Disabling GC')
+      GC.disable
+      super
+    end
+  end
+
+  module Response #:nodoc:
+    def close
+      Rails.logger.debug('Re-enabling and running garbage collector')
+
+      GC.enable
+      GC.start
+    end
+  end
+end


### PR DESCRIPTION
If an action raised an exception then the GC wasn't re-enabled.
Although this is unlikely to be happening in production the cucumber
features do this all of the time.  Before this change the code ran the
risk that the time between an exception from the API to the point where
a valid request was made, could be a while and so the memory could
become used up.
