### PR TITLE
15408393 large sample manifests break delayed job

### DIFF
--- a/app/models/sample_manifest.rb
+++ b/app/models/sample_manifest.rb
@@ -153,18 +153,8 @@ class SampleManifest < ActiveRecord::Base
   end
   private :generate_sanger_ids
 
-  def delayed_generate_study_samples(study_samples_data)
+  def generate_study_samples(study_samples_data)
     study_sample_fields = [:study_id, :sample_id]
     StudySample.import study_sample_fields, study_samples_data
-  end
-  handle_asynchronously :delayed_generate_study_samples
-
-  def delayed_generate_asset_requests_with_ids(asset_ids,study_id)
-    RequestFactory.create_assets_requests(asset_ids, study_id)
-  end
-  handle_asynchronously :delayed_generate_asset_requests_with_ids
-
-  def delayed_generate_asset_requests(assets,study)
-    delayed_generate_asset_requests_with_ids(assets.map(&:id), study.id)
   end
 end

--- a/app/models/sample_manifest/sample_tube_behaviour.rb
+++ b/app/models/sample_manifest/sample_tube_behaviour.rb
@@ -80,9 +80,14 @@ module SampleManifest::SampleTubeBehaviour
     self.barcodes = tubes.map(&:sanger_human_barcode)
 
     sample_tube_sample_creation(samples_data,self.study.id)
-    delayed_generate_asset_requests(tubes, self.study)
+    delayed_generate_asset_requests(tubes.map(&:id), self.study.id)
     save!
   end
+
+  def delayed_generate_asset_requests(asset_ids,study_id)
+    RequestFactory.create_assets_requests(asset_ids, study_id)
+  end
+  handle_asynchronously :delayed_generate_asset_requests
 
   def sample_tube_sample_creation(samples_data,study_id)
     study_samples_data = []
@@ -93,7 +98,7 @@ module SampleManifest::SampleTubeBehaviour
       sample_tube.save!
       study_samples_data << [study_id, sample.id]
     end
-    delayed_generate_study_samples(study_samples_data)
+    generate_study_samples(study_samples_data)
   end
   private :sample_tube_sample_creation
 end


### PR DESCRIPTION
The size of the delayed job column 'handler' is causing large sample
manifests to truncate their parameters to generate_wells_asynchronously.
This code breaks the manifest into a delayed job for each plate, rather
than one for the entire manifest.
