### PR TITLE
[fixes 17458797] Disable grouped requests on oversizing

### DIFF
--- a/app/views/pipelines/_assets.html.erb
+++ b/app/views/pipelines/_assets.html.erb
@@ -28,7 +28,7 @@
             <% request_group_id = "request_group_#{ group_id.gsub(/[^a-z0-9]+/, '_') }" %>
             <%= label_tag(request_group_id, "Select #{ parent.sanger_human_barcode } for batch", :style => 'display:none') %>
             <%= label_tag(request_group_id, "Include request #{index+1}", :style => 'display:none') %>
-            <%= check_box(:request_group, group_id, :id => request_group_id, :onclick => 'check_grouped_request_count();') %>
+            <%= check_box(:request_group, group_id, :id => request_group_id, :class => 'grouped_checkbox', :'data-count' => requests.size) %>
             <%= hidden_field_tag("#{request_group_id}_size", "",  :value => requests.size)  %>
           </td>
           <td><%= parent.id %></td>

--- a/app/views/pipelines/_pipeline_limit.html.erb
+++ b/app/views/pipelines/_pipeline_limit.html.erb
@@ -1,10 +1,14 @@
 <div id="limit_info">
-<% batch_limit = @pipeline.item_limit || @pipeline.max_size %>
-<% if batch_limit -%>
-  <p>This pipelines has a limit of <strong><%= batch_limit %></strong> requests in a batch.
-<% else -%>
-  <p>This pipeline does not have a limit set on the number of requests in a batch.</p>
-<% end -%>
-<p>There are <%= @requests.size %> requests available.</p>
-<p id="selection_count"><span></span></p>
+  <% batch_limit = @pipeline.item_limit || @pipeline.max_size %>
+  <% if batch_limit -%>
+    <p>
+      This pipelines has a limit of <strong><%= batch_limit %></strong> requests in a batch.  Any requests that would
+      take you over this limit will be disabled and appear faded.
+    </p>
+  <% else -%>
+    <p>This pipeline does not have a limit set on the number of requests in a batch.</p>
+  <% end -%>
+
+  <p>There are <%= @requests.size %> requests available.</p>
+  <p>You have <span id="selection_count">no</span> requests selected.</p>
 </div>

--- a/app/views/pipelines/_requests.html.erb
+++ b/app/views/pipelines/_requests.html.erb
@@ -36,8 +36,9 @@
         <% request_asset_comments = request.asset.comments -%>
         <tr>
           <td class="request center" width='5%'>
-          <label for="request_<%= request.id %>"><%=  "Select #{request.asset.sti_type} #{request.asset.barcode} for batch" %></label>
-          <%= check_box :request, request.id, :value => request.id, :onclick => "Inbox.update_selected_requests();", :class => 'request_checkbox' %></td>
+            <label for="request_<%= request.id %>"><%=  "Select #{request.asset.sti_type} #{request.asset.barcode} for batch" %></label>
+            <%= check_box :request, request.id, :value => request.id, :class => 'grouped_checkbox request_checkbox', :'data-count' => 1 %>
+          </td>
           <% if current_user.is_lab_manager? %>
             <td  style="display:none" width='5%' id="flag_value_<%= request.id.to_s %>"><%= request.priority %></td>
             <td  style='text-align: center' width='5%'>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -15,8 +15,42 @@
 
 <%= render :partial => @pipeline.inbox_partial, :locals => { :pipeline => @pipeline } %>
 
-<script>
-Event.observe(window, 'load', function() {
-  Inbox.setup_dynamic_interface();
-});
+<script type="text/javascript">
+  /*
+   * When someone clicks on a request group checkbox we ensure that the count of the number of requests selected is
+   * updated and, if the pipeline has a limit, that any group requests that would take us over that limit are disabled.
+   */
+  (function($, undefined) {
+    var batch_size = 0;
+    var top_of_the_inbox = $('#pipeline_inbox > tbody'), counter = $('#selection_count');
+
+    /* Handle updating the current size of the batch */
+    top_of_the_inbox.delegate('.grouped_checkbox', 'change', function(event) {
+      var element = $(this);
+      batch_size += (this.checked ? 1 : -1) * parseInt(element.attr('data-count'));
+      counter.html('' + (batch_size === 0 ? 'no' : batch_size));
+    });
+
+<% if (batch_size = @pipeline.item_limit || @pipeline.max_size).present? %>
+    /* Handle disabling the inappropriate grouped requests */
+    var maximum_batch_size       = <%= @pipeline.item_limit || @pipeline.max_size %>;
+    var updateSelectableRequests = function(event) {
+      var remaining = maximum_batch_size - batch_size;
+      $('.grouped_checkbox:not(:checked)').each(function(index, value) {
+        var checkbox = $(value);
+        var parent   = checkbox.parents('tr');
+        if (parseInt(checkbox.attr('data-count')) > remaining) {
+          checkbox.attr('disabled', 'disabled');
+          parent.fadeTo(150, 0.25);
+        } else {
+          checkbox.removeAttr('disabled');
+          parent.fadeTo(150, 1);
+        }
+      });
+    }
+
+    top_of_the_inbox.delegate('.grouped_checkbox', 'change', updateSelectableRequests);
+    updateSelectableRequests();
+<% end %>
+  })(jQuery);
 </script>

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -1344,3 +1344,7 @@ table.checktext_field td {
   padding-left: 0;
   margin-left: 0;
 }
+
+#pipeline_inbox {
+  background-color: white;
+}


### PR DESCRIPTION
When creating batches in a pipeline that has a maximum size of batch,
requests should be enabled/disabled based on whether they would exceed
the limit.
