### PR TITLE
[fixes 15352609] Remove item ID from UI.

### DIFF
--- a/app/views/assets/complete_move_to_2D.html.erb
+++ b/app/views/assets/complete_move_to_2D.html.erb
@@ -64,7 +64,6 @@
     <tr>
       <th width='5%'>Request ID</th>
       <th width='10%'>Request type</th>
-      <th width='5%'>Item ID</th>
       <th width='10%'>Study name </th>
       <th width='10%'>State</th>
       <th width='10%'>Batches</th>
@@ -81,7 +80,6 @@
     <tr>
       <td><%= link_to(request.id, request, :title => "#{ request.request_type.try(:name) || 'Unknown' } request") %></td>
       <td><%= request.request_type and request.request_type.name %></td>
-      <td><%= request.item_id %></td>
       <td><%= request.study ? request.study.name : "NA" %></td>
       <td><%= request_status(request) %></td>
       <td>

--- a/app/views/assets/show.html.erb
+++ b/app/views/assets/show.html.erb
@@ -85,7 +85,6 @@
     <tr>
       <th width='5%'>Request ID</th>
       <th width='10%'>Request type</th>
-      <th width='5%'>Item ID</th>
       <th width='10%'>Study name </th>
       <th width='10%'>State</th>
       <th width='10%'>Batches</th>
@@ -102,7 +101,6 @@
     <tr>
       <td><%= link_to(request.id, request_url(request), :title => "#{ request.request_type.try(:name) || 'Unknown' } request") %></td>
       <td><%= request.request_type and request.request_type.name %></td>
-      <td><%= request.item_id %></td>
       <td>
         <% if request.study %>
           <%= link_to(request.study.name, study_path(request.study) ) %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -37,7 +37,6 @@
         <th>Study</th>
         <th>Date Created</th>
         <th>Status</th>
-        <th>Item ID</th>
       </tr>
     </thead>
     <tbody>
@@ -68,7 +67,6 @@
         <td><%= link_to(request.study.name, study_path(request.study)) if request.study %></td>
         <td><%= request.created_at.to_formatted_s(:sortable) %></td>
         <td><%= display_status(request.state) %></td>
-        <td><%= link_to(request.item.id, item_url(request.item)) if request.item %></td>
       </tr>
     <% end -%>
   </tbody>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -29,9 +29,6 @@
 <% if @request.study_id %>
 <div class='subtitle'>
   Study <%= @request.study.id %> &middot; Created on <%= @request.study.created_at.to_formatted_s(:long) %> &middot; <%= @request.study.state.capitalize %>
-  <% if @request.item_id %>
-    &middot; Item ID: <%= link_to  @request.item_id, item_url(@request.item) %>
-  <% end %>
 </div>
 <% end %>
 


### PR DESCRIPTION
This removes a number of mentions of 'Item ID' from the views as the
ItemsController no longer exists and certainly shouldn't be linked to.
