### PR TITLE
Various fixes from testing in the next release environment.

### DIFF
--- a/app/models/api/batch_io.rb
+++ b/app/models/api/batch_io.rb
@@ -20,7 +20,7 @@ class Api::BatchIO < Api::Base
   map_attribute_to_json_attribute(:uuid)
   map_attribute_to_json_attribute(:id)
   map_attribute_to_json_attribute(:state)
-  map_attribute_to_json_attribute(:compatible_qc_state)
+  map_attribute_to_json_attribute(:qc_state)
   map_attribute_to_json_attribute(:production_state)
   map_attribute_to_json_attribute(:created_at)
   map_attribute_to_json_attribute(:updated_at)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ActiveRecord::Base
-
+  include Uuid::Uuidable
   include EventfulRecord
   include Workflowed
   extend EventfulRecord

--- a/app/models/request/statistics.rb
+++ b/app/models/request/statistics.rb
@@ -54,6 +54,7 @@ module Request::Statistics
     end
 
     def progress
+      return 0 if self.passed.zero?  # If there are no passed then the progress is 0% by definition
       (self.passed * 100) / (self.total - self.failed)
     end
   end

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -1,4 +1,6 @@
 class TagGroup < ActiveRecord::Base
+  include Uuid::Uuidable
+
   has_many :tags
   acts_as_audited :on => [:destroy, :update]
 

--- a/db/migrate/20110519125824_create_pulldown_submission_templates.rb
+++ b/db/migrate/20110519125824_create_pulldown_submission_templates.rb
@@ -7,9 +7,9 @@ class CreatePulldownSubmissionTemplates < ActiveRecord::Migration
   ]
 
   REQUEST_TYPES_TO_DEFAULTS = {
-    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
+    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => '300', :fragment_size_required_to => '500' },
+    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' },
+    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' }
   }
 
   def self.up

--- a/db/migrate/20110804154629_remove_batch_limits_from_pipelines.rb
+++ b/db/migrate/20110804154629_remove_batch_limits_from_pipelines.rb
@@ -1,0 +1,9 @@
+class RemoveBatchLimitsFromPipelines < ActiveRecord::Migration
+  def self.up
+    Pipeline.update_all('max_size=8', 'name LIKE "%Cluster formation%"')
+  end
+
+  def self.down
+    Pipeline.update_all('max_size=NULL', 'name LIKE "%Cluster formation%"')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110731184359) do
+ActiveRecord::Schema.define(:version => 20110804154629) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false

--- a/db/seeds/0007_submission_templates.rb
+++ b/db/seeds/0007_submission_templates.rb
@@ -22,9 +22,9 @@ def create_pulldown_submission_templates
   ]
 
   request_types_to_defaults = {
-    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
+    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => '300', :fragment_size_required_to => '500' },
+    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' },
+    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' }
   }
 
   workflow   = Submission::Workflow.find_by_key('short_read_sequencing') or raise StandardError, 'Cannot find Next-gen sequencing workflow'

--- a/db/seeds/0017_bait_libraries.rb
+++ b/db/seeds/0017_bait_libraries.rb
@@ -1,7 +1,8 @@
 # Generate a few bait libraries.
 BaitLibrary::Supplier.create!(:name => 'Agilent').tap do |supplier|
-  supplier.bait_libraries.create!(:name => 'SureSelect Human all exon 50MB', :target_species => 'Human')
-  supplier.bait_libraries.create!(:name => 'SureSelect Mouse all exon 50MB', :target_species => 'Mouse')
-  supplier.bait_libraries.create!(:name => 'SureSelect Human custom', :target_species => 'Human')
-  supplier.bait_libraries.create!(:name => 'SureSelect Mouse custom', :target_species => 'Mouse')
+  # Standard bait libraries
+  supplier.bait_libraries.create!(:name => 'Human all exon 50MB', :target_species => 'Human')
+  supplier.bait_libraries.create!(:name => 'Mouse all exon',      :target_species => 'Mouse')
+  supplier.bait_libraries.create!(:name => 'Zebrafish ZV9',       :target_species => 'Zebrafish')
+  supplier.bait_libraries.create!(:name => 'Zebrafish ZV8',       :target_species => 'Zebrafish')
 end


### PR DESCRIPTION
The progress of anything is 0% if there are no passed requests.

Various things need UUID, like item and tag group.  And the qc_state on
a batch comes from qc_state, not compatible_qc_state which is on asset.

Updated the bait library information in the seeds and fixed the fragment
sizes in the migration and the seeds as the column is a string.

Added a batch limit to the cluster formation pipelines as these had nil
or 2, both of which are wrong!
