### PR TITLE
[fixes 19172491] Ensure wells are ordered in plate JSON.

### DIFF
--- a/app/api/io/plate.rb
+++ b/app/api/io/plate.rb
@@ -6,7 +6,7 @@ class Io::Plate < Io::Asset
   define_attribute_and_json_mapping(%Q{
                                     size <=> size
                       plate_purpose.name  => plate_purpose.name
-                                   wells  => wells
+                wells.in_row_major_order  => wells
 
                                    state  => state
                                iteration  => iteration

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -32,7 +32,7 @@ class Well < Aliquot::Receptacle
     }
   }
   named_scope :in_column_major_order, { :joins => :map, :order => 'column_order ASC' }
-  named_scope :in_row_major_order, { :joins => :map, :orer => 'row_order ASC' }
+  named_scope :in_row_major_order, { :joins => :map, :order => 'row_order ASC' }
 
   after_create :create_well_attribute_if_not_exists
 


### PR DESCRIPTION
The wells should be ordered in row major order in the plate JSON having
removed this ordering by default.
