### PR TITLE
[fixes 20187583] Add blank to delay reason.

### DIFF
--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -14,7 +14,10 @@
         });
       };
 
-      var valueFrom = function(element) { return element.value.toLowerCase().replace(/[^a-z0-9]+/, '_'); };
+      var valueFrom = function(element) {
+        var value = element.value.toLowerCase().replace(/[^a-z0-9]+/, '_');
+        return (value.length == 0) ? 'blank' : value;
+      };
 
       observe = function(id) {
         var selectRelatedFor = function(value) { return jQuery('.related_to.' + id + '.' + value); }

--- a/app/views/shared/metadata/edit/_study.html.erb
+++ b/app/views/shared/metadata/edit/_study.html.erb
@@ -39,7 +39,7 @@
       <%= metadata_fields.select(:data_release_timing, Study::DATA_RELEASE_TIMINGS + [ Study::DATA_RELEASE_TIMING_NEVER ]) %>
       <%
         metadata_fields.change_select_options_for(:data_release_timing, :when => :data_release_strategy, :values => {
-          Study::DATA_RELEASE_STRATEGY_NOT_APPLICABLE => Study::DATA_RELEASE_TIMING_NEVER,
+          Study::DATA_RELEASE_STRATEGY_NOT_APPLICABLE                                    => Study::DATA_RELEASE_TIMING_NEVER,
           (Study::DATA_RELEASE_STRATEGIES-[Study::DATA_RELEASE_STRATEGY_NOT_APPLICABLE]) => Study::DATA_RELEASE_TIMINGS
         })
       %>
@@ -54,8 +54,8 @@
           <%= group.select(:data_release_delay_reason, Study::DATA_RELEASE_DELAY_REASONS_STANDARD) %>
           <%
             group.change_select_options_for(:data_release_delay_reason, :when => :data_release_study_type_id, :values => {
-              DataReleaseStudyType.assay_types.map(&:id) => Study::DATA_RELEASE_DELAY_REASONS_ASSAY,
-              DataReleaseStudyType.non_assay_types.map(&:id) => Study::DATA_RELEASE_DELAY_REASONS_STANDARD
+              DataReleaseStudyType.assay_types.map(&:id)     => [ '' ] + Study::DATA_RELEASE_DELAY_REASONS_ASSAY,
+              DataReleaseStudyType.non_assay_types.map(&:id) => [ '' ] + Study::DATA_RELEASE_DELAY_REASONS_STANDARD
             })
           %>
 


### PR DESCRIPTION
Because one of the options in delay reason can disappear we need to make
sure that the user notices this.  By adding a blank option, which is
invalid, we guarantee that they will have to choose if they don't after
submitting the details.
