### PR TITLE
[fixes 14743087] Use Mongrel for fake services as it's quicker.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :warehouse do
 end
 
 group :development do
+  # The fake services run better with Mongrel
+  gem "mongrel", "~>1.1.5"
+
   gem "flay"
   gem "flog"
   gem "roodi"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,7 @@ DEPENDENCIES
   launchy
   log4r
   mocha
+  mongrel (~> 1.1.5)
   mongrel_cluster
   mysql
   net-ldap

--- a/features/support/fake_sinatra_service.rb
+++ b/features/support/fake_sinatra_service.rb
@@ -1,4 +1,15 @@
-class FakeSinatraService 
+# We're going to be using mongrel but it outputs stuff to STDERR.  Luckily it doesn't reference the
+# top-level constant, so we can override it here!
+require 'mongrel'
+class Mongrel::HttpServer
+  const_set(:STDERR, Object.new.tap do |null_outputter|
+    def null_outputter.puts(*args, &block)
+      # Do nothing, we don't care
+    end
+  end)
+end
+
+class FakeSinatraService
   include Singleton
 
   # Ensures that ports are assigned dynamically and that they are random, reducing the chances of
@@ -20,19 +31,6 @@ class FakeSinatraService
     @host, @port = 'localhost', self.class.take_next_port
   end
 
-  def run!(&block)
-    start_sinatra do |thread|
-      begin
-        wait_for_sinatra_to_startup! 
-        yield
-      ensure
-        kill_running_sinatra
-        thread.join
-        clear
-      end
-    end
-  end
-
   def self.install_hooks(target, tags)
     service = self
     target.instance_eval do
@@ -51,8 +49,8 @@ class FakeSinatraService
     raise StandardError, "Cannot start up multiple instances of #{self.class.name}" unless @thread.nil?
 
     start_sinatra do |thread|
-      wait_for_sinatra_to_startup!
       @thread = thread
+      wait_for_sinatra_to_startup!
     end
   end
 
@@ -94,9 +92,10 @@ private
   # We have to pause execution until Sinatra has come up.  This makes a number of attempts to
   # retrieve the root document.  If it runs out of attempts it raises an exception
   def wait_for_sinatra_to_startup!
-    (1..10).each do |_|
+    connect_uri = URI.parse("http://#{@host}:#{@port}/up_and_running")
+    (1..200).each do |i|
       begin
-        Net::HTTP.get(URI.parse("http://#{@host}:#{@port}/up_and_running"))
+        Net::HTTP.get(connect_uri)
         return
       rescue Errno::ECONNREFUSED => exception
         sleep(1)
@@ -107,14 +106,15 @@ private
   end
 
   class Base < Sinatra::Base
+    # Use Mongrel as the handler as it's quicker to start than Webrick.  It might take a few seconds to
+    # shutdown but Webrick takes ~30 to start so Mongrel wins out.
+    HANDLER, QUIT_HANDLER = Rack::Handler.get('mongrel'), :stop
+
     def self.run!(options={})
       set options
-      set :server, %w{webrick}                             # Force Webrick to be used as it's quicker to startup & shutdown
-      handler      = detect_rack_handler
-      handler_name = handler.name.gsub(/.*::/, '')
-      handler.run(self, { :Host => bind, :Port => port }.merge(options.fetch(:webrick, {}))) do |server|
+      HANDLER.run(self, { :Host => bind, :Port => port }.merge(options.fetch(:webrick, {}))) do |server|
         set :running, true
-        set :quit_handler, Proc.new { server.shutdown }   # Kill the Webrick specific instance if we need to
+        set :quit_handler, Proc.new { server.send(QUIT_HANDLER) }
       end
     rescue Errno::EADDRINUSE => e
       raise StandardError, "== Someone is already performing on port #{port}!"
@@ -130,10 +130,18 @@ private
     end
 
     get('/die_eat_flaming_death') do
-      status(200)
-      body('Died!')
-      settings.quit_handler
+      Object.tap do |handler|
+        handler.instance_variable_set(:@quit, settings.method(:quit_handler))
+
+        def handler.each(&block)
+          yield('done')
+        end
+
+        def handler.close
+          @quit.call
+        end
+      end
     end
   end
-end
+end unless self.class.const_defined?(:FakeSinatraService)
 


### PR DESCRIPTION
This commit changes the fake web services to use mongrel which gives an
overall time improvement for features using them.  Webrick takes can
take up to 30s to start, and some features use multiple services,
whereas mongrel can start in a fraction of that time.
