### PR TITLE
[fixes 18599155] Prevent multiple untagged aliquots.

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -119,8 +119,13 @@ class Aliquot < ActiveRecord::Base
   validates_presence_of :sample
 
   # It may have a tag but not necessarily.  If it does, however, that tag needs to be unique within the receptacle.
+  # To ensure that there can only be one untagged aliquot present in a receptacle we use a special value for tag_id,
+  # rather than NULL which does not work in MySQL.  It also works because the unassigned tag ID never gets matched
+  # for a Tag and so the result is nil!
+  UNASSIGNED_TAG = -1
   belongs_to :tag
-  validates_uniqueness_of :tag_id, :scope => :receptacle_id, :allow_nil => true, :allow_blank => true
+  validates_uniqueness_of :tag_id, :scope => :receptacle_id
+  before_validation { |record| record.tag_id ||= UNASSIGNED_TAG }
 
   # It may have a bait library but not necessarily.
   belongs_to :bait_library

--- a/db/migrate/20110927132235_cleanup_multiple_untagged_aliquots.rb
+++ b/db/migrate/20110927132235_cleanup_multiple_untagged_aliquots.rb
@@ -1,0 +1,57 @@
+class CleanupMultipleUntaggedAliquots < ActiveRecord::Migration
+  class Aliquot < ActiveRecord::Base
+    set_table_name('aliquots')
+  end
+
+  class Receptacle < ActiveRecord::Base
+    set_table_name('assets')
+
+    has_many :aliquots, :class_name => 'CleanupMultipleUntaggedAliquots::Aliquot', :foreign_key => :receptacle_id
+
+    def self.find_with_duplicate_untagged_aliquots(options = {}, &block)
+      self.connection.select_all(%q{
+        SELECT assets.id AS id
+        FROM assets
+        INNER JOIN aliquots ON assets.id=aliquots.receptacle_id
+        WHERE aliquots.tag_id IS NULL
+        GROUP BY assets.id, aliquots.sample_id
+        HAVING count(*) > 1;
+      }).in_groups_of(500) do |details|
+        details.compact!
+        next if details.empty?
+        self.all(options.merge(:conditions => { :id => details.map { |d| d['id'] } })).each(&block)
+      end
+    end
+  end
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      count = 0
+      Receptacle.find_with_duplicate_untagged_aliquots(:include => :aliquots) do |receptacle|
+        # Eliminate duplicate aliquots for a sample in the current receptacle
+        receptacle.aliquots.group_by(&:sample_id).each do |sample_id, aliquots|
+          aliquots = aliquots.sort_by(&:updated_at).reverse
+
+          save_this_aliquot   = aliquots.detect { |a| a.tag_id.present? }      # Take the one with a tag ...
+          save_this_aliquot ||= aliquots.detect { |a| a.library_id.present? }  # ... otherwise try library ...
+          save_this_aliquot ||= aliquots.first                                 # ... failing that the first one, by updated_at
+
+          aliquots.reject { |a| a == save_this_aliquot }.map(&:destroy)
+        end
+
+        # If there are multiply untagged aliquots across samples in this receptacle then we have
+        # a bit of a problem!
+        untagged_aliquots = receptacle.aliquots(true).select { |a| a.tag_id.nil? }
+        raise "There are multiple untagged aliquots in #{receptacle.id}" if untagged_aliquots.size > 1
+
+        count += 1
+      end
+
+      say("Completed processing #{count} receptacles")
+    end
+  end
+
+  def self.down
+    # Nothing to do in the down bit
+  end
+end

