### PR TITLE
[fixes 18141977] Tagging obeys plates then pools.

### DIFF
--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -80,6 +80,28 @@ class Plate < Asset
         yield(well, index) if well.present?
       end
     end
+
+    # Returns the wells grouped into columns
+    def in_columns
+      width, height = Map.plate_width(proxy_owner.size), Map.plate_length(proxy_owner.size)
+      wells_in_columns, position = (1..width).map { |_| [] }, 0
+      self.walk_in_column_major_order do |well, _|
+        wells_in_columns[position / height] << well
+        position += 1
+      end
+      wells_in_columns
+    end
+
+    # Returns the wells grouped into rows
+    def in_rows
+      width, height = Map.plate_width(proxy_owner.size), Map.plate_length(proxy_owner.size)
+      wells_in_rows, position = (1..height).map { |_| [] }, 0
+      self.walk_in_row_major_order do |well, _|
+        wells_in_rows[position / width] << well
+        position += 1
+      end
+      wells_in_rows
+    end
   end
 
   #has_many :wells, :as => :holder, :class_name => "Well"

--- a/app/models/tag_layout.rb
+++ b/app/models/tag_layout.rb
@@ -37,7 +37,27 @@ class TagLayout < ActiveRecord::Base
   private :layout_tags_into_wells
 
   def walk_wells(&block)
-    plate.wells.send(:"walk_in_#{direction}_major_order", &block)
+    # Adjust each of the groups so that any wells that are in the same pool as those at the same position
+    # in the group to the left are moved to a non-clashing position.  Effectively this makes the view of the
+    # plate slightly jagged.
+    wells_in_groups = plate.wells.send(:"in_#{direction.pluralize}").map { |wells| wells.map { |well| [ well, well.pool_id ] } }
+    wells_in_groups.each_with_index do |current_group, group|
+      next if group == 0
+      prior_group = wells_in_groups[group-1]
+
+      current_group.each_with_index do |well_and_pool, index|
+        break if prior_group.size <= index
+        next unless prior_group[index].last == well_and_pool.last
+
+        current_group.push(well_and_pool)                # Move the well to the end of the group
+        current_group[index] = [nil, well_and_pool.last] # Blank out the well at the current position but maintain the pool
+      end
+    end
+
+    # Now we can walk the wells in the groups, skipping any that have been nil'd by the above code.
+    wells_in_groups.each do |group|
+      group.each_with_index { |(well, _), index| yield(well, index) unless well.nil? }
+    end
   end
   private :walk_wells
 

--- a/features/api/tag_layout_templates.feature
+++ b/features/api/tag_layout_templates.feature
@@ -393,3 +393,345 @@ Feature: Access tag layout templates through the API
       | F12  | TTGG |
       | G12  | CCGG |
       | H12  | AATT |
