### PR TITLE
[fixes 18389389] Rename the pulldown plate purpose names.

### DIFF
--- a/app/models/pulldown/initial_plate_purpose.rb
+++ b/app/models/pulldown/initial_plate_purpose.rb
@@ -1,5 +1,5 @@
 # Specialised implementation of the plate purpose for the initial plate types in the Pulldown pipelines:
-# WGS fragmentation plate, SC fragmentation plate, ISC fragmentation plate.
+# WGS Covaris, SC Covaris, ISC Covaris.
 class Pulldown::InitialPlatePurpose < PlatePurpose
   include Pulldown::WorksOnLibraryRequests
 

--- a/app/models/pulldown/plate_purposes.rb
+++ b/app/models/pulldown/plate_purposes.rb
@@ -1,57 +1,57 @@
 module Pulldown::PlatePurposes
   PULLDOWN_PLATE_PURPOSE_FLOWS = [
     [
-      'WGS stock plate',
-      'WGS fragmentation plate',
-      'WGS fragment purification plate',
-      'WGS library preparation plate',
-      'WGS library plate',
-      'WGS library PCR plate',
-      'WGS amplified library plate',
-      'WGS pooled amplified library plate'
+      'WGS stock DNA',
+      'WGS Covaris',
+      'WGS post-Cov',
+      'WGS post-Cov-XP',
+      'WGS lib',
+      'WGS lib PCR',
+      'WGS lib PCR-XP',
+      'WGS lib pool'
     ], [
-      'SC stock plate',
-      'SC fragmentation plate',
-      'SC fragment purification plate',
-      'SC library preparation plate',
-      'SC library plate',
-      'SC library PCR plate',
-      'SC amplified library plate',
-      'SC hybridisation plate',
-      'SC captured library plate',
-      'SC captured library PCR plate',
-      'SC amplified captured library plate',
-      'SC pooled captured library plate'
+      'SC stock DNA',
+      'SC Covaris',
+      'SC post-Cov',
+      'SC post-Cov-XP',
+      'SC lib',
+      'SC lib PCR',
+      'SC lib PCR-XP',
+      'SC hyb',
+      'SC cap lib',
+      'SC cap lib PCR',
+      'SC cap lib PCR-XP',
+      'SC cap lib pool'
     ], [
-      'ISC stock plate',
-      'ISC fragmentation plate',
-      'ISC fragment purification plate',
-      'ISC library preparation plate',
-      'ISC library plate',
-      'ISC library PCR plate',
-      'ISC amplified library plate',
-      'ISC pooled amplified library plate',
-      'ISC hybridisation plate',
-      'ISC captured library plate',
-      'ISC captured library PCR plate',
-      'ISC amplified captured library plate',
-      'ISC pooled captured library plate'
+      'ISC stock DNA',
+      'ISC Covaris',
+      'ISC post-Cov',
+      'ISC post-Cov-XP',
+      'ISC lib',
+      'ISC lib PCR',
+      'ISC lib PCR-XP',
+      'ISC lib pool',
+      'ISC hyb',
+      'ISC cap lib',
+      'ISC cap lib PCR',
+      'ISC cap lib PCR-XP',
+      'ISC cap lib pool'
     ]
   ]
 
   PULLDOWN_PLATE_PURPOSE_LEADING_TO_QC_PLATES = [
-    'WGS fragment purification plate',
-    'WGS library preparation plate',
-    'WGS amplified library plate',
+    'WGS post-Cov',
+    'WGS post-Cov-XP',
+    'WGS lib PCR-XP',
 
-    'SC fragment purification plate',
-    'SC library preparation plate',
-    'SC amplified library plate',
-    'SC amplified captured library plate',
+    'SC post-Cov',
+    'SC post-Cov-XP',
+    'SC lib PCR-XP',
+    'SC cap lib PCR-XP',
 
-    'ISC fragment purification plate',
-    'ISC library preparation plate',
-    'ISC amplified library plate',
-    'ISC amplified captured library plate'
+    'ISC post-Cov',
+    'ISC post-Cov-XP',
+    'ISC lib PCR-XP',
+    'ISC cap lib PCR-XP'
   ]
 end

--- a/app/models/snp/dna_plate.rb
+++ b/app/models/snp/dna_plate.rb
@@ -7,4 +7,4 @@ class Snp::DnaPlate < ActiveRecord::Base
   set_table_name "dna_plate"
 
   alias_attribute :id, :id_dnaplate
-end
+end if false

