### PR TITLE
[fixes 17743975] Remove qc_state from tube JSON.

### DIFF
--- a/features/plain/api/multiplexed_library_tube.feature
+++ b/features/plain/api/multiplexed_library_tube.feature
@@ -26,7 +26,6 @@ Feature: Interacting with multiplexed_library_tubes through the API
             "barcode_prefix": "NT", 
             "scanned_in_date": "",
             "public_name": "ABC",
-            "qc_state": "",
             "lanes": "http://localhost:3000/0_5/multiplexed_library_tubes/00000000-1111-2222-3333-444444444444/lanes",
             "requests": "http://localhost:3000/0_5/multiplexed_library_tubes/00000000-1111-2222-3333-444444444444/requests",
 
@@ -54,7 +53,6 @@ Feature: Interacting with multiplexed_library_tubes through the API
           "uuid": "00000000-1111-2222-3333-444444444444",
           "barcode_prefix": "NT", 
           "scanned_in_date": "",
-          "qc_state": "",
           "lanes": "http://localhost:3000/0_5/multiplexed_library_tubes/00000000-1111-2222-3333-444444444444/lanes",
           "requests": "http://localhost:3000/0_5/multiplexed_library_tubes/00000000-1111-2222-3333-444444444444/requests",
 

--- a/features/plain/api/pulldown_multiplexed_library_tube.feature
+++ b/features/plain/api/pulldown_multiplexed_library_tube.feature
@@ -26,7 +26,6 @@ Feature: Interacting with pulldown_multiplexed_library_tubes through the API
             "barcode_prefix": "NT", 
             "scanned_in_date": "",
             "public_name": "ABC",
-            "qc_state": "",
 
             "internal_id": 1
           }
@@ -53,7 +52,6 @@ Feature: Interacting with pulldown_multiplexed_library_tubes through the API
           "barcode_prefix": "NT", 
           "scanned_in_date": "",
           "public_name": "ABC",
-          "qc_state": "",
 
           "internal_id": 1
         }


### PR DESCRIPTION
qc_state makes no sense for any non-Lane asset so it has been removed,
which means that these features needed to be updated.
