### PR TITLE
[fixes 15113511] Use AssetLink#create_edge! rather than connect

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
 
 GIT
   remote: git+ssh://git@github.com/sanger/acts-as-dag.git
-  revision: f8135a3c20c81430cd61bb870bec036e887f1db9
+  revision: 2d5c44b836c253a2603bd5b00840ed0c2d31bace
   branch: fix_rewire_crossing
   specs:
     acts-as-dag (1.1.3)

--- a/app/models/add_spiked_in_control_task.rb
+++ b/app/models/add_spiked_in_control_task.rb
@@ -14,7 +14,7 @@ class AddSpikedInControlTask < Task
       next unless request_id_set.include? request.id
       lane = request.target_asset
       next unless lane
-      AssetLink.connect(control_asset, lane) 
+      AssetLink.create_edge!(control_asset, lane) 
     end
 
     control_asset.save!

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -526,7 +526,7 @@ class Asset < ActiveRecord::Base
     
     self.save!
     parent.save!
-    AssetLink.connect(parent, self)
+    AssetLink.create_edge!(parent, self)
   end
 
   def attach_tag(tag)

--- a/app/models/assign_tags_to_wells_task.rb
+++ b/app/models/assign_tags_to_wells_task.rb
@@ -42,7 +42,7 @@ class AssignTagsToWellsTask < Task
         if well.tag_instance.nil?
           tag = Tag.find(tag_id)
           tag_instance  = TagInstance.create!(:tag => tag)
-          AssetLink.connect(well, tag_instance)
+          AssetLink.create_edge!(well, tag_instance)
         else
           raise "Unable to add multiple tags to a well."
         end

--- a/app/models/plate_purpose.rb
+++ b/app/models/plate_purpose.rb
@@ -37,7 +37,7 @@ class PlatePurpose < ActiveRecord::Base
         RequestFactory.create_assets_requests([child_plate.id], plate.study.id)
       end
       child_plate.delayed_stamp_samples_into_wells(plate.id)
-      AssetLink.connect(plate,child_plate)
+      AssetLink.create_edge!(plate,child_plate)
       new_child_plates << child_plate
     end
 

--- a/app/models/request_factory.rb
+++ b/app/models/request_factory.rb
@@ -112,7 +112,7 @@ class RequestFactory
 
       request = create_request(request_type, item, asset, target_asset)
       if target_asset
-        AssetLink.connect(asset, target_asset)
+        AssetLink.create_edge!(asset, target_asset)
       end
       requests << request
 

--- a/app/models/sequenom_qc_plate.rb
+++ b/app/models/sequenom_qc_plate.rb
@@ -130,7 +130,7 @@ class SequenomQcPlate < Plate
     
     cloned_well.save!
     
-    AssetLink.connect(source_well, cloned_well)
+    AssetLink.create_edge!(source_well, cloned_well)
   end
   
   

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -129,7 +129,7 @@ class Well < Asset
 
   def create_child_sample_tube
     sample_tube = SampleTube.create(:sample => self.sample, :map => self.map)
-    AssetLink.connect(self, sample_tube)
+    AssetLink.create_edge!(self, sample_tube)
 
     sample_tube
   end

--- a/lib/link_pico_dilution_plates_to_stock.rb
+++ b/lib/link_pico_dilution_plates_to_stock.rb
@@ -3,7 +3,7 @@ num_pico_plates = PicoDilutionPlate.count
 stock_plates = Plate.find(:all, :conditions => "sti_type = 'Plate'", :limit => num_pico_plates)
 count = 0
 PicoDilutionPlate.all.each do |pico_plate|
-  AssetLink.connect(stock_plates[count],pico_plate)
+  AssetLink.create_edge!(stock_plates[count],pico_plate)
   count = count +1
 end
 

--- a/test/functional/pico_dilutions_controller_test.rb
+++ b/test/functional/pico_dilutions_controller_test.rb
@@ -20,8 +20,8 @@ class PicoDilutionsControllerTest < ActionController::TestCase
         @pico_dilution_plate = Factory :plate, :barcode => "2222"
         @assay_plate_a = Factory :plate, :barcode => "9999", :plate_purpose => pico_assay_a_plate_purpose
         @assay_plate_b = Factory :plate, :barcode => "8888", :plate_purpose => pico_assay_b_plate_purpose
-        AssetLink.connect(@pico_dilution_plate,@assay_plate_a)
-        AssetLink.connect(@pico_dilution_plate,@assay_plate_b)
+        AssetLink.create_edge!(@pico_dilution_plate,@assay_plate_a)
+        AssetLink.create_edge!(@pico_dilution_plate,@assay_plate_b)
       end
 
       context "#index" do

--- a/test/functional/plates_controller_test.rb
+++ b/test/functional/plates_controller_test.rb
@@ -139,9 +139,9 @@ class PlatesControllerTest < ActionController::TestCase
         @pico_dilution_plate = Factory :plate, :barcode => "2222"
         @assay_plate_a = Factory :plate, :barcode => "9999", :plate_purpose => pico_assay_a_plate_purpose
         @assay_plate_b = Factory :plate, :barcode => "8888", :plate_purpose => pico_assay_b_plate_purpose
-        AssetLink.connect(@stock_plate,@pico_dilution_plate)
-        AssetLink.connect(@pico_dilution_plate,@assay_plate_a)
-        AssetLink.connect(@pico_dilution_plate,@assay_plate_b)
+        AssetLink.create_edge!(@stock_plate,@pico_dilution_plate)
+        AssetLink.create_edge!(@pico_dilution_plate,@assay_plate_a)
+        AssetLink.create_edge!(@pico_dilution_plate,@assay_plate_b)
       end
     end
   end


### PR DESCRIPTION
AssetLink#connect builds all ancestry links which are not required in
our asset graph.  Instead we should be building links with
AssetLink#create_edge! which only builds the specified edge.  This
should eliminate the issues we are seeing in production.
