### PR TITLE
[fixes 20188983] Add recording number of gigabases to studies.

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -202,6 +202,8 @@ class Study < ActiveRecord::Base
     # SNP information
     attribute(:snp_study_id, :integer => true)
     attribute(:snp_parent_study_id, :integer => true)
+
+    attribute(:number_of_gigabases_per_sample)
     
     REMAPPED_ATTRIBUTES = {
       :contaminated_human_dna     => YES_OR_NO,
@@ -244,6 +246,8 @@ class Study < ActiveRecord::Base
     def delayed_for_long_time?
       DATA_RELEASE_DELAY_PERIODS.include?(self.data_release_delay_period)
     end
+
+    validates_numericality_of :number_of_gigabases_per_sample, :greater_than_or_equal_to => 0.15, :allow_blank => true, :allow_nil => true
 
     has_one :data_release_non_standard_agreement, :class_name => 'Document', :as => :documentable
     accepts_nested_attributes_for :data_release_non_standard_agreement

--- a/app/views/shared/metadata/edit/_study.html.erb
+++ b/app/views/shared/metadata/edit/_study.html.erb
@@ -2,6 +2,7 @@
 <% fields_for(study) do |form| %>
   <% form.fields_for(:study_metadata, :builder => Metadata::FormBuilder) do |metadata_fields| %>
     <%= metadata_fields.select_by_association(:faculty_sponsor)%>
+    <%= metadata_fields.text_field(:number_of_gigabases_per_sample) %>
 
     <% metadata_fields.with_options(:grouping => 'ENA requirement') do |group| %>
       <%= group.text_field(:study_study_title) %>
@@ -14,7 +15,6 @@
     <%= metadata_fields.select(:contains_human_dna, Study::YES_OR_NO) %>
     <%= metadata_fields.select(:contaminated_human_dna, Study::YES_OR_NO) %>
     <%= metadata_fields.select(:commercially_available, Study::YES_OR_NO) %>
-    
 
     <%= metadata_fields.text_field(:study_project_id, :grouping => 'SRA') %>
     <%= metadata_fields.text_field(:study_ebi_accession_number, :grouping => 'SRA AN') %>
@@ -70,6 +70,7 @@
         <% end %>
       <% end %>
     <% end %>
+
     <% metadata_fields.finalize_related_fields %>
   <% end %>
 <% end %>

--- a/config/locales/metadata/en.yml
+++ b/config/locales/metadata/en.yml
@@ -232,6 +232,9 @@ en:
 
     study:
       metadata:
+        number_of_gigabases_per_sample:
+          label: Number of gigabases per sample (minimum 0.15)
+
         reference_genome_id:
           label: Reference genome
 

--- a/db/migrate/20111026151521_add_number_of_gigabases_to_study_metadata.rb
+++ b/db/migrate/20111026151521_add_number_of_gigabases_to_study_metadata.rb
@@ -1,0 +1,9 @@
+class AddNumberOfGigabasesToStudyMetadata < ActiveRecord::Migration
+  def self.up
+    add_column :study_metadata, :number_of_gigabases_per_sample, :float
+  end
+
+  def self.down
+    remove_column :study_metadata, :number_of_gigabases_per_sample
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111011150028) do
+ActiveRecord::Schema.define(:version => 20111026151521) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -991,6 +991,7 @@ ActiveRecord::Schema.define(:version => 20111011150028) do
     t.string  "ega_dac_accession_number"
     t.string  "commercially_available",                 :default => "No"
     t.integer "faculty_sponsor_id"
+    t.float   "number_of_gigabases_per_sample"
   end
 
   add_index "study_metadata", ["faculty_sponsor_id"], :name => "index_study_metadata_on_faculty_sponsor_id"


### PR DESCRIPTION
Adds a field that record the number of gigabases per sample required by
the study.  This field is optional.
