### PR TITLE
Sample tubes need aliquots to generate their name.

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -94,8 +94,8 @@ class AssetsController < ApplicationController
 
                   # We must copy the aliquots of the 'extract' to the asset, otherwise the asset remains
                   # empty.
-                  asset.save!
                   asset.aliquots = parent.aliquots.map(&:clone)
+                  asset.save!
                 elsif asset.is_a?(SpikedBuffer) and !parent.is_a?(SpikedBuffer)
                   # error should have its own volume
                   flash[:error] = "Enter a volume"

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -15,7 +15,7 @@ class Aliquot < ActiveRecord::Base
 
     # A receptacle can hold many aliquots.  For example, a multiplexed library tube will contain more than
     # one aliquot.
-    has_many :aliquots, :foreign_key => :receptacle_id, :autosave => true, :dependent => :destroy
+    has_many :aliquots, :foreign_key => :receptacle_id, :autosave => true, :dependent => :destroy, :inverse_of => :receptacle
     has_one :primary_aliquot, :class_name => 'Aliquot', :foreign_key => :receptacle_id, :order => 'created_at ASC', :readonly => true
 
     # Named scopes for the future

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -536,10 +536,10 @@ class Asset < ActiveRecord::Base
     raise VolumeError, "not enough volume left" if volume <=0
 
     self.class.create!(:name => self.name) do |new_asset|
-      new_asset.volume = volume
+      new_asset.aliquots = self.aliquots.map(&:clone)
+      new_asset.volume   = volume
       update_attributes!(:volume => self.volume - volume)  # Update ourselves
     end.tap do |new_asset|
-      new_asset.aliquots = self.aliquots.map(&:clone)
       new_asset.add_parent(self)
     end
   end

--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -37,7 +37,7 @@ class CherrypickTask < Task
   def generate_control_request(well)
     # TODO: create a genotyping request for the control request
     #Request.create(:state => "pending", :sample => well.sample, :asset => well, :target_asset => Well.create(:sample => well.sample, :name => well.sample.name))
-    target_well = Well.create!(:name => well.primary_aliquot.sample.name).tap { |target_well| target_well.aliquots = well.aliquots.map(&:clone) }
+    target_well = Well.create!(:name => well.primary_aliquot.sample.name, :aliquots => well.aliquots.map(&:clone))
     workflow.pipeline.request_type.create_control!(:asset => well, :target_asset => target_well)
   end
 

--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -24,9 +24,11 @@ class LibraryTube < Tube
   end
 
   def create_stock_asset!(attributes = {}, &block)
-    StockLibraryTube.create!(attributes.reverse_merge(:name => "(s) #{self.name}", :barcode => AssetBarcode.new_barcode), &block).tap do |stock_asset|
-      stock_asset.aliquots = aliquots.map(&:clone)
-    end
+    StockLibraryTube.create!(attributes.reverse_merge(
+      :name     => "(s) #{self.name}",
+      :aliquots => aliquots.map(&:clone),
+      :barcode  => AssetBarcode.new_barcode
+    ), &block)
   end
 
   def new_stock_asset

--- a/app/models/multiplexed_library_tube.rb
+++ b/app/models/multiplexed_library_tube.rb
@@ -44,9 +44,11 @@ class MultiplexedLibraryTube < Tube
   end
 
   def create_stock_asset!(attributes = {}, &block)
-    StockMultiplexedLibraryTube.create!(attributes.reverse_merge(:name => "(s) #{self.name}", :barcode => AssetBarcode.new_barcode), &block).tap do |stock_asset|
-      stock_asset.aliquots = aliquots.map(&:clone)
-    end
+    StockMultiplexedLibraryTube.create!(attributes.reverse_merge(
+      :name     => "(s) #{self.name}",
+      :aliquots => aliquots.map(&:clone),
+      :barcode  => AssetBarcode.new_barcode
+    ), &block)
   end
 
   def new_stock_asset

--- a/app/models/sequenom_qc_plate.rb
+++ b/app/models/sequenom_qc_plate.rb
@@ -117,11 +117,10 @@ class SequenomQcPlate < Plate
     return nil if source_well.nil?
 
     source_well.clone.tap do |cloned_well|
-      cloned_well.plate = self
-      cloned_well.map   = destination_map_based_on_source_row_col_and_quadrant(quadrant, row, col)
-      cloned_well.save!
-
+      cloned_well.plate    = self
+      cloned_well.map      = destination_map_based_on_source_row_col_and_quadrant(quadrant, row, col)
       cloned_well.aliquots = source_well.aliquots.map(&:clone)
+      cloned_well.save!
 
       # FIXME: This fix seems a bit dirty but it works
       # Adding source_wells directly to cloned_well parents is broken so have to 

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -129,8 +129,7 @@ class Well < Aliquot::Receptacle
   end
 
   def create_child_sample_tube
-    SampleTube.create!(:map => self.map).tap do |sample_tube|
-      sample_tube.aliquots = aliquots.map(&:clone)
+    SampleTube.create!(:map => self.map, :aliquots => aliquots.map(&:clone)).tap do |sample_tube|
       AssetLink.connect(self, sample_tube)
     end
   end

--- a/features/step_definitions/9314145_pacbio_submission_steps.rb
+++ b/features/step_definitions/9314145_pacbio_submission_steps.rb
@@ -54,9 +54,9 @@ Given /^I have a fast PacBio sequencing batch$/ do
   Given %Q{the sample tubes are part of the study}
   Given %Q{I have a PacBio submission}
   location = Location.find_by_name("PacBio sequencing freezer")
-  library_1 = PacBioLibraryTube.create!(:location => location, :barcode => "333").tap { |tube| tube.aliquots.clear ; tube.aliquots = SampleTube.find_by_barcode(111).aliquots.map(&:clone) }
+  library_1 = PacBioLibraryTube.create!(:location => location, :barcode => "333", :aliquots => SampleTube.find_by_barcode(111).aliquots.map(&:clone))
   library_1.pac_bio_library_tube_metadata.update_attributes!(:prep_kit_barcode => "999", :smrt_cells_available => 3)
-  library_2 = PacBioLibraryTube.create!(:location => location, :barcode => "444").tap { |tube| tube.aliquots.clear ; tube.aliquots = SampleTube.find_by_barcode(222).aliquots.map(&:clone) }
+  library_2 = PacBioLibraryTube.create!(:location => location, :barcode => "444", :aliquots => SampleTube.find_by_barcode(222).aliquots.map(&:clone))
   library_2.pac_bio_library_tube_metadata.update_attributes!(:prep_kit_barcode => "999", :smrt_cells_available => 1)
   PacBioSequencingRequest.first.update_attributes!(:asset => library_1)
   PacBioSequencingRequest.last.update_attributes!(:asset => library_2)


### PR DESCRIPTION
When creating a sample tube the name is taken from the sample in the
primary aliquot, unless a name is specified.  Unfortunately this wasn't
possible because the aliquots could only be added _after_ the asset had
been created.

However, an undocumented feature of has_many is that if you set
:inverse_of appropriately then new records are properly setup.  In
other words, you can do Asset.create!(:aliquots => [ Aliquot.new ]),
where before you couldn't.
