### PR TITLE
[fixes 17902575] Allow study owner to be properly set

### DIFF
--- a/app/views/studies/_study.html.erb
+++ b/app/views/studies/_study.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <tr>
     <td width="40%" class="item"><%= label_tag(:study_owner_id, 'Study owner:') %></td>
-    <td width="40%"><%= select_tag "study_owner_id", options_for_select([[" " , "0" ]] + User.owners.map { |user| [user.name, user.id] }) %></td>
+    <td width="40%"><%= select_tag "study_owner_id", options_for_select([[" " , "0" ]] + User.owners.map { |user| [user.name, user.id] }, study.owners.first.try(:id) || params[:study_owner_id].to_i) %></td>
     <td class="help_field">&nbsp;</td>
   </tr>
 


### PR DESCRIPTION
The owner/manager information wasn't being set properly on a study
because the study itself hadn't been saved before the role was being
set.  This refactors the code to ensure that the study exists first.

It also addresses the problem where PMs could not change the owner of a
study, which was completely missing, and ensures that if there are more
than one owner they are not all removed.  In other words, it should
behave appropriately if there is only ever one owner, which the UI
suggests but doesn't necessarily enforce.
