### PR TITLE
[fixes 17466935] Spiked in phiX should not be in pools or libraries

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -270,8 +270,7 @@ class Batch < ActiveRecord::Base
   end
 
   def ordered_requests(options=nil)
-    br = batch_requests.find(:all, options).sort { |a, b| a.position.to_i <=> b.position.to_i }.map {|br| br.request }
-    br.compact
+    batch_requests.ordered.all(options).map(&:request).compact
   end
 
   def assets

--- a/app/models/batch_request.rb
+++ b/app/models/batch_request.rb
@@ -10,6 +10,8 @@ class BatchRequest < ActiveRecord::Base
   belongs_to :request
   validates_presence_of :request
 
+  named_scope :ordered, :order => 'position ASC'
+
   # Ensure that any requests that are added have a position that is unique and incremental in the batch,
   # unless we're moving them around in the batch, in which case we assume it'll be valid.
   attr_accessor :sorting_requests_within_batch


### PR DESCRIPTION
The batch XML should not have the aliquots from the spiked in phiX
present in either pools or libraries, as these are represented by
separate elements.
