### PR TITLE
Add an index on sample_id in aliquots.

### DIFF
--- a/db/migrate/20110809083029_add_index_to_aliquots_sample_id.rb
+++ b/db/migrate/20110809083029_add_index_to_aliquots_sample_id.rb
@@ -1,0 +1,9 @@
+class AddIndexToAliquotsSampleId < ActiveRecord::Migration
+  def self.up
+    add_index :aliquots, :sample_id
+  end
+
+  def self.down
+    remove_index :aliquots, :sample_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110804154629) do
+ActiveRecord::Schema.define(:version => 20110809083029) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(:version => 20110804154629) do
   end
 
   add_index "aliquots", ["receptacle_id", "tag_id"], :name => "aliquot_tags_are_unique_within_receptacle", :unique => true
+  add_index "aliquots", ["sample_id"], :name => "index_aliquots_on_sample_id"
 
   create_table "archived_properties", :force => true do |t|
     t.text    "value"


### PR DESCRIPTION
By adding this index queries are drastically improved because sample_id
is relatively repetitive. It's primarily for the checking done by the
sample manifest code but should benefit elsewhere.
