### PR TITLE
19464643 Fixed closing div tag

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -25,5 +25,5 @@
         <td><br /><%= submit_tag "Update" %> or <%= link_to 'cancel', "javascript:history.back();" %></td>
       </tr>
     </table>
-  <div>
+  </div>
 <% end %>


### PR DESCRIPTION
There was a problem with the profile edit view: the right hand column was shifted to the bottom of the page. This was caused by a missing '/' on a closing div tag. Now fixed.