--- a/db/migrate/20110916104200_change_pulldown_plate_purpose_names.rb
+++ b/db/migrate/20110916104200_change_pulldown_plate_purpose_names.rb
@@ -1,0 +1,56 @@
+class ChangePulldownPlatePurposeNames < ActiveRecord::Migration
+  PLATE_PURPOSE_NAME_MAPPINGS = {
+    'WGS stock plate'                      => 'WGS stock DNA',
+    'WGS fragmentation plate'              => 'WGS Covaris',
+    'WGS fragment purification plate'      => 'WGS post-Cov',
+    'WGS library preparation plate'        => 'WGS post-Cov-XP',
+    'WGS library plate'                    => 'WGS lib',
+    'WGS library PCR plate'                => 'WGS lib PCR',
+    'WGS amplified library plate'          => 'WGS lib PCR-XP',
+    'WGS pooled amplified library plate'   => 'WGS lib pool',
+
+    'SC stock plate'                       => 'SC stock DNA',
+    'SC fragmentation plate'               => 'SC Covaris',
+    'SC fragment purification plate'       => 'SC post-Cov',
+    'SC library preparation plate'         => 'SC post-Cov-XP',
+    'SC library plate'                     => 'SC lib',
+    'SC library PCR plate'                 => 'SC lib PCR',
+    'SC amplified library plate'           => 'SC lib PCR-XP',
+    'SC hybridisation plate'               => 'SC hyb',
+    'SC captured library plate'            => 'SC cap lib',
+    'SC captured library PCR plate'        => 'SC cap lib PCR',
+    'SC amplified captured library plate'  => 'SC cap lib PCR-XP',
+    'SC pooled captured library plate'     => 'SC cap lib pool',
+
+    'ISC stock plate'                      => 'ISC stock DNA',
+    'ISC fragmentation plate'              => 'ISC Covaris',
+    'ISC fragment purification plate'      => 'ISC post-Cov',
+    'ISC library preparation plate'        => 'ISC post-Cov-XP',
+    'ISC library plate'                    => 'ISC lib',
+    'ISC library PCR plate'                => 'ISC lib PCR',
+    'ISC amplified library plate'          => 'ISC lib PCR-XP',
+    'ISC pooled amplified library plate'   => 'ISC lib pool',
+    'ISC hybridisation plate'              => 'ISC hyb',
+    'ISC captured library plate'           => 'ISC cap lib',
+    'ISC captured library PCR plate'       => 'ISC cap lib PCR',
+    'ISC amplified captured library plate' => 'ISC cap lib PCR-XP',
+    'ISC pooled captured library plate'    => 'ISC cap lib pool'
+  }
+
+  def self.update_names(mappings)
+    PlatePurpose.transaction do
+      mappings.each do |existing, updated|
+        purpose = PlatePurpose.find_by_name(existing) or raise StandardError, "Cannot find #{existing.inspect}"
+        purpose.update_attributes!(:name => updated)
+      end
+    end
+  end
+
+  def self.up
+    update_names(PLATE_PURPOSE_NAME_MAPPINGS)
+  end
+
+  def self.down
+    update_names(Hash[PLATE_PURPOSE_NAME_MAPPINGS.to_a.map(&:reverse)])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110912115027) do
+ActiveRecord::Schema.define(:version => 20110916104200) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false

--- a/features/api/pulldown/bait_library_assignment.feature
+++ b/features/api/pulldown/bait_library_assignment.feature
@@ -18,11 +18,11 @@ Feature: Assigning bait libraries to a plate
 
     # Setup the plates so that they flow appropriately.  This is a bit of a cheat in that it's only
     # a direct link and that we're faking out the pipeline work but it suffices.
-    Given a "SC stock plate" plate called "Testing bait libraries" exists
+    Given a "SC stock DNA" plate called "Testing bait libraries" exists
       And all wells on the plate "Testing bait libraries" have unique samples
       And the UUID for the plate "Testing bait libraries" is "00000000-1111-2222-3333-000000000001"
 
-    Given a "SC hybridisation plate" plate called "Target for bait libraries" exists
+    Given a "SC hyb" plate called "Target for bait libraries" exists
       And the "Transfer columns 1-12" transfer template has been used between "Testing bait libraries" and "Target for bait libraries"
       And the UUID for the plate "Target for bait libraries" is "00000000-1111-2222-3333-000000000002"
 

--- a/features/api/pulldown/bottom_of_the_pipeline.feature
+++ b/features/api/pulldown/bottom_of_the_pipeline.feature
@@ -16,13 +16,13 @@ Feature: The bottom of the pulldown pipeline
     Given the plate barcode webservice returns "1000001"
       And the plate barcode webservice returns "1000002"
 
-    Given the UUID for the plate purpose "WGS stock plate" is "11111111-2222-3333-4444-000000000001"
+    Given the UUID for the plate purpose "WGS stock DNA" is "11111111-2222-3333-4444-000000000001"
       And the UUID for the transfer template "Transfer wells to MX library tubes by submission" is "22222222-3333-4444-5555-000000000001"
       And the UUID for the search "Find assets by barcode" is "33333333-4444-5555-6666-000000000001"
       And the UUID of the next plate creation created will be "55555555-6666-7777-8888-000000000001"
       And the UUID of the next state change created will be "44444444-5555-6666-7777-000000000001"
 
