### PR TITLE
Couple of bugs & performance enhancement.

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -44,7 +44,7 @@ class SamplesController < ApplicationController
   end
 
   def show
-    @sample  = Sample.find(params[:id])
+    @sample  = Sample.find(params[:id], :include => :assets)
     @studies = Study.all(:conditions => ["state = ? OR state = ?", "pending", "active"], :order => :name)
 
     respond_to do |format|

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -433,10 +433,11 @@ class Batch < ActiveRecord::Base
     first_control = [3, (self.item_limit - control_count)].min
 
     self.shift_item_positions(first_control+1, control_count)
-    requests << (1..control_count).map do |index|
-      self.pipeline.request_type.create_control!(:asset => asset, :study_id => 198).tap do |request|
-        request.set_position(self, first_control+index)
-      end
+    (1..control_count).each do |index|
+      self.batch_requests.create!(
+        :request  => self.pipeline.request_type.create_control!(:asset => asset, :study_id => 198),
+        :position => first_control+index
+      )
     end
     control_count
   end

--- a/app/models/cherrypick_for_pulldown_pipeline.rb
+++ b/app/models/cherrypick_for_pulldown_pipeline.rb
@@ -1,6 +1,10 @@
 class CherrypickForPulldownPipeline < CherrypickingPipeline
   include Pipeline::InboxGroupedBySubmission
 
+  def display_next_pipeline?
+    true
+  end
+
   ALWAYS_SHOW_RELEASE_ACTIONS = true
 
   def post_finish_batch(batch, user)

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -36,7 +36,7 @@ class Pipeline < ActiveRecord::Base
 
     # Used by the Pipeline class to retrieve the list of requests that are coming into the pipeline.
     def inputs(show_held_requests = false)
-      send(show_held_requests ? :full_inbox : :pipeline_pending)
+      ready_in_storage.send(show_held_requests ? :full_inbox : :pipeline_pending)
     end
   end
 
@@ -68,6 +68,10 @@ class Pipeline < ActiveRecord::Base
   
   def inbox_partial
     INBOX_PARTIAL
+  end
+
+  def display_next_pipeline?
+    false
   end
 
   def requires_position?

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -310,12 +310,6 @@ class Request < ActiveRecord::Base
     end
   end
 
-  def set_position(batch, pos)
-    batch.reload
-    batch_request = batch.batch_requests.detect { |br| br.request_id == self.id }
-    batch_request.move_to_position!(pos) if batch_request.present?
-  end
-
   def self.number_expected_for_submission_id_and_request_type_id(submission_id, request_type_id)
     Request.count(:conditions => "submission_id = #{submission_id} and request_type_id = #{request_type_id}")
   end

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -323,12 +323,16 @@ class Study < ActiveRecord::Base
 
   # Yields information on the state of all assets in a convenient fashion for displaying in a table.
   def asset_progress(assets = nil, &block)
-    yield(self.requests.asset_statistics(:having => (assets && "asset_id IN (#{assets.map(&:id).join(',')})")))
+    conditions = { }
+    conditions[:having] = "asset_id IN (#{assets.map(&:id).join(',')})" unless assets.blank?
+    yield(self.requests.asset_statistics(conditions))
   end
 
   # Yields information on the state of all samples in a convenient fashion for displaying in a table.
   def sample_progress(samples = nil, &block)
-    yield(self.requests.sample_statistics(:having => (samples && "sample_id IN (#{samples.map(&:id).join(',')})")))
+    conditions = { }
+    conditions[:having] = "sample_id IN (#{samples.map(&:id).join(',')})" unless samples.blank?
+    yield(self.requests.sample_statistics(conditions))
   end
 
   def study_status

--- a/app/views/pipelines/_assets.html.erb
+++ b/app/views/pipelines/_assets.html.erb
@@ -5,7 +5,7 @@
       <th class='label'><%= link_to "Internal ID", "javascript:void(0);" %></th>
 			<th class='label'><%= link_to "Barcode", "javascript:void(0);" %></th>
       <th class='label'><%= link_to "Wells", "javascript:void(0);" %></th>