--- a/db/migrate/20110927132236_fake_tags_on_multiple_untagged_aliquots.rb
+++ b/db/migrate/20110927132236_fake_tags_on_multiple_untagged_aliquots.rb
@@ -1,0 +1,45 @@
+class FakeTagsOnMultipleUntaggedAliquots < ActiveRecord::Migration
+  class Aliquot < ActiveRecord::Base
+    set_table_name('aliquots')
+
+    UNASSIGNED_TAG = -1
+
+    def self.unset_fake_tags_for_multiple_aliquots
+      self.update_all('tag_id=NULL', [ 'tag_id < ?', UNASSIGNED_TAG ])
+    end
+  end
+
+  class Asset < ActiveRecord::Base
+    set_table_name('assets')
+
+    has_many :aliquots, :class_name => 'FakeTagsOnMultipleUntaggedAliquots::Aliquot', :foreign_key => :receptacle_id
+
+    def self.find_with_multiple_untagged_aliquots(options = {}, &block)
+      self.connection.select_all(%Q{
+        SELECT receptacle_id AS id
+        FROM aliquots
+        WHERE tag_id IS NULL
+        GROUP BY receptacle_id
+        HAVING COUNT(*) > 1
+      }).in_groups_of(500) do |details|
+        details.compact!
+        next if details.empty?
+        self.all(options.merge(:condition => { :id => details.map { |d| d['id'] } })).each(&block)
+      end
+    end
+  end
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      Asset.find_with_multiple_untagged_aliquots(:include => :aliquots) do |receptacle|
+        receptacle.aliquots.each_with_index do |aliquot, index|
+          aliquot.update_attributes!(:tag_id => Aliquot::UNASSIGNED_TAG - index - 1)
+        end
+      end
+    end
+  end
+
+  def self.down
+    Aliquot.unset_fake_tags_for_multiple_aliquots
+  end
+end

--- a/db/migrate/20110927132237_tag_untagged_aliquots_with_untagged_tag.rb
+++ b/db/migrate/20110927132237_tag_untagged_aliquots_with_untagged_tag.rb
@@ -1,0 +1,18 @@
+class TagUntaggedAliquotsWithUntaggedTag < ActiveRecord::Migration
+  class Aliquot < ActiveRecord::Base
+    set_table_name('aliquots')
+
+    def self.tag_untagged(details)
+      conditions = details[:from].nil? ? 'tag_id IS NULL' : [ 'tag_id=?', details[:from] ]
+      self.update_all("tag_id=#{details[:to] || 'NULL'}", conditions)
+    end
+  end
+
+  def self.up
+    Aliquot.tag_untagged(:from => nil, :to => -1)
+  end
+
+  def self.down
+    Aliquot.tag_untagged(:from => -1, :to => nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110916104200) do
+ActiveRecord::Schema.define(:version => 20110927132237) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -184,6 +184,14 @@ Factory.define :request, :parent => :request_without_assets do |r|
   end
 end
 
+# A request that has an input asset with something in it, and an empty start asset.
+Factory.define :request_suitable_for_starting, :parent => :request_without_assets do |request|
+  request.after_build do |request|
+    request.asset        ||= Factory(:sample_tube)
+    request.target_asset ||= Factory(:empty_library_tube)
+  end
+end
+
 Factory.define :request_without_item, :class => "Request" do |r|
   r.study         {|pr| pr.association(:study)}
   r.project         {|pr| pr.association(:project)}

--- a/test/unit/asset_test.rb
+++ b/test/unit/asset_test.rb
@@ -53,12 +53,12 @@ class AssetTest < ActiveSupport::TestCase
       @study_to = Factory :study
       
       @sample = Factory :sample
