### PR TITLE
Add Aliquot::BulkCreator and use in batch start request

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -149,7 +149,9 @@ class Batch < ActiveRecord::Base
   end
 
   def start_requests
-    self.requests.each { |request| request.start! unless request.failed? }
+    Request::UpdateRequestInBulk() do
+      self.requests.each { |request| request.start! unless request.failed? }
+    end
   end
 
   def input_group

--- a/features/batch/4759010_bug_on_reset_batches.feature
+++ b/features/batch/4759010_bug_on_reset_batches.feature
@@ -5,7 +5,7 @@ Feature: Resetting a batch and creating an "identical" batch
     Given I am logged in as "John Smith"
     And I am an administrator
 
-  Scenario: 
+  Scenario: Reseting a batch and creating an "identical" batch
     Given a batch in "MX Library Preparation [NEW]" has been setup for feature 4759010
     When I go to the edit page for the last batch
     And I press "Reset"


### PR DESCRIPTION
Create Aliquot when a batch is started in batch.
Save a bit of time. Drawback don't create the UUID of the Aliquot

DO NOT MERGE for now
