### PR TITLE
[fixes 17299599] Reduce the time for mongrel to shutdown.

### DIFF
--- a/features/support/fake_sinatra_service.rb
+++ b/features/support/fake_sinatra_service.rb
@@ -112,7 +112,7 @@ private
 
     def self.run!(options={})
       set options
-      HANDLER.run(self, { :Host => bind, :Port => port }.merge(options.fetch(:webrick, {}))) do |server|
+      HANDLER.run(self, { :Host => bind, :Port => port, :timeout => 1 }.merge(options.fetch(:webrick, {}))) do |server|
         set :running, true
         set :quit_handler, Proc.new { server.send(QUIT_HANDLER) }
       end


### PR DESCRIPTION
By reducing the timeout for mongrel to 1s we massively reduce the time
spent at the end of the each scenario for the fake services to shutdown.
