### PR TITLE
[fixes 18328593] Improve the performance of sample accessioning.

### DIFF
--- a/lib/cron_scripts/generate_sample_accessions.rb
+++ b/lib/cron_scripts/generate_sample_accessions.rb
@@ -1,36 +1,24 @@
-samples_to_accession = []
-Study.all.each do |study|
-  next if ! (
-    study.data_release_strategy == "managed" ||
-    study.data_release_strategy == "open"
-  )
-
-
+current_user = User.find_by_api_key(configatron.accession_local_key) or raise StandardError, "Cannot find accessioning user"
+Study.find_each(:include => { :study_metadata => :data_release_study_type }) do |study|
+  next if not (study.data_release_strategy == "managed" or study.data_release_strategy == "open")
+  #next if study.data_release_strategy != "managed" and study.data_release_strategy != "open"
   next unless study.ena_accession_required?
-  next if study.samples.nil?
 
-  study.samples.each do |sample|
-    if sample.accession_could_be_generated?
-      samples_to_accession << sample
+  study.samples.find_each(:include => [ :sample_metadata, { :studies => :study_metadata } ]) do |sample|
+    next unless sample.accession_could_be_generated?
+
+    # Get new ebi accesion number.
+    begin
+      sample.validate_ena_required_fields!
+      sample.accession_service.submit_sample_for_user(sample, current_user)
+    rescue ActiveRecord::RecordInvalid => exception
+      #warn "Please fill in the required fields for sample: #{sample.name}"
+    rescue AccessionService::NumberNotRequired => exception
+      #warn "An accession number is not required for this study.  Study name: #{sample.study.name}"
+    rescue AccessionService::NumberNotGenerated => exception
+      warn 'No accession number was generated'
+    rescue AccessionService::AccessionServiceError => exception
+      warn exception.message
     end
-  end
-end
-
-current_user = User.find_by_api_key(configatron.accession_local_key)
-
-samples_to_accession.each do |sample|
-  # Get new ebi accesion number.
-  begin
-  sample.validate_ena_required_fields!
-  sample.accession_service.submit_sample_for_user(sample, current_user)
-    
-  rescue ActiveRecord::RecordInvalid => exception
-    #warn "Please fill in the required fields for sample: #{sample.name}"
-  rescue AccessionService::NumberNotRequired => exception
-    #warn "An accession number is not required for this study.  Study name: #{sample.study.name}"
-  rescue AccessionService::NumberNotGenerated => exception
-    warn 'No accession number was generated'
-  rescue AccessionService::AccessionServiceError => exception
-    warn exception.message
   end
 end


### PR DESCRIPTION
This script used to take 15 minutes on psd1j and use 1GB of memory in
doing so.  The updates make it run in about 10 minutes and use about
500MB.  Essentially lots of eager loading and use of find_each.
