### PR TITLE
Add api_key support back into authentication

### DIFF
--- a/app/api/core/abilities.rb
+++ b/app/api/core/abilities.rb
@@ -157,7 +157,7 @@ module Core::Abilities
       if single_sign_on_cookie.blank? and cannot?(:authenticate, :nil)
         Core::Service::Authentication::UnauthenticatedError.no_cookie!
       elsif not single_sign_on_cookie.blank?
-        user = ::User.authenticate_by_sanger_cookie(single_sign_on_cookie) or Core::Service::Authentication::UnauthenticatedError.unauthenticated!
+        user = ::User.authenticate_by_sanger_cookie(single_sign_on_cookie) or ::User.find_by_api_key(single_sign_on_cookie) or Core::Service::Authentication::UnauthenticatedError.unauthenticated!
         @request.service.instance_variable_set(:@user, user)
       end
 


### PR DESCRIPTION
Add support for API key to make Activity logger work again. Temporary fix until we make it a trusted application.
