### PR TITLE
[fixes 19084579] Pools defined by outbound requests in pulldown

### DIFF
--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -72,6 +72,17 @@ class Plate < Asset
       end
     end
 
+    # Yields each pool of wells as it walks in the given direction.
+    def walk_in_pools(direction = :column, &block)
+      ActiveSupport::OrderedHash.new { |h,k| h[k] = [] }.tap do |pools|
+        send(:"walk_in_#{direction}_major_order") do |well, _|
+          proxy_owner.pool_id_for_well(well) { |pool_id| pools[pool_id] << well }
+        end
+      end.each do |pool_id, wells|
+        yield(pool_id, wells)
+      end
+    end
+
     # Walks the wells A1, B1, C1, ... A2, B2, C2, ... H12
     def walk_in_column_major_order(&block)
       locations_to_well = Hash[self.map { |well| [ well.map.description, well ] }]

--- a/app/models/pulldown/stock_plate_purpose.rb
+++ b/app/models/pulldown/stock_plate_purpose.rb
@@ -1,0 +1,9 @@
+# Specialised implementation of the plate purpose for the stock plates that lead into the various
+# pulldown pipelines.
+class Pulldown::StockPlatePurpose < PlatePurpose
+  # Returns the pulldown requests that lead out of this well
+  def requests_for_pool(well)
+    well.requests_as_source.where_is_a?(Pulldown::Requests::LibraryCreation)
+  end
+  private :requests_for_pool
+end

--- a/app/models/tag_layout.rb
+++ b/app/models/tag_layout.rb
@@ -40,7 +40,7 @@ class TagLayout < ActiveRecord::Base
     # Adjust each of the groups so that any wells that are in the same pool as those at the same position
     # in the group to the left are moved to a non-clashing position.  Effectively this makes the view of the
     # plate slightly jagged.
-    wells_in_groups = plate.wells.send(:"in_#{direction.pluralize}").map { |wells| wells.map { |well| [ well, well.pool_id ] } }
+    wells_in_groups = plate.wells.send(:"in_#{direction.pluralize}").map { |wells| wells.map { |well| [ well, plate.pool_id_for_well(well) ] } }
     wells_in_groups.each_with_index do |current_group, group|
       next if group == 0
       prior_group = wells_in_groups[group-1]
@@ -73,8 +73,8 @@ class TagLayout < ActiveRecord::Base
 
     # We can now check that the pools do not contain duplicate tags.
     pool_to_tag = Hash.new { |h,k| h[k] = [] }
-    plate.wells.walk_in_column_major_order do |well, _|
-      well.pool_id { |pool_id| pool_to_tag[pool_id] << well.aliquots.map(&:tag).uniq }
+    plate.wells.walk_in_pools do |pool_id, wells|
+      pool_to_tag[pool_id] = wells.map { |well| well.aliquots.map(&:tag).uniq }.flatten
     end
     errors.add_to_base('duplicate tags within a pool') if pool_to_tag.any? { |_,t| t.uniq.size > 1 }
   end

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -160,14 +160,4 @@ class Well < Aliquot::Receptacle
     end
     nil
   end
-
-  def pool_id(&block)
-    return nil if requests_as_target.empty?
-    requests_as_target.map(&:submission_id).uniq.tap do |submission_ids|
-      raise StandardError, "Cannot handle no submissions" if submission_ids.empty?
-      raise StandardError, "Cannot handle multiple submissions (#{submission_ids.inspect})" if submission_ids.size > 1
-    end.first.tap do |pool_id|
-      yield(pool_id) if block_given?
-    end
-  end
 end

--- a/db/migrate/20110930120355_change_pulldown_stock_plate_purpose.rb
+++ b/db/migrate/20110930120355_change_pulldown_stock_plate_purpose.rb
@@ -1,0 +1,20 @@
+class ChangePulldownStockPlatePurpose < ActiveRecord::Migration
+  class PlatePurpose < ActiveRecord::Base
+    set_table_name('plate_purposes')
+
+    def self.change_implementation(to)
+      PlatePurpose.update_all(
+        "type=#{ to.nil? ? 'NULL' : to.inspect }",
+        [ 'name IN (?)', [ 'WGS stock DNA', 'SC stock DNA', 'ISC stock DNA' ] ]
+      )
+    end
+  end
+
+  def self.up
+    PlatePurpose.change_implementation('Pulldown::StockPlatePurpose')
+  end
+
+  def self.down
+    PlatePurpose.change_implementation(nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20110927132237) do
+ActiveRecord::Schema.define(:version => 20110930120355) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
The pools on a stock plate in the pulldown pipeline come from the
outbound pulldown requests, rather than the inbound transfer requests,
as the submissions are defined after the plate has been cherrypicked by
SLF.