-    Given a "WGS stock plate" plate called "Testing the API" exists
+    Given a "WGS stock DNA" plate called "Testing the API" exists
       And the UUID for the plate "Testing the API" is "00000000-1111-2222-3333-000000000001"
       And all wells on the plate "Testing the API" have unique samples
 

--- a/features/api/pulldown/submissions.feature
+++ b/features/api/pulldown/submissions.feature
@@ -14,7 +14,7 @@ Feature: Creating submissions for pulldown
 
     Given the plate barcode webservice returns "1000001"
 
-    Given a "WGS stock plate" plate called "Testing the pulldown submissions" exists
+    Given a "WGS stock DNA" plate called "Testing the pulldown submissions" exists
       And all of the wells on the plate "Testing the pulldown submissions" are in an asset group called "Testing the pulldown submissions" owned by the study "Testing submission creation"
       And the UUID for the asset group "Testing the pulldown submissions" is "88888888-1111-2222-3333-000000000000"
 

--- a/features/api/pulldown/tagging_a_plate.feature
+++ b/features/api/pulldown/tagging_a_plate.feature
@@ -1,8 +1,8 @@
 @api @json @single-sign-on @new-api
 Feature: Tagging the wells on a plate using a tag layout template
   There are several points in the pulldown laboratory workflow where the contents of a plate are tagged.  Taking
-  WGS as an example: the user will create a WGS library PCR plate from a WGS library plate, they will then start
-  that WGS library PCR plate, then assign the tags, do the PCR reaction, and then pass the WGS library PCR plate.
+  WGS as an example: the user will create a WGS lib PCR from a WGS lib, they will then start
+  that WGS lib PCR, then assign the tags, do the PCR reaction, and then pass the WGS lib PCR.
 
   Background:
     Given all HTTP requests to the API have the cookie "WTSISignOn" set to "I-am-authenticated"
@@ -266,8 +266,8 @@ Feature: Tagging the wells on a plate using a tag layout template
 
     Scenarios:
       | parent plate type         | child plate type              |
-      | WGS library plate         | WGS library PCR plate         |
-      | SC captured library plate | SC captured library PCR plate |
-      | ISC library plate         | ISC library PCR plate         |
+      | WGS lib         | WGS lib PCR         |
+      | SC cap lib | SC cap lib PCR |
+      | ISC lib         | ISC lib PCR         |
 
 

--- a/features/api/pulldown/top_of_the_pipeline.feature
+++ b/features/api/pulldown/top_of_the_pipeline.feature
@@ -24,8 +24,8 @@ Feature: The top of the pulldown pipeline
 
   @authorised
   Scenario Outline: Dealing with the initial plate in the pipeline
-    Given the UUID for the plate purpose "<pipeline> stock plate" is "11111111-2222-3333-4444-000000000001"
-      And a "<pipeline> stock plate" plate called "Testing the API" exists
+    Given the UUID for the plate purpose "<pipeline> stock DNA" is "11111111-2222-3333-4444-000000000001"
+      And a "<pipeline> stock DNA" plate called "Testing the API" exists
       And the UUID for the plate "Testing the API" is "00000000-1111-2222-3333-000000000001"
       And all wells on the plate "Testing the API" have unique samples
 
@@ -315,6 +315,6 @@ Feature: The top of the pulldown pipeline
 
     Scenarios:
       | pipeline | plate purpose           |
-      | WGS      | WGS fragmentation plate |
-      | SC       | SC fragmentation plate  |
-      | ISC      | ISC fragmentation plate |
+      | WGS      | WGS Covaris |
+      | SC       | SC Covaris  |
+      | ISC      | ISC Covaris |

--- a/features/step_definitions/pulldown_steps.rb
+++ b/features/step_definitions/pulldown_steps.rb
@@ -73,13 +73,13 @@ end
 # pipelines back to the stock plate directly.  Eventually these can grow into a proper work through of
 # a pipeline.
 Given /^(all submissions) have been worked until the last plate of the "Pulldown WGS" pipeline$/ do |submissions|
-  work_pipeline_for(submissions, 'WGS pooled amplified library plate')
+  work_pipeline_for(submissions, 'WGS lib pool')
 end
 Given /^(all submissions) have been worked until the last plate of the "Pulldown SC" pipeline$/ do |submissions|
-  work_pipeline_for(submissions, 'SC pooled captured library plate')
+  work_pipeline_for(submissions, 'SC cap lib pool')
 end
 Given /^(all submissions) have been worked until the last plate of the "Pulldown ISC" pipeline$/ do |submissions|
-  work_pipeline_for(submissions, 'ISC pooled captured library plate')
+  work_pipeline_for(submissions, 'ISC cap lib pool')
 end
 
 Transform /^the (sample|library) tube "([^\"]+)"$/ do |type, name|


### PR DESCRIPTION
The names for the pulldown plate purposes should match what they use in
the laboratory so that there is less confusion when using the
application.
