### PR TITLE
19881309 barcode label names should be implementation specific

### DIFF
--- a/app/controllers/barcode_printers_controller.rb
+++ b/app/controllers/barcode_printers_controller.rb
@@ -81,7 +81,7 @@ class BarcodePrintersController < ApplicationController
         asset.barcode = AssetBarcode.new_barcode
         asset.save!
         end
-        printables.push PrintBarcode::Label.new({ :number => asset.barcode, :study => "#{asset.tube_name}", :prefix => prefix, :suffix => "" })
+        printables.push PrintBarcode::Label.new({ :number => asset.barcode, :study => asset.name_for_label.to_s, :prefix => prefix, :suffix => "" })
        end
 
        unless printables.empty?

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -535,6 +535,10 @@ class Plate < Asset
     unique_positions_on_plate == unique_positions_from_caller
   end
 
+  def name_for_label
+    self.name
+  end
+
   private
   def set_plate_name_and_size
     self.name = "Plate #{barcode}" if self.name.blank?

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -12,4 +12,8 @@ class Tube < Aliquot::Receptacle
   end
 
   delegate :barcode_type, :to => 'self.class'
+
+  def name_for_label
+    (primary_aliquot.nil? or primary_aliquot.sample.sanger_sample_id.blank?) ? self.name : primary_aliquot.sample.shorten_sanger_sample_id
+  end
 end


### PR DESCRIPTION
The 'study' attribute for a barcode label comes from different places
depending upon the asset.  For tubes it comes from the primary aliquot
sample ID, or the name of the asset if that is not present.  For plates
it is the name of the plate.

All other assets are unprintable and therefore should error.