-      @sample_tube  = Factory(:empty_sample_tube).tap { |sample_tube|  sample_tube.aliquots.create!(:sample => @sample)  }
-      @library_tube = Factory(:library_tube).tap      { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
+      @sample_tube  = Factory(:empty_sample_tube).tap  { |sample_tube|  sample_tube.aliquots.create!(:sample => @sample)  }
+      @library_tube = Factory(:empty_library_tube).tap { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
 
       @sample_2 = Factory :sample
-      @sample_tube_2  = Factory(:empty_sample_tube).tap { |sample_tube|  sample_tube.aliquots.create!(:sample => @sample_2)  }
-      @library_tube_2 = Factory(:library_tube).tap      { |library_tube| library_tube.aliquots.create!(:sample => @sample_2) }
+      @sample_tube_2  = Factory(:empty_sample_tube).tap  { |sample_tube|  sample_tube.aliquots.create!(:sample => @sample_2)  }
+      @library_tube_2 = Factory(:empty_library_tube).tap { |library_tube| library_tube.aliquots.create!(:sample => @sample_2) }
 
       @multiplex_tube = Factory :multiplexed_library_tube
       @lane = Factory :lane, :sti_type => "Lane"
@@ -138,9 +138,9 @@ class AssetTest < ActiveSupport::TestCase
       @study_to = Factory :study
 
       @sample = Factory :sample
-      @sample_tube    = Factory(:empty_sample_tube).tap { |sample_tube| sample_tube.aliquots.create!(:sample => @sample) }
-      @library_tube   = Factory(:library_tube).tap      { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
-      @library_tube_2 = Factory(:library_tube).tap      { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
+      @sample_tube    = Factory(:empty_sample_tube).tap  { |sample_tube|  sample_tube.aliquots.create!(:sample => @sample) }
+      @library_tube   = Factory(:empty_library_tube).tap { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
+      @library_tube_2 = Factory(:empty_library_tube).tap { |library_tube| library_tube.aliquots.create!(:sample => @sample) }
       @multiplex_tube = Factory(:multiplexed_library_tube)
 
       @study_sample = Factory :study_sample, :study => @study, :sample => @sample

--- a/test/unit/request_test.rb
+++ b/test/unit/request_test.rb
@@ -161,9 +161,8 @@ class RequestTest < ActiveSupport::TestCase
     context "#state" do
       setup do
         @study = Factory :study
-        @item         = Factory :item
-        @request = Factory :request, :study => @study, :item => @item
-        # @item_request = Factory :request_item, :item => @item, :request => @request
+        @item  = Factory :item
+        @request = Factory :request_suitable_for_starting, :study => @study, :item => @item
         @user = Factory :admin
         @user.has_role 'owner', @study
       end

--- a/test/unit/sample_test.rb
+++ b/test/unit/sample_test.rb
@@ -22,7 +22,7 @@ class SampleTest < ActiveSupport::TestCase
         @new_assets_name = ""
         @current_user = Factory :user
 
-        @asset_1 = Factory(:sample_tube, :name => @sample_from.name).tap { |sample_tube| sample_tube.aliquots.create!(:sample => @sample_from) }
+        @asset_1 = Factory(:empty_sample_tube, :name => @sample_from.name).tap { |sample_tube| sample_tube.aliquots.create!(:sample => @sample_from) }
         
         @asset_group = Factory :asset_group, :name => "not mx"
         @asset_group_asset = Factory :asset_group_asset, :asset_id => @asset_1.id, :asset_group_id => @asset_group.id
@@ -43,7 +43,7 @@ class SampleTest < ActiveSupport::TestCase
 
       context "only valid assets and without submissions" do
         setup do
-          @asset_from = Factory(:empty_sample_tube, :name => @sample_from_ok.name, :sample => @sample_from_ok).tap { |sample_tube| sample_tube.aliquots.create!(:sample => @sample_from_ok) }
+          @asset_from = Factory(:empty_sample_tube, :name => @sample_from_ok.name).tap { |sample_tube| sample_tube.aliquots.create!(:sample => @sample_from_ok) }
           @asset_group_from_new = Factory :asset_group, :name => "Asset_Sample_New", :study => @study_from
           @asset_group_asset_from = Factory :asset_group_asset, :asset_id => @asset_from.id, :asset_group_id => @asset_group_from_new.id
 


### PR DESCRIPTION
This uses a -1 for tag_id to represent untagged aliquots which prevents
them being multiply added to a receptacle.  It doesn't, however, prevent
an untagged aliquot being put with a tagged one.