+
+  @tag_layout @create @barcode-service
+  Scenario: Creating a tag layout where the pools are factors of the number of rows on the plate
+    Given the plate barcode webservice returns "1000001..1000002"
+
+    Given the column order tag layout template "Test tag layout" exists
+      And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
+      And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
+      And the tag group for tag layout template "Test tag layout" contains the following tags:
+        | index | oligo |
+        | 1     | AAAA  |
+        | 2     | CCCC  |
+        | 3     | TTTT  |
+        | 4     | GGGG  |
+        | 5     | AACC  |
+        | 6     | TTGG  |
+        | 7     | AATT  |
+        | 8     | CCGG  |
+        | 9     | GAGA  |
+        | 10    | CACA  |
+      And the UUID of the next tag layout created will be "00000000-1111-2222-3333-000000000002"
+
+    Given a "Stock plate" plate called "Testing the API" exists
+      And the UUID for the plate "Testing the API" is "11111111-2222-3333-4444-000000000002"
+      And all wells on the plate "Testing the API" have unique samples
+
+    Given a "Stock plate" plate called "Testing the tagging" exists
+      And the UUID for the plate "Testing the tagging" is "11111111-2222-3333-4444-000000000001"
+      And the wells for the plate "Testing the API" have been pooled to the plate "Testing the tagging" according to the pooling strategy 8, 4, 8, 4, 8, 4, 8, 4, 8, 4, 8, 4, 8, 4, 8, 4
+
+    When I make an authorised POST with the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
+      """
+      {
+        "tag_layout": {
+          "plate": "11111111-2222-3333-4444-000000000001"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "tag_layout": {
+          "actions": {
+            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+          },
+          "plate": {
+            "actions": {
+              "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+            }
+          },
+
+          "uuid": "00000000-1111-2222-3333-000000000002",
+          "direction": "column",
+
+          "tag_group": {
+            "name": "Tag group 1",
+            "tags": {
+              "1": "AAAA",
+              "2": "CCCC",
+              "3": "TTTT",
+              "4": "GGGG",
+              "5": "AACC",
+              "6": "TTGG",
+              "7": "AATT",
+              "8": "CCGG"
+            }
+          },
+          "substitutions": { }
+        }
+      }
+      """
+
+    Then the tags assigned to the plate "Testing the tagging" should be:
+      | well | tag  |
+      | A1   | AAAA |
+      | B1   | CCCC |
+      | C1   | TTTT |
+      | D1   | GGGG |
+      | E1   | AACC |
+      | F1   | TTGG |
+      | G1   | AATT |
+      | H1   | CCGG |
+      | A2   | AAAA |
+      | B2   | CCCC |
+      | C2   | TTTT |
+      | D2   | GGGG |
+      | E2   | AACC |
+      | F2   | TTGG |
+      | G2   | AATT |
+      | H2   | CCGG |
+      | A3   | AAAA |
+      | B3   | CCCC |
+      | C3   | TTTT |
+      | D3   | GGGG |
+      | E3   | AACC |
+      | F3   | TTGG |
+      | G3   | AATT |
+      | H3   | CCGG |
+      | A4   | AAAA |
+      | B4   | CCCC |
+      | C4   | TTTT |
+      | D4   | GGGG |
+      | E4   | AACC |
+      | F4   | TTGG |
+      | G4   | AATT |
+      | H4   | CCGG |
+      | A5   | AAAA |
+      | B5   | CCCC |
+      | C5   | TTTT |
+      | D5   | GGGG |
+      | E5   | AACC |
+      | F5   | TTGG |
+      | G5   | AATT |
+      | H5   | CCGG |
+      | A6   | AAAA |
+      | B6   | CCCC |
+      | C6   | TTTT |
+      | D6   | GGGG |
+      | E6   | AACC |
+      | F6   | TTGG |
+      | G6   | AATT |
+      | H6   | CCGG |
+      | A7   | AAAA |
+      | B7   | CCCC |
+      | C7   | TTTT |
+      | D7   | GGGG |
+      | E7   | AACC |
+      | F7   | TTGG |
+      | G7   | AATT |
+      | H7   | CCGG |
+      | A8   | AAAA |
+      | B8   | CCCC |
+      | C8   | TTTT |
+      | D8   | GGGG |
+      | E8   | AACC |
+      | F8   | TTGG |
+      | G8   | AATT |
+      | H8   | CCGG |
+      | A9   | AAAA |
+      | B9   | CCCC |
+      | C9   | TTTT |
+      | D9   | GGGG |
+      | E9   | AACC |
+      | F9   | TTGG |
+      | G9   | AATT |
+      | H9   | CCGG |
+      | A10  | AAAA |
+      | B10  | CCCC |
+      | C10  | TTTT |
+      | D10  | GGGG |
+      | E10  | AACC |
+      | F10  | TTGG |
+      | G10  | AATT |
+      | H10  | CCGG |
+      | A11  | AAAA |
+      | B11  | CCCC |
+      | C11  | TTTT |
+      | D11  | GGGG |
+      | E11  | AACC |
+      | F11  | TTGG |
+      | G11  | AATT |
+      | H11  | CCGG |
+      | A12  | AAAA |
+      | B12  | CCCC |
+      | C12  | TTTT |
+      | D12  | GGGG |
+      | E12  | AACC |
+      | F12  | TTGG |
+      | G12  | AATT |
+      | H12  | CCGG |
+
+  @tag_layout @create @barcode-service
+  Scenario: Creating a tag layout where the pools are awkwardly sized and cause overlaps
+    Given the plate barcode webservice returns "1000001..1000002"
+
+    Given the column order tag layout template "Test tag layout" exists
+      And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
+      And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
+      And the tag group for tag layout template "Test tag layout" contains the following tags:
+        | index | oligo |
+        | 1     | AAAA  |
+        | 2     | CCCC  |
+        | 3     | TTTT  |
+        | 4     | GGGG  |
+        | 5     | AACC  |
+        | 6     | TTGG  |
+        | 7     | AATT  |
+        | 8     | CCGG  |
+        | 9     | GAGA  |
+        | 10    | CACA  |
+      And the UUID of the next tag layout created will be "00000000-1111-2222-3333-000000000002"
+
+    Given a "Stock plate" plate called "Testing the API" exists
+      And the UUID for the plate "Testing the API" is "11111111-2222-3333-4444-000000000002"
+      And all wells on the plate "Testing the API" have unique samples
+
+    Given a "Stock plate" plate called "Testing the tagging" exists
+      And the UUID for the plate "Testing the tagging" is "11111111-2222-3333-4444-000000000001"
+      And the wells for the plate "Testing the API" have been pooled to the plate "Testing the tagging" according to the pooling strategy 8, 2, 10, 4, 8, 2, 10, 4, 8, 2, 10, 4, 8, 8, 8
+
+    When I make an authorised POST with the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
+      """
+      {
+        "tag_layout": {
+          "plate": "11111111-2222-3333-4444-000000000001"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "tag_layout": {
+          "actions": {
+            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+          },
+          "plate": {
+            "actions": {
+              "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+            }
+          },
+
+          "uuid": "00000000-1111-2222-3333-000000000002",
+          "direction": "column",
+
+          "tag_group": {
+            "name": "Tag group 1",
+            "tags": {
+              "1": "AAAA",
+              "2": "CCCC",
+              "3": "TTTT",
+              "4": "GGGG",
+              "5": "AACC",
+              "6": "TTGG",
+              "7": "AATT",
+              "8": "CCGG"
+            }
+          },
+          "substitutions": { }
+        }
+      }
+      """
+
+    Then the tags assigned to the plate "Testing the tagging" should be:
+      | well | tag  |
+      | A1   | AAAA |
+      | B1   | CCCC |
+      | C1   | TTTT |
+      | D1   | GGGG |
+      | E1   | AACC |
+      | F1   | TTGG |
+      | G1   | AATT |
+      | H1   | CCGG |
+      | A2   | AAAA |
+      | B2   | CCCC |
+      | C2   | TTTT |
+      | D2   | GGGG |
+      | E2   | AACC |
+      | F2   | TTGG |
+      | G2   | AATT |
+      | H2   | CCGG |
+      | A3   | AAAA |
+      | B3   | CCCC |
+      | C3   | GAGA |
+      | D3   | CACA |
+      | E3   | AACC |
+      | F3   | TTGG |
+      | G3   | AATT |
+      | H3   | CCGG |
+      | A4   | AAAA |
+      | B4   | CCCC |
+      | C4   | TTTT |
+      | D4   | GGGG |
+      | E4   | AACC |
+      | F4   | TTGG |
+      | G4   | AATT |
+      | H4   | CCGG |
+      | A5   | AAAA |
+      | B5   | CCCC |
+      | C5   | TTTT |
+      | D5   | GGGG |
+      | E5   | AACC |
+      | F5   | TTGG |
+      | G5   | AATT |
+      | H5   | CCGG |
+      | A6   | AAAA |
+      | B6   | CCCC |
+      | C6   | GAGA |
+      | D6   | CACA |
+      | E6   | AACC |
+      | F6   | TTGG |
+      | G6   | AATT |
+      | H6   | CCGG |
+      | A7   | AAAA |
+      | B7   | CCCC |
+      | C7   | TTTT |
+      | D7   | GGGG |
+      | E7   | AACC |
+      | F7   | TTGG |
+      | G7   | AATT |
+      | H7   | CCGG |
+      | A8   | AAAA |
+      | B8   | CCCC |
+      | C8   | TTTT |
+      | D8   | GGGG |
+      | E8   | AACC |
+      | F8   | TTGG |
+      | G8   | AATT |
+      | H8   | CCGG |
+      | A9   | AAAA |
+      | B9   | CCCC |
+      | C9   | GAGA |
+      | D9   | CACA |
+      | E9   | AACC |
+      | F9   | TTGG |
+      | G9   | AATT |
+      | H9   | CCGG |
+      | A10  | AAAA |
+      | B10  | CCCC |
+      | C10  | TTTT |
+      | D10  | GGGG |
+      | E10  | AACC |
+      | F10  | TTGG |
+      | G10  | AATT |
+      | H10  | CCGG |
+      | A11  | AAAA |
+      | B11  | CCCC |
+      | C11  | TTTT |
+      | D11  | GGGG |
+      | E11  | AACC |
+      | F11  | TTGG |
+      | G11  | AATT |
+      | H11  | CCGG |
+      | A12  | AAAA |
+      | B12  | CCCC |
+      | C12  | TTTT |
+      | D12  | GGGG |
+      | E12  | AACC |
+      | F12  | TTGG |
+      | G12  | AATT |
+      | H12  | CCGG |

--- a/test/factories/pulldown_factories.rb
+++ b/test/factories/pulldown_factories.rb
@@ -63,6 +63,10 @@ Factory.define(:tag_layout_template) do |tag_layout_template|
   tag_layout_template.layout_class_name 'TagLayout::ByPools'
   tag_layout_template.tag_group { |target| target.association(:tag_group_for_layout) }
 end
+Factory.define(:column_order_tag_layout_template, :class => TagLayoutTemplate) do |tag_layout_template|
+  tag_layout_template.layout_class_name 'TagLayout::InColumns'
+  tag_layout_template.tag_group { |target| target.association(:tag_group_for_layout) }
+end
 
 Factory.define(:tag_layout, :class => TagLayout::InColumns) do |tag_layout|
   tag_layout.user      { |target| target.association(:user) }


### PR DESCRIPTION
The tagging will ensure that tags are laid out in the correct order
regardless of pools.  So each row will have the same tag across its
entire length in the case where there are no long pools.  In cases where
the pool is longer than the column extra tags will be used to avoid
clashes but as substitutions for the overlap.
