### PR TITLE
19757887 dont swallow exceptions in plate printing

### DIFF
--- a/app/controllers/pulldown/plates_controller.rb
+++ b/app/controllers/pulldown/plates_controller.rb
@@ -20,20 +20,22 @@ class Pulldown::PlatesController < Pulldown::BaseController
   end
   
   def create
-    barcode_printer = BarcodePrinter.find(params[:plates][:barcode_printer])
-    source_plate_barcodes = params[:plates][:source_plates]
+    ActiveRecord::Base.transaction do
+      barcode_printer = BarcodePrinter.find(params[:plates][:barcode_printer])
+      source_plate_barcodes = params[:plates][:source_plates]
 
-    respond_to do |format|
-      if Plate.create_default_plates_and_print_barcodes(source_plate_barcodes, barcode_printer, current_user)
-        flash[:notice] = 'Created plates and printed barcodes'
-        format.html { redirect_to('/pulldown/plates/new') }
-        format.xml  { render :xml  => new_plates, :status => :created}
-        format.json { render :json => new_plates, :status => :created}
-      else
-        flash[:error] = 'Failed to create plates'
-        format.html { redirect_to('/pulldown/plates/new') }
-        format.xml  { render :xml  => flash.to_xml, :status => :unprocessable_entity }
-        format.json { render :json => flash.to_json, :status => :unprocessable_entity }
+      respond_to do |format|
+        if Plate.create_default_plates_and_print_barcodes(source_plate_barcodes, barcode_printer, current_user)
+          flash[:notice] = 'Created plates and printed barcodes'
+          format.html { redirect_to('/pulldown/plates/new') }
+          format.xml  { render :xml  => new_plates, :status => :created}
+          format.json { render :json => new_plates, :status => :created}
+        else
+          flash[:error] = 'Failed to create plates'
+          format.html { redirect_to('/pulldown/plates/new') }
+          format.xml  { render :xml  => flash.to_xml, :status => :unprocessable_entity }
+          format.json { render :json => flash.to_json, :status => :unprocessable_entity }
+        end
       end
     end
   end

--- a/features/create_plates.feature
+++ b/features/create_plates.feature
@@ -15,6 +15,16 @@ Feature: Printing new plate barcodes
     And I select "xyz" from "Barcode printer"
     And I press "Submit"
     Then I should see "Please scan your user barcode"
+
+  Scenario: Creating plates where the barcode service errors
+    Given the plate barcode printing service will error
+    Given I am on the new plate page
+    Then I should see "Create Plates"
+    And I should see "Barcode printer"
+    When I select "Pulldown" from "plates_plate_purpose"
+    And I fill in "User barcode" with "2470000100730"
+    And I select "xyz" from "Barcode printer"
+    Then I expect an exception to be raised when I press "Submit"
     
   Scenario: Creating plates where the scanner appends a carriage return
     Given I am on the new plate page

--- a/features/pulldown/4642667_pulldown_plate_creation.feature
+++ b/features/pulldown/4642667_pulldown_plate_creation.feature
@@ -1,4 +1,4 @@
-@barcode-service @wip
+@barcode-service
 Feature: Printing new plate barcodes in pulldown
   Background:
     Given I am logged in as "user"

--- a/features/step_definitions/barcode_steps.rb
+++ b/features/step_definitions/barcode_steps.rb
@@ -11,6 +11,11 @@ Given /^a plate barcode webservice is available and returns "(\d+)"$/ do |barcod
   Given %Q{the plate barcode webservice returns "#{barcode}"}
 end
 
+Given /^the plate barcode printing service will error$/ do
+  FakeBarcodeService.instance.push_printing_error
+end
+
+
 Given /^the plate barcode webservice returns "([1-9][0-9]*)\.\.([1-9][0-9]*)"$/ do |start, finish|
   (start.to_i..finish.to_i).each { |i| Given %Q{the plate barcode webservice returns "#{i}"} }
 end

--- a/features/step_definitions/web_form_steps.rb
+++ b/features/step_definitions/web_form_steps.rb
@@ -107,3 +107,16 @@ end
 Then /^"([^\"]+)" should be selected from "([^\"]+)"$/ do |value, name|
   assert_equal([ value ], find_field(name).value, "Field #{name.inspect} does not have the correct value selected")
 end
+
+Then /^I expect an exception to be raised when I press "([^"]*)"(?: within "([^"]*)")?$/ do |button, selector|
+  begin
+    with_scope(selector) do
+      click_button(button)
+    end
+    fail("No exception raised!")
+  rescue RuntimeError => exception  # 'fail' raises, so we need to check that
+    raise
+  rescue => exception
+    # Good, that was expected
+  end
+end


### PR DESCRIPTION
The code was swallowing exceptions raised from communicating with the
barcode printing service which meant that it was incredibly hard to
identify the problem, even noticing there was one came from a user
email.
