### PR TITLE
Fragment sizes are fixed for the pulldown pipelines.

### DIFF
--- a/app/models/pulldown/requests.rb
+++ b/app/models/pulldown/requests.rb
@@ -8,6 +8,10 @@ module Pulldown::Requests
         has_metadata :as => Request do
           include BaitLibrary::Associations
           association(:bait_library, :name)
+
+          # Redefine the fragment size attributes as they are fixed
+          attribute(:fragment_size_required_from, :required => true, :in => [ 100 ], :default => 100)
+          attribute(:fragment_size_required_to,   :required => true, :in => [ 400 ], :default => 400)
         end
         include Request::LibraryManufacture
       end
@@ -27,7 +31,11 @@ module Pulldown::Requests
     DEFAULT_LIBRARY_TYPE = 'Standard'
     LIBRARY_TYPES        = [ DEFAULT_LIBRARY_TYPE ]
 
-    has_metadata :as => Request
+    has_metadata :as => Request do
+      # Redefine the fragment size attributes as they are fixed
+      attribute(:fragment_size_required_from, :required => true, :in => [ 300 ], :default => 300)
+      attribute(:fragment_size_required_to,   :required => true, :in => [ 500 ], :default => 500)
+    end
     include Request::LibraryManufacture
   end
 

--- a/db/migrate/20110519125824_create_pulldown_submission_templates.rb
+++ b/db/migrate/20110519125824_create_pulldown_submission_templates.rb
@@ -7,9 +7,9 @@ class CreatePulldownSubmissionTemplates < ActiveRecord::Migration
   ]
 
   REQUEST_TYPES_TO_DEFAULTS = {
-    'Pulldown WGS' => { :library_type => 'Standard' },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown' },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown' }
+    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
+    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
+    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
   }
 
   def self.up

--- a/db/seeds/0007_submission_templates.rb
+++ b/db/seeds/0007_submission_templates.rb
@@ -22,9 +22,9 @@ def create_pulldown_submission_templates
   ]
 
   request_types_to_defaults = {
-    'Pulldown WGS' => { :library_type => 'Standard' },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown' },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown' }
+    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
+    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
+    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
   }
 
   workflow   = Submission::Workflow.find_by_key('short_read_sequencing') or raise StandardError, 'Cannot find Next-gen sequencing workflow'

--- a/db/seeds/9999_pulldown_setup.rb
+++ b/db/seeds/9999_pulldown_setup.rb
@@ -56,7 +56,6 @@ if ENV['PULLDOWN']
         :assets => stock_plate.wells,
         :request_options => {
           :read_length => 100,
-          :fragment_size_required_from => 100, :fragment_size_required_to => 200,
           :bait_library_name => BaitLibrary.first.name
         }
       ).built!
@@ -68,7 +67,6 @@ if ENV['PULLDOWN']
         :assets => stock_plate.wells.slice(0, 48),
         :request_options => {
           :read_length => 100,
-          :fragment_size_required_from => 100, :fragment_size_required_to => 200,
           :bait_library_name => BaitLibrary.first.name
         }
       ).built!
@@ -77,7 +75,6 @@ if ENV['PULLDOWN']
         :assets => stock_plate.wells.slice(48, 96),
         :request_options => {
           :read_length => 100,
-          :fragment_size_required_from => 100, :fragment_size_required_to => 200,
           :bait_library_name => BaitLibrary.first.name
         }
       ).built!
@@ -95,7 +92,6 @@ if ENV['PULLDOWN']
           :assets => wells_to_submit,
           :request_options => {
             :read_length => 100,
-            :fragment_size_required_from => 100, :fragment_size_required_to => 200,
             :bait_library_name => BaitLibrary.first.name
           }
         ).built!


### PR DESCRIPTION
The fragment sizes for the pulldown pipelines are always fixed to a particular range and should not be adjustable.
