### PR TITLE
12736961 expose request priority in batch xml

### DIFF
--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -5,7 +5,7 @@ xml.batch {
   xml.lanes {
     @batch.batch_requests.ordered.each do |batch_request|
       request = batch_request.request
-      xml.lane("position" => batch_request.position, 'id' => request.target_asset_id) {
+      xml.lane("position" => batch_request.position, 'id' => request.target_asset_id, 'priority' => request.priority) {
         # This batch seems very broken!
         if request.asset.nil?
           xml.comment!("The request #{request.id} has no source asset which is very bad!")

--- a/test/functional/batches_controller_test.rb
+++ b/test/functional/batches_controller_test.rb
@@ -35,7 +35,7 @@ class BatchesControllerTest < ActionController::TestCase
           batch = Factory :batch, :pipeline => pipeline
           library1 = Factory(:empty_library_tube).tap { |library_tube| library_tube.aliquots.create!(:sample => @sample, :project => @project, :study => @study) }
           @lane = Factory(:empty_lane, :qc_state => 'failed').tap { |lane| lane.aliquots.create!(:sample => @sample, :project => @project, :study => @study) }
-          @request_one = pipeline.request_type.create!(:asset => library1, :target_asset => @lane, :project => @project, :study => @study)
+          @request_one = pipeline.request_type.create!(:asset => library1, :target_asset => @lane, :project => @project, :study => @study, :priority => 99)
           batch.batch_requests.create!(:request => @request_one, :position => 1)
 
           get :show, :id => batch.id, :format => "xml"
@@ -44,7 +44,7 @@ class BatchesControllerTest < ActionController::TestCase
         
         should "have api version attribute on root object" do
           assert_response :success
-          assert_tag :tag => 'lane', :attributes => { :position => 1, :id => @lane.id }
+          assert_tag :tag => 'lane', :attributes => { :position => 1, :id => @lane.id, :priority => 99 }
           assert_tag :tag => "library", :attributes => {:sample_id => @sample.id, :request_id => @request_one.id}
           assert_tag :tag => "library", :attributes => {:project_id => @project.id, :study_id => @study.id}
           assert_tag :tag => "library", :attributes => {:qc_state => "fail"}


### PR DESCRIPTION
This adds a 'priority' attribute to the lane element in the batch XML to
indicate whether the lane was a priority for sequencing.  The exposed
value is an integer, although currently only 0 (non-priority) and 1
(priority) are used.
