### PR TITLE
[fixes 18069777] Allow tag substitutions in tag layouts.

### DIFF
--- a/app/api/io/tag_layout.rb
+++ b/app/api/io/tag_layout.rb
@@ -4,9 +4,10 @@ class ::Io::TagLayout < ::Core::Io::Base
   set_eager_loading { |model| model.include_plate.include_tag_group }
 
   define_attribute_and_json_mapping(%Q{
-         user <=> user
-        plate <=> plate
-    tag_group  => tag_group
-    direction  => direction
+             user <=> user
+            plate <=> plate
+    substitutions <=> substitutions
+        tag_group  => tag_group
+        direction  => direction
   })
 end

--- a/db/migrate/20110909083958_add_substitutions_to_tag_layouts.rb
+++ b/db/migrate/20110909083958_add_substitutions_to_tag_layouts.rb
@@ -1,0 +1,19 @@
+class AddSubstitutionsToTagLayouts < ActiveRecord::Migration
+  class TagLayout < ActiveRecord::Base
+    set_table_name('tag_layouts')
+    serialize :subtitutions
+  end
+
+  def self.up
+    add_column :tag_layouts, :substitutions, :string
+
+    TagLayout.reset_column_information
+    TagLayout.find_each do |layout|
+      layout.update_attributes!(:subtitutions => {})
+    end
+  end
+
+  def self.down
+    remove_column :tag_layouts, :substitutions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110831130628) do
+ActiveRecord::Schema.define(:version => 20110909083958) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -1148,12 +1148,12 @@ ActiveRecord::Schema.define(:version => 20110831130628) do
     t.string   "Lib Batch Creator"
     t.string   "Lib Batch State",           :limit => 20
     t.datetime "Lib Batch State Date"
-    t.binary   "Mplex Tube ID",             :limit => 11
+    t.binary   "Mplex Tube ID",             :limit => 255
     t.string   "Mplex Tube Name"
-    t.binary   "Tag Group ID",              :limit => 11,                  :null => false
+    t.binary   "Tag Group ID",              :limit => 255,                 :null => false
     t.string   "Tag Group Name"
-    t.binary   "Tag ID",                    :limit => 11,                  :null => false
-    t.binary   "Tag Map ID",                :limit => 11
+    t.binary   "Tag ID",                    :limit => 255,                 :null => false
+    t.binary   "Tag Map ID",                :limit => 255
     t.string   "Tag Sequence"
     t.integer  "Library Tube ID"
     t.string   "Library Name"
@@ -1200,6 +1200,7 @@ ActiveRecord::Schema.define(:version => 20110831130628) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "substitutions"
   end
 
   create_table "tags", :force => true do |t|

--- a/features/api/tag_layout_templates.feature
+++ b/features/api/tag_layout_templates.feature
@@ -217,3 +217,179 @@ Feature: Access tag layout templates through the API
       | F12  | TTGG |
       | G12  | AATT |
       | H12  | CCGG |
