### PR TITLE
[fixes 14869919] Hide 'Not specified' from study type on creation.

### DIFF
--- a/app/models/metadata/form_builder.rb
+++ b/app/models/metadata/form_builder.rb
@@ -22,11 +22,7 @@ class Metadata::FormBuilder < Metadata::BuilderBase
   end
   
   def select_by_association(association, options={})
-    select(:"#{association}_id", association.to_s.classify.constantize.all.map(&:for_select_dropdown))
-  end
-
-  def select_by_association(association, options={})
-    select(:"#{association}_id", association.to_s.classify.constantize.all.map(&:for_select_dropdown))
+    select(:"#{association}_id", association.to_s.classify.constantize.all.map(&:for_select_dropdown).compact)
   end
 
   def checktext_field(field, options = {})

--- a/app/models/study_type.rb
+++ b/app/models/study_type.rb
@@ -1,14 +1,14 @@
 class StudyType < ActiveRecord::Base 
   has_many :study
-  
+
   validates_presence_of  :name
   validates_uniqueness_of :name, :message => "of study type already present in database"
   acts_as_audited :on => [:destroy, :update]
-  
+
   def for_select_dropdown
-    [self.name, self.id]
-  end  
-  
+    valid_for_creation? ? [self.name, self.id] : nil
+  end
+
   def self.include?(studytype_name)
     study_type = StudyType.find_by_name(studytype_name)
     unless study_type.nil?

--- a/db/migrate/20110622085623_add_not_valid_for_creation_flag_to_study_types.rb
+++ b/db/migrate/20110622085623_add_not_valid_for_creation_flag_to_study_types.rb
@@ -1,0 +1,9 @@
+class AddNotValidForCreationFlagToStudyTypes < ActiveRecord::Migration
+  def self.up
+    add_column :study_types, :valid_for_creation, :boolean, :default => true, :null => false
+  end
+
+  def self.down
+    remove_column :study_types, :valid_for_creation
+  end
+end

--- a/db/migrate/20110622085830_hide_not_specified_study_type.rb
+++ b/db/migrate/20110622085830_hide_not_specified_study_type.rb
@@ -1,0 +1,17 @@
+class HideNotSpecifiedStudyType < ActiveRecord::Migration
+  class StudyType < ActiveRecord::Base
+    set_table_name('study_types')
+  end
+
+  def self.set_valid_for_creation_to(state)
+    StudyType.update_all("valid_for_creation=#{state.to_s.upcase}", [ 'name=?', 'Not specified' ])
+  end
+
+  def self.up
+    set_valid_for_creation_to(false)
+  end
+
+  def self.down
+    set_valid_for_creation_to(true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110601083338) do
+ActiveRecord::Schema.define(:version => 20110622085830) do
 
   create_table "archived_properties", :force => true do |t|
     t.text    "value"
@@ -295,7 +295,7 @@ ActiveRecord::Schema.define(:version => 20110601083338) do
     t.integer "parent_id"
     t.string  "thumbnail"
     t.integer "db_file_id"
-    t.string  "documentable_type",     :limit => 50
+    t.string  "documentable_type", :limit => 50
     t.text    "uploaded_file"
   end
 
@@ -950,6 +950,7 @@ ActiveRecord::Schema.define(:version => 20110601083338) do
     t.boolean  "valid_type"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "valid_for_creation", :default => true, :null => false
   end
 
   create_table "subclass_attributes", :force => true do |t|

--- a/db/seeds/0011_study_type.rb
+++ b/db/seeds/0011_study_type.rb
@@ -1,19 +1,19 @@
 study_types = [
-  ["Not specified", 0],
-  ["Synthetic Genomics", 1],
-  ["Exome Sequencing", 0],
-  ["Forensic or Paleo-genomics", 1],
-  ["Pooled Clone Sequencing", 0],
-  ["Gene Regulation Study", 1],
-  ["Cancer Genomics", 1],
-  ["Whole Genome Sequencing", 1],
-  ["Metagenomics", 1],
-  ["Transcriptome Analysis", 1],
-  ["Population Genomics", 1],
-  ["Resequencing", 1],
-  ["Epigenetics", 1],
-  ["TraDIS", 0],
-  ["Clone Sequencing", 0]
+  ["Not specified"              , 0, 0],
+  ["Synthetic Genomics"         , 1, 1],
+  ["Exome Sequencing"           , 0, 1],
+  ["Forensic or Paleo-genomics" , 1, 1],
+  ["Pooled Clone Sequencing"    , 0, 1],
+  ["Gene Regulation Study"      , 1, 1],
+  ["Cancer Genomics"            , 1, 1],
+  ["Whole Genome Sequencing"    , 1, 1],
+  ["Metagenomics"               , 1, 1],
+  ["Transcriptome Analysis"     , 1, 1],
+  ["Population Genomics"        , 1, 1],
+  ["Resequencing"               , 1, 1],
+  ["Epigenetics"                , 1, 1],
+  ["TraDIS"                     , 0, 1],
+  ["Clone Sequencing"           , 0, 1]
 ]
 
-StudyType.import [ :name, :valid_type ], study_types, :validate => false
+StudyType.import [ :name, :valid_type, :valid_for_creation ], study_types, :validate => false


### PR DESCRIPTION
'Not specified' is not a valid selection when creating a study but is
perfectly valid for display, as we have had studies in the past that do
not have this information.
