### PR TITLE
[fixes 15356889] Create asset requests are always passed.

### DIFF
--- a/app/models/request_factory.rb
+++ b/app/models/request_factory.rb
@@ -217,7 +217,7 @@ class RequestFactory
     # internal requests to link study -> request -> asset -> sample
     # TODO: do this as a submission
     request_type = RequestType.find_by_key('create_asset') or raise StandardError, "Cannot find create asset request type"
-    requests = asset_ids.map { |asset_id| request_type.new(:study_id => study_id, :asset_id => asset_id) }
+    requests = asset_ids.map { |asset_id| request_type.new(:study_id => study_id, :asset_id => asset_id, :state => 'passed') }
     Request.import requests
   end
 end

--- a/db/migrate/20110707080726_change_create_asset_requests_state_to_passed.rb
+++ b/db/migrate/20110707080726_change_create_asset_requests_state_to_passed.rb
@@ -1,0 +1,12 @@
+class ChangeCreateAssetRequestsStateToPassed < ActiveRecord::Migration
+  def self.up
+    Request.update_all(
+      'state="passed"',
+      [ 'request_type_id=?', RequestType.find_by_key('create_asset').id ]
+    )
+  end
+
+  def self.down
+    # Nothing really needed here
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110622141828) do
+ActiveRecord::Schema.define(:version => 20110707080726) do
 
   create_table "archived_properties", :force => true do |t|
     t.text    "value"

--- a/test/unit/request_factory_test.rb
+++ b/test/unit/request_factory_test.rb
@@ -178,4 +178,24 @@ class RequestFactoryTest < ActiveSupport::TestCase
     end
   end
 
+  context '.create_assets_requests' do
+    setup do
+      @study  = Factory(:study)
+      @assets = [ Factory(:sample_tube), Factory(:sample_tube) ]
+
+      RequestFactory.create_assets_requests(@assets.map(&:id), @study.id)
+    end
+
+    should 'have all create asset requests as passed' do
+      assert_equal ['passed'], RequestType.find_by_key('create_asset').requests.map(&:state).uniq
+    end
+
+    should 'have the study on all requests' do
+      assert_equal [@study.id], RequestType.find_by_key('create_asset').requests.map(&:study_id).uniq
+    end
+
+    should 'have the asset IDs' do
+      assert_equal @assets.map(&:id).sort, RequestType.find_by_key('create_asset').requests.map(&:asset_id).sort
+    end
+  end
 end


### PR DESCRIPTION
This ensures that all create asset requests are created in the passed state as the asset has been created.