+
+  @tag_layout @create @barcode-service
+  Scenario: Creating a tag layout with substitutions from a tag layout template
+    Given the plate barcode webservice returns "1000001..1000002"
+
+    Given the tag layout template "Test tag layout" exists
+      And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
+      And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
+      And the tag group for tag layout template "Test tag layout" contains the following tags:
+        | index | oligo |
+        | 1     | AAAA  |
+        | 2     | CCCC  |
+        | 3     | TTTT  |
+        | 4     | GGGG  |
+        | 5     | AACC  |
+        | 6     | TTGG  |
+        | 7     | AATT  |
+        | 8     | CCGG  |
+      And the UUID of the next tag layout created will be "00000000-1111-2222-3333-000000000002"
+
+    Given a "Stock plate" plate called "Testing the API" exists
+      And the UUID for the plate "Testing the API" is "11111111-2222-3333-4444-000000000002"
+      And all wells on the plate "Testing the API" have unique samples
+
+    Given a "Stock plate" plate called "Testing the tagging" exists
+      And the UUID for the plate "Testing the tagging" is "11111111-2222-3333-4444-000000000001"
+      And the wells for the plate "Testing the API" have been pooled in columns to the plate "Testing the tagging"
+
+    When I make an authorised POST with the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
+      """
+      {
+        "tag_layout": {
+          "plate": "11111111-2222-3333-4444-000000000001",
+          "substitutions": {
+            "8": "7",
+            "7": "8"
+          }
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "tag_layout": {
+          "actions": {
+            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+          },
+          "plate": {
+            "actions": {
+              "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+            }
+          },
+
+          "uuid": "00000000-1111-2222-3333-000000000002",
+          "direction": "column",
+
+          "tag_group": {
+            "name": "Tag group 1",
+            "tags": {
+              "1": "AAAA",
+              "2": "CCCC",
+              "3": "TTTT",
+              "4": "GGGG",
+              "5": "AACC",
+              "6": "TTGG",
+              "7": "AATT",
+              "8": "CCGG"
+            }
+          },
+          "substitutions": {
+            "8": "7",
+            "7": "8"
+          }
+        }
+      }
+      """
+
+    Then the tags assigned to the plate "Testing the tagging" should be:
+      | well | tag  |
+      | A1   | AAAA |
+      | B1   | CCCC |
+      | C1   | TTTT |
+      | D1   | GGGG |
+      | E1   | AACC |
+      | F1   | TTGG |
+      | G1   | CCGG |
+      | H1   | AATT |
+      | A2   | AAAA |
+      | B2   | CCCC |
+      | C2   | TTTT |
+      | D2   | GGGG |
+      | E2   | AACC |
+      | F2   | TTGG |
+      | G2   | CCGG |
+      | H2   | AATT |
+      | A3   | AAAA |
+      | B3   | CCCC |
+      | C3   | TTTT |
+      | D3   | GGGG |
+      | E3   | AACC |
+      | F3   | TTGG |
+      | G3   | CCGG |
+      | H3   | AATT |
+      | A4   | AAAA |
+      | B4   | CCCC |
+      | C4   | TTTT |
+      | D4   | GGGG |
+      | E4   | AACC |
+      | F4   | TTGG |
+      | G4   | CCGG |
+      | H4   | AATT |
+      | A5   | AAAA |
+      | B5   | CCCC |
+      | C5   | TTTT |
+      | D5   | GGGG |
+      | E5   | AACC |
+      | F5   | TTGG |
+      | G5   | CCGG |
+      | H5   | AATT |
+      | A6   | AAAA |
+      | B6   | CCCC |
+      | C6   | TTTT |
+      | D6   | GGGG |
+      | E6   | AACC |
+      | F6   | TTGG |
+      | G6   | CCGG |
+      | H6   | AATT |
+      | A7   | AAAA |
+      | B7   | CCCC |
+      | C7   | TTTT |
+      | D7   | GGGG |
+      | E7   | AACC |
+      | F7   | TTGG |
+      | G7   | CCGG |
+      | H7   | AATT |
+      | A8   | AAAA |
+      | B8   | CCCC |
+      | C8   | TTTT |
+      | D8   | GGGG |
+      | E8   | AACC |
+      | F8   | TTGG |
+      | G8   | CCGG |
+      | H8   | AATT |
+      | A9   | AAAA |
+      | B9   | CCCC |
+      | C9   | TTTT |
+      | D9   | GGGG |
+      | E9   | AACC |
+      | F9   | TTGG |
+      | G9   | CCGG |
+      | H9   | AATT |
+      | A10  | AAAA |
+      | B10  | CCCC |
+      | C10  | TTTT |
+      | D10  | GGGG |
+      | E10  | AACC |
+      | F10  | TTGG |
+      | G10  | CCGG |
+      | H10  | AATT |
+      | A11  | AAAA |
+      | B11  | CCCC |
+      | C11  | TTTT |
+      | D11  | GGGG |
+      | E11  | AACC |
+      | F11  | TTGG |
+      | G11  | CCGG |
+      | H11  | AATT |
+      | A12  | AAAA |
+      | B12  | CCCC |
+      | C12  | TTTT |
+      | D12  | GGGG |
+      | E12  | AACC |
+      | F12  | TTGG |
+      | G12  | CCGG |
+      | H12  | AATT |

--- a/features/api/tag_layouts.feature
+++ b/features/api/tag_layouts.feature
@@ -46,7 +46,8 @@ Feature: Access tag layouts through the API
               "1": "ACGT",
               "2": "TGCA"
             }
-          }
+          },
+          "substitutions": { }
         }
       }
       """


### PR DESCRIPTION
This allows the client to specify a cross plate tag substitution.  This
would be used when there is not enough of a particular tag to complete
the entire plate.