-      <th class="label"><%= link_to "Next Pipeline", "javascript:void(0);" %></th>
+      <% if @pipeline.display_next_pipeline? %><th class="label"><%= link_to "Next Pipeline", "javascript:void(0);" %></th><% end %>
 			<th class='label'><% if @pipeline.group_by_submission? -%><%= link_to "Submission", "javascript:void(0);" %><% end -%></th>
 			<th class='label'><% if @pipeline.group_by_study? %><%= link_to "Study", "javascript:void(0);" %><% end%></th>
       <th class='label'></th>
@@ -14,10 +14,9 @@
   <tbody>
     <!-- <%= @request_groups.inspect -%> -->
     <% @request_groups.each_with_index do |(group, requests),index| -%>
-      <% if group.blank? -%>
-        Null Group
-      <% next; end -%>
-      <% hash_group = @pipeline.group_key_to_hash(group) %>
+      <% if group.blank? -%><tr><td colspan="7">Null Group</td></tr><% next; end -%>
+
+      <%# hash_group = @pipeline.group_key_to_hash(group) %>
       <% group_id = group.join(", ") %>
       <%- #beware , the group will be destructed after the shift operation %>
       <%  parent  = @pipeline.group_by_parent? && ( pid = group.shift ) && Asset.find(pid) %>
@@ -35,7 +34,7 @@
           <td><%= parent.id %></td>
           <td><%= parent.sanger_human_barcode %></td>
           <td><%= requests.size %></td>
-          <td><%= next_pipeline_name_for(requests.first) %></td>
+          <% if @pipeline.display_next_pipeline? %><td><%= next_pipeline_name_for(requests.first) %></td><% end %>
 					<td>
           	<% if @pipeline.group_by_submission? %>
           		<%= submission_id %>
@@ -49,16 +48,16 @@
           <td><%= link_to 'Show plate', show_plate_asset_url(parent) %></td>
         </tr>
       <% else %>
-      <tr>
-        <td class="request center" width='5%' colspan="3" style="background:red;font-weight:bold;">Empty parent ID set</td>
-        <td style="background:red;"><%= requests.size %></td>
-        <td style="background:red;">&nbsp;</td>
-        <td style="background:red;">&nbsp;</td>
-        <td style="background:red;">&nbsp;</td>
-				<td style="background:red;">&nbsp;</td>
-				<td style="background:red;">&nbsp;</td>
-				<td style="background:red;">&nbsp;</td>
-      </tr>
+        <tr>
+          <td class="request center" width='5%' colspan="3" style="background:red;font-weight:bold;">Empty parent ID set</td>
+          <td style="background:red;"><%= requests.size %></td>
+          <td style="background:red;">&nbsp;</td>
+          <td style="background:red;">&nbsp;</td>
+          <td style="background:red;">&nbsp;</td>
+          <td style="background:red;">&nbsp;</td>
+          <td style="background:red;">&nbsp;</td>
+          <td style="background:red;">&nbsp;</td>
+        </tr>
       <% end -%>
     <% end -%>
   </tbody>

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -141,7 +141,6 @@ class BatchTest < ActiveSupport::TestCase
     context "create requests" do
       setup do
         Request.any_instance.stubs(:mark_in_batch).returns(true)
-        Request.any_instance.stubs(:set_position).returns(true)
 
         @requests    = (1..4).map { |_| Factory(:request, :request_type => @pipeline.request_type) }
         @request_ids = @requests.map { |r| Request.new_proxy(r.id) }
@@ -292,7 +291,6 @@ class BatchTest < ActiveSupport::TestCase
     context "create requests" do
       setup do
         Request.any_instance.stubs(:mark_in_batch).returns(true)
-        Request.any_instance.stubs(:set_position).returns(true)
 
         @requests = (1..4).map { |_| Factory(:request, :request_type => @pipeline.request_type) }
         @request_ids = @requests.map { |r| Request.new_proxy(r.id) }


### PR DESCRIPTION
Controls were being added in a funny way to batches meaning that they
ended up in completely the wrong position and upset the ordering.

Requests that were not ready were showing up in the pipeline inboxes
causing genotyping to display a lot of red warnings.

Assets for a sample should be eager loaded to drastically improve the
performance of the sample show page.
