### PR TITLE
[fixes 17900025] Order aliquots by their tag map ID if present.

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -15,7 +15,7 @@ class Aliquot < ActiveRecord::Base
 
     # A receptacle can hold many aliquots.  For example, a multiplexed library tube will contain more than
     # one aliquot.
-    has_many :aliquots, :foreign_key => :receptacle_id, :autosave => true, :dependent => :destroy, :inverse_of => :receptacle
+    has_many :aliquots, :foreign_key => :receptacle_id, :autosave => true, :dependent => :destroy, :inverse_of => :receptacle, :include => :tag, :order => 'tags.map_id ASC'
     has_one :primary_aliquot, :class_name => 'Aliquot', :foreign_key => :receptacle_id, :order => 'created_at ASC', :readonly => true
 
     # Named scopes for the future


### PR DESCRIPTION
This ensures that the aliquots in a pool appear in the order of their
tag numbers.
