### PR TITLE
[fixes 19382269] Asset progress displaying incorrect requests.

### DIFF
--- a/app/views/studies/workflows/_asset_progress.html.erb
+++ b/app/views/studies/workflows/_asset_progress.html.erb
@@ -7,10 +7,8 @@
       <th>Type</th>
       <th>Sample</th>
       <th>Closed?</th>
-      <% @workflow.request_types.each do |request_type| %>
-        <% if @total_requests[request_type] > 0 %>
-          <th class='label'><center><%= request_type.name %></center></th>
-        <% end %>
+      <% @request_types.each do |request_type| %>
+        <th class='label'><center><%= request_type.name %></center></th>
       <% end %>
       <th>Latest update</th>
       <th>Update date</th>

--- a/app/views/studies/workflows/_sample_progress.html.erb
+++ b/app/views/studies/workflows/_sample_progress.html.erb
@@ -5,9 +5,7 @@
       <th>Name</th>
       <th>Update date</th>
       <% @request_types.each do |request_type| %>
-        <% if @total_requests[request_type] > 0 %>
-          <th><center><%= request_type.name %></center></th>
-        <% end %>
+        <th><center><%= request_type.name %></center></th>
       <% end %>
     </tr>
   </thead>


### PR DESCRIPTION
The request types in the headers were in a different order than those
displayed in the body, meaning that cherrypicking requests could appear
to be sequencing requests.
