### PR TITLE
19764171 fix for array express accession

### DIFF
--- a/app/models/accessionable/base.rb
+++ b/app/models/accessionable/base.rb
@@ -42,7 +42,7 @@ class Accessionable::Base
   end
 
   def extract_array_express_accession_number(xmldoc)
-          element = xmldoc.root.elements["/RECEIPT/#{schema_type.upcase}/EXT_ID[@type='array express']"]
+          element = xmldoc.root.elements["/RECEIPT/#{schema_type.upcase}/EXT_ID[@type='ArrayExpress']"]
           accession_number       = element &&  element.attributes['accession']
   end
 

--- a/features/step_definitions/4491710_ega_integration_steps.rb
+++ b/features/step_definitions/4491710_ega_integration_steps.rb
@@ -8,7 +8,7 @@ end
 
 Given /^an accessioning service exists which returns an array express accession number "([^\"]+)"/ do |ae_an|
   FakeAccessionService.instance.success("Study", "EGAS00001000241", <<-XML)
-  <EXT_ID accession="#{ae_an}" type="array express"/>
+  <EXT_ID accession="#{ae_an}" type="ArrayExpress"/>
   XML
 
 end


### PR DESCRIPTION
This will enable Sequencescape to retrieve back the AE accession number
