### PR TITLE
Fix stock asset creation issue

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -446,15 +446,12 @@ class AssetsController < ApplicationController
   def create_stocks
     params[:assets].each do |id, params|
       asset = Asset.find(id)
-      unless asset.nil?
-        stock_asset = asset.create_stock_asset!(
-          :name          => params[:name],
-          :volume        => params[:volume],
-          :concentration => params[:concentration]
-        )
-        
-        stock_asset.assign_relationships(asset.parents, asset)
-      end
+      stock_asset = asset.create_stock_asset!(
+        :name          => params[:name],
+        :volume        => params[:volume],
+        :concentration => params[:concentration]
+      )
+      stock_asset.assign_relationships(asset.parents, asset)
     end
     
     batch = Batch.find(params[:batch_id])

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -135,7 +135,14 @@ class Aliquot < ActiveRecord::Base
   # It can belong to a library asset
   belongs_to :library, :class_name => 'Aliquot::Receptacle'
   composed_of :insert_size, :mapping => [%w{insert_size_from from}, %w{insert_size_to to}], :class_name => 'Aliquot::InsertSize', :allow_nil => true
-  
+
+  # Cloning an aliquot should unset the receptacle ID because otherwise it won't get reassigned.
+  def clone
+    super.tap do |cloned_aliquot|
+      cloned_aliquot.receptacle_id = nil
+    end
+  end
+
   # return all aliquots originated from the current one
   # ie aliquots sharing the sample, tag information, descending the requess graph
   def descendants(include_self=false)

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -16,17 +16,6 @@ class Asset < ActiveRecord::Base
   end
   include InstanceMethods
 
-  # Some assets are considered stock assets, that can be reused.
-  module Stock
-    def has_stock_asset?
-      false
-    end
-
-    def is_a_stock_asset?
-      true
-    end
-  end
-
   class VolumeError< StandardError
   end
 

--- a/app/models/asset/stock.rb
+++ b/app/models/asset/stock.rb
@@ -1,0 +1,41 @@
+module Asset::Stock
+  # Extending this module will allow an asset to have a stock asset and be able to
+  # create it.
+  module CanCreateStockAsset
+    def self.extended(base)
+      base.class_eval do
+        has_one_as_child(:stock_asset, :class_name => stock_asset_type.name)
+
+        stock_asset_factory(:create_stock_asset!, :create!)
+        stock_asset_factory(:new_stock_asset, :new)
+        deprecate :new_stock_asset
+      end
+    end
+
+    # By being able to create a stock asset the asset itself is not a stock.
+    def is_a_stock_asset?
+      false
+    end
+
+    def stock_asset_factory(name, ctor)
+      line = __LINE__
+      class_eval(%Q{
+        def #{name}(attributes = {}, &block)
+          self.class.stock_asset_type.#{ctor}(attributes.reverse_merge(
+            :name     => "(s) \#{self.name}",
+            :barcode  => AssetBarcode.new_barcode,
+            :aliquots => self.aliquots.map(&:clone)
+          ), &block)
+        end
+      }, __FILE__, line)
+    end
+  end
+
+  def has_stock_asset?
+    false
+  end
+
+  def is_a_stock_asset?
+    true
+  end
+end

--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -17,22 +17,9 @@ class LibraryTube < Tube
     creation_request.try(:request_options_for_creation) || {}
   end
 
-  has_one_as_child(:stock_asset, :conditions => { :sti_type => 'StockLibraryTube' })
-
-  def is_a_stock_asset?
-    false
+  def self.stock_asset_type
+    StockLibraryTube
   end
 
-  def create_stock_asset!(attributes = {}, &block)
-    StockLibraryTube.create!(attributes.reverse_merge(
-      :name     => "(s) #{self.name}",
-      :aliquots => aliquots.map(&:clone),
-      :barcode  => AssetBarcode.new_barcode
-    ), &block)
-  end
-
-  def new_stock_asset
-    StockLibraryTube.new(:name => "(s) #{self.name}", :sample_id => self.sample_id, :barcode => AssetBarcode.new_barcode)
-  end
-  deprecate :new_stock_asset
+  extend Asset::Stock::CanCreateStockAsset
 end

--- a/app/models/multiplexed_library_tube.rb
+++ b/app/models/multiplexed_library_tube.rb
@@ -37,22 +37,9 @@ class MultiplexedLibraryTube < Tube
     LibraryTube
   end
 
-  has_one_as_child(:stock_asset, :conditions => { :sti_type => 'StockMultiplexedLibraryTube' })
-
-  def is_a_stock_asset?
-    false
+  def self.stock_asset_type
+    StockMultiplexedLibraryTube
   end
 
-  def create_stock_asset!(attributes = {}, &block)
-    StockMultiplexedLibraryTube.create!(attributes.reverse_merge(
-      :name     => "(s) #{self.name}",
-      :aliquots => aliquots.map(&:clone),
-      :barcode  => AssetBarcode.new_barcode
-    ), &block)
-  end
-
-  def new_stock_asset
-    stock = StockMultiplexedLibraryTube.new(:name => "(s) #{self.name}", :barcode => AssetBarcode.new_barcode)
-  end
-  deprecate :new_stock_asset
+  extend Asset::Stock::CanCreateStockAsset
 end


### PR DESCRIPTION
It seems that cloning an aliquot maintains the receptacle information
and that it doesn't get overridden when you add them to another
receptacle.  This fix overrides the behaviour of clone so that the
receptacle is always nil.
