### PR TITLE
19943167 fix submission request options

### DIFF
--- a/app/api/endpoints/submission_templates.rb
+++ b/app/api/endpoints/submission_templates.rb
@@ -7,7 +7,6 @@ class Endpoints::SubmissionTemplates < Core::Endpoint::Base
     factory(:to => 'submissions', :json => 'submissions') do |request, _|
       ActiveRecord::Base.transaction do
         attributes = ::Io::Submission.map_parameters_to_attributes(request.json)
-        attributes[:request_options] = attributes.delete(:request_options_structured)
         request.create!(attributes.merge(:user => request.user))
       end
     end

--- a/app/api/io/submission.rb
+++ b/app/api/io/submission.rb
@@ -3,7 +3,8 @@ class ::Io::Submission < ::Core::Io::Base
     :read_length                 => 'read_length',
     :library_type                => 'library_type',
     :fragment_size_required_from => 'fragment_size_required.from',
-    :fragment_size_required_to   => 'fragment_size_required.to'
+    :fragment_size_required_to   => 'fragment_size_required.to',
+    :bait_library_name           => 'bait_library'
   }.map { |k,v| [ k, "request_options.#{v}"] }]
 
   def self.json_field_for(attribute)

--- a/app/api/model_extensions/submission.rb
+++ b/app/api/model_extensions/submission.rb
@@ -30,6 +30,8 @@ module ModelExtensions::Submission
     base.class_eval do
       include Validations
 
+      before_validation :merge_in_structured_request_options
+
       named_scope :include_study,   :include => { :study => :uuid_object }
       named_scope :include_project, :include => { :project => :uuid_object }
       named_scope :include_assets,  :include => { :assets => :uuid_object }
@@ -59,7 +61,7 @@ module ModelExtensions::Submission
   class NonNilHash 
     def initialize(key_style_operation = :symbolize_keys)
       @key_style_operation = key_style_operation
-      @store = Hash.new { |h,k| h[k] = Hash.new(&h.default_proc) }
+      @store = {}
     end
 
     def deep_merge(hash)
@@ -77,13 +79,18 @@ module ModelExtensions::Submission
       node_and_leaf(*keys_and_values) { |node, leaf| node[leaf] = value }
     end
 
+    def fetch(*keys_and_default)
+      default = keys_and_default.pop
+      node_and_leaf(*keys_and_default) { |node, left| node.fetch(left, default) }
+    end
+
     def to_hash
       Hash.new.deep_merge(@store)
     end
 
     def node_and_leaf(*keys, &block)
       leaf = keys.pop
-      node = keys.inject(@store) { |h,k| h[k] }
+      node = keys.inject(@store) { |h,k| h[k] ||= {} }
       yield(node, leaf)
     end
     private :node_and_leaf
@@ -96,47 +103,39 @@ module ModelExtensions::Submission
   def request_options_structured
     NonNilHash.new(:stringify_keys).tap do |json|
       NonNilHash.new.deep_merge(self.request_options).tap do |attributes|
-        json['read_length']                    = attributes[:read_length]
+        json['read_length']                    = attributes[:read_length].try(:to_i)
         json['library_type']                   = attributes[:library_type]
-        json['fragment_size_required', 'from'] = attributes[:fragment_size_required_from]
-        json['fragment_size_required', 'to']   = attributes[:fragment_size_required_to]
+        json['fragment_size_required', 'from'] = attributes[:fragment_size_required_from].try(:to_i)
+        json['fragment_size_required', 'to']   = attributes[:fragment_size_required_to].try(:to_i)
         json['bait_library']                   = attributes[:bait_library_name]
+        json['sequencing_type']                = attributes[:sequencing_type]
+        json['insert_size']                    = attributes[:insert_size].try(:to_i)
         request_type_multiplier { |id| json['number_of_lanes'] = attributes[:multiplier, id] }
       end
     end.to_hash
   end
-  
-  def request_options_structioned_normalised
-    structured_options = request_options_structured
-    return nil if structured_options.blank?
-    ['read_length', 'library_type'].each do |attribute_name|
-      structured_options[attribute_name] = structured_options[attribute_name]['value'] if contains_value_attribute?(structured_options[attribute_name])
-    end
-    ['to', 'from'].each do |attribute_name|
-      structured_options['fragment_size_required'][attribute_name] = structured_options['fragment_size_required'][attribute_name]['value'] if structured_options['fragment_size_required'] && contains_value_attribute?(structured_options['fragment_size_required'][attribute_name])
-    end
-
-    structured_options
-  end
-  
-  def contains_value_attribute?(request_option)
-    return true if ! request_option.blank? && request_option.is_a?(Hash) && request_option['value']
-    
-    false
-  end
 
   def request_options_structured=(values)
-    self.request_options = NonNilHash.new.tap do |attributes|
+    @request_options_structured = NonNilHash.new.tap do |attributes|
       NonNilHash.new(:stringify_keys).deep_merge(values).tap do |json|
-        attributes[:read_length]                 = json['read_length'] 
-        attributes[:library_type]                = json['library_type'] 
-        attributes[:fragment_size_required_from] = json['fragment_size_required', 'from'] 
-        attributes[:fragment_size_required_to]   = json['fragment_size_required', 'to'] 
+        attributes[:read_length]                 = json['read_length']
+        attributes[:library_type]                = json['library_type']
+        attributes[:fragment_size_required_from] = json['fragment_size_required', 'from']
+        attributes[:fragment_size_required_to]   = json['fragment_size_required', 'to']
         attributes[:bait_library_name]           = json['bait_library']
+        attributes[:sequencing_type]             = json['sequencing_type']
+        attributes[:insert_size]                 = json['insert_size']
         request_type_multiplier { |id| attributes[:multiplier, id] = json['number_of_lanes'] }
       end
     end.to_hash
   end
+
+  def merge_in_structured_request_options
+    self.request_options ||= {}
+    self.request_options = self.request_options.deep_merge(@request_options_structured || {})
+    true
+  end
+  private :merge_in_structured_request_options
 
   def request_type_objects
     return [] if self.request_types.blank?

--- a/app/models/api/submission_io.rb
+++ b/app/models/api/submission_io.rb
@@ -27,7 +27,7 @@ class Api::SubmissionIO < Api::Base
   
   extra_json_attributes do |object, json_attributes|
     json_attributes["asset_uuids"] = object.asset_uuids
-    json_attributes["request_options"] =  object.request_options_structioned_normalised unless object.request_options.blank?
+    json_attributes["request_options"] =  object.request_options_structured unless object.request_options_structured.blank?
   end
 
 end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -227,7 +227,7 @@ class Asset < ActiveRecord::Base
     [  nil, '']
   ]
 
-  QC_STATES.each do |state, qc_state|
+  QC_STATES.reject { |k,v| k.nil? }.each do |state, qc_state|
     line = __LINE__ + 1
     class_eval(%Q{
       def qc_#{qc_state}

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -482,8 +482,13 @@ class Plate < Asset
     source_plate_barcodes.scan(/\d+/).map(&method(:find_from_machine_barcode))
   end
 
+  #--
+  # NOTE: I'm getting odd behaviour where '&method(:find_from_machine_barcode)' raises a SecurityError.  I haven't
+  # been able to track down why, and it only happens under 'rake cucumber', so somewhere something is doing something
+  # nasty.
+  #++
   def self.plates_from_scanned_plates_and_typed_plate_ids(source_plate_barcodes)
-    scanned_plates = source_plate_barcodes.scan(/\d+/).map(&method(:find_from_machine_barcode))
+    scanned_plates = source_plate_barcodes.scan(/\d+/).map { |v| find_from_machine_barcode(v) }
     typed_plates   = source_plate_barcodes.scan(/\d+/).map(&method(:find_by_barcode))
 
     (scanned_plates | typed_plates).compact

--- a/app/models/pulldown/requests.rb
+++ b/app/models/pulldown/requests.rb
@@ -5,15 +5,12 @@ module Pulldown::Requests
         const_set(:DEFAULT_LIBRARY_TYPE, 'Agilent Pulldown')
         const_set(:LIBRARY_TYPES, [ 'Agilent Pulldown' ])
 
-        has_metadata :as => Request do
-          include BaitLibrary::Associations
-          association(:bait_library, :name)
-
-          # Redefine the fragment size attributes as they are fixed
-          attribute(:fragment_size_required_from, :required => true, :in => [ '100' ], :default => '100')
-          attribute(:fragment_size_required_to,   :required => true, :in => [ '400' ], :default => '400')
-        end
-        include Request::LibraryManufacture
+        fragment_size_details(100, 400)
+      end
+      base::Metadata.class_eval do
+        include BaitLibrary::Associations
+        association(:bait_library, :name)
+        validates_presence_of :bait_library
       end
     end
   end
@@ -25,18 +22,40 @@ module Pulldown::Requests
     def on_started
       # Override the default behaviour to not do the transfer
     end
+
+    # Convenience helper for ensuring that the fragment size information is properly treated.
+    # The columns in the database are strings and we need them to be integers, hence we force
+    # that here.
+    def self.fragment_size_details(minimum, maximum)
+      class_eval do
+        has_metadata :as => Request do
+          # Redefine the fragment size attributes as they are fixed
+          attribute(:fragment_size_required_from, :required => true, :in => [ minimum ], :default => minimum, :integer => true)
+          attribute(:fragment_size_required_to,   :required => true, :in => [ maximum ], :default => maximum, :integer => true)
+        end
+        include Request::LibraryManufacture
+      end
+      const_get(:RequestOptionsValidator).class_eval do
+        validates_inclusion_of :fragment_size_required_from, :in => [ minimum ], :allow_blank => true
+        validates_inclusion_of :fragment_size_required_to,   :in => [ maximum ], :allow_blank => true
+      end
+      const_get(:Metadata).class_eval do
+        def fragment_size_required_from
+          self[:fragment_size_required_from].try(:to_i)
+        end
+
+        def fragment_size_required_to
+          self[:fragment_size_required_to].try(:to_i)
+        end
+      end
+    end
   end
 
   class WgsLibraryRequest < LibraryCreation
     DEFAULT_LIBRARY_TYPE = 'Standard'
     LIBRARY_TYPES        = [ DEFAULT_LIBRARY_TYPE ]
 
-    has_metadata :as => Request do
-      # Redefine the fragment size attributes as they are fixed
-      attribute(:fragment_size_required_from, :required => true, :in => [ '300' ], :default => '300')
-      attribute(:fragment_size_required_to,   :required => true, :in => [ '500' ], :default => '500')
-    end
-    include Request::LibraryManufacture
+    fragment_size_details(300, 500)
   end
 
   class ScLibraryRequest < LibraryCreation

--- a/app/models/submission_template.rb
+++ b/app/models/submission_template.rb
@@ -18,7 +18,8 @@ class SubmissionTemplate < ActiveRecord::Base
 
   # create a new submission of the good subclass and with pre-set attributes
   def new_submission(params={})
-    attributes = submission_attributes.deep_merge(params)
+    restructured_params = Marshal.load(Marshal.dump(params))
+    attributes = submission_attributes.deep_merge(restructured_params)
     infos      = SubmissionTemplate.unserialize(attributes.delete(:input_field_infos))
 
     submission_class.new(attributes).tap do |submission|
@@ -32,6 +33,7 @@ class SubmissionTemplate < ActiveRecord::Base
     return {} if self.submission_parameters.nil?
     submission_attributes = Marshal.load(Marshal.dump(self.submission_parameters))  # Deep clone
     submission_attributes[:request_types] = submission_attributes[:request_type_ids_list].flatten
+#    submission_attributes[:request_options_structured] = submission_attributes.delete(:request_options) if submission_attributes.key?(:request_options)
     submission_attributes
   end
   private :submission_attributes

--- a/db/seeds/0007_submission_templates.rb
+++ b/db/seeds/0007_submission_templates.rb
@@ -22,9 +22,9 @@ def create_pulldown_submission_templates
   ]
 
   request_types_to_defaults = {
-    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => '300', :fragment_size_required_to => '500' },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => '100', :fragment_size_required_to => '400' }
+    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
+    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
+    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
   }
 
   workflow   = Submission::Workflow.find_by_key('short_read_sequencing') or raise StandardError, 'Cannot find Next-gen sequencing workflow'

--- a/features/api/pulldown/bait_library_assignment.feature
+++ b/features/api/pulldown/bait_library_assignment.feature
@@ -23,12 +23,12 @@ Feature: Assigning bait libraries to a plate
       And the UUID for the plate "Testing bait libraries" is "00000000-1111-2222-3333-000000000001"
 
     Given "A1-H6" of the plate with UUID "00000000-1111-2222-3333-000000000001" have been submitted to "Pulldown SC - HiSeq Paired end sequencing" with the following request options:
-      | read_length                 | 100                 |
-      | bait_library_name           | Human all exon 50MB |
+      | read_length       | 100                 |
+      | bait_library_name | Human all exon 50MB |
 
     Given "A7-H12" of the plate with UUID "00000000-1111-2222-3333-000000000001" have been submitted to "Pulldown SC - HiSeq Paired end sequencing" with the following request options:
-      | read_length                 | 100            |
-      | bait_library_name           | Mouse all exon |
+      | read_length       | 100            |
+      | bait_library_name | Mouse all exon |
 
     Given a "SC hyb" plate called "Target for bait libraries" exists
       And the "Transfer columns 1-12" transfer template has been used between "Testing bait libraries" and "Target for bait libraries"

--- a/features/api/pulldown/submissions.feature
+++ b/features/api/pulldown/submissions.feature
@@ -33,7 +33,7 @@ Feature: Creating submissions for pulldown
           "asset_group_name": "Testing the pulldown submissions",
           "request_options": {
             "read_length": 100,
-            "bait_library_name": "Human all exon 50MB"
+            "bait_library": "Human all exon 50MB"
           }
         }
       }
@@ -167,3 +167,41 @@ Feature: Creating submissions for pulldown
       | fragment_size_required_from | 300            |
       | fragment_size_required_to   | 500            |
 
+
+  @create
+  Scenario Outline: Attempting to set the fragment sizes to anything other than the acceptable values is an error
+    Given the UUID for the submission template "Pulldown <pipeline> - HiSeq paired end sequencing" is "00000000-1111-2222-3333-444444444444"
+
+    When I POST the following JSON to the API path "/00000000-1111-2222-3333-444444444444/submissions":
+      """
+      {
+        "submission": {
+          "project": "22222222-3333-4444-5555-000000000001",
+          "study": "22222222-3333-4444-5555-000000000000",
+          "asset_group_name": "Testing the pulldown submissions",
+          "request_options": {
+            "read_length": 100,
+            "fragment_size_required": {
+              "from": 99,
+              "to": 999
+            }
+          }
+        }
+      }
+      """
+    Then the HTTP response should be "422 Unprocessable Entity"
+     And the JSON should be:
+      """
+      {
+        "content": {
+          "request_options.fragment_size_required.to": ["is not included in the list"],
+          "request_options.fragment_size_required.from": ["is not included in the list"]
+        }
+      }
+      """
+
+    Examples:
+      | pipeline |
+      | WGS      |
+      | SC       |
+      | ISC      |

--- a/features/plain/api/submissions.feature
+++ b/features/plain/api/submissions.feature
@@ -118,53 +118,14 @@ Feature: Interacting with submissions through the API
             "asset_uuids": [],
             "request_options":
             {
-              "read_length": "76",
+              "read_length": 76,
               "fragment_size_required": 
               {
-                "from": "100", 
-                "to": "200"
+                "from": 100, 
+                "to": 200
               },
              "library_type": "qPCR only"
             }
           }
         }
       """
-
-  Scenario: Retrieving the JSON for a submission with request options in old format
-    Given I have a submission created with the following details based on the template "Library creation - Paired end sequencing":
-      | study   | 22222222-3333-4444-5555-000000000000 |
-      | project | 22222222-3333-4444-5555-000000000001 |
-      | assets  | 33333333-4444-5555-6666-000000000001 |
-      | request_options  | read_length: 76, fragment_size_required_from: 100, fragment_size_required_to: 200, library_type: qPCR only |
-    And submission "11111111-2222-3333-4444-555555555555" has old format request options
-    When I GET the API path "/submissions/11111111-2222-3333-4444-555555555555"
-    Then ignoring "internal_id" the JSON should be:
-      """
-        { 
-          "submission":
-          {
-            "uuid": "11111111-2222-3333-4444-555555555555",
-            "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
-            "created_by": "abc123",
-            "template_name":"Library creation - Paired end sequencing",
-            "state": "building",
-            "study_name": "Testing submission creation",
-            "study_uuid": "22222222-3333-4444-5555-000000000000",
-            "project_name": "Testing submission creation", 
-            "project_uuid": "22222222-3333-4444-5555-000000000001",
-            "asset_uuids": [],
-            "request_options":
-            {
-              "read_length": "76",
-              "fragment_size_required": 
-              {
-                "from": "100",
-                "to": "200"
-              },
-             "library_type": "qPCR only"
-            }
-          }
-        }
-      """
-

--- a/features/step_definitions/genotyping_steps.rb
+++ b/features/step_definitions/genotyping_steps.rb
@@ -163,7 +163,7 @@ Given /^I have a Cherrypicking submission for asset group "([^"]*)"$/ do |asset_
     :project => project,
     :workflow => Submission::Workflow.find_by_key('microarray_genotyping'),
     :user => User.last,
-    :assets => asset_group.assets
+    :asset_group => asset_group
     ).built!
   And %Q{1 pending delayed jobs are processed}
 end

--- a/features/step_definitions/submission_steps.rb
+++ b/features/step_definitions/submission_steps.rb
@@ -143,17 +143,7 @@ Given /^the last submission wants (\d+) runs of the "([^\"]+)" requests$/ do |co
   submission.save!
 end
 
-
 Given /^the sample tubes are part of submission "([^"]*)"$/ do |submission_uuid|
   submission = Uuid.find_by_external_id(submission_uuid).resource or raise StandardError, "Couldnt find object for UUID"
   Asset.all.map{ |asset| submission.assets << asset } 
-end
-
-Given /^submission "([^"]*)" has old format request options$/ do |submission_uuid|
-  submission = Uuid.find_by_external_id(submission_uuid).resource or raise StandardError, "Couldnt find object for UUID"
-  submission.request_options["read_length"] = { 'value' =>  submission.request_options["read_length"] }
-  submission.request_options["library_type"] = { 'value' =>  submission.request_options["library_type"] }
-  submission.request_options["fragment_size_required_from"] = { 'value' =>  submission.request_options["fragment_size_required_from"] }
-  submission.request_options["fragment_size_required_to"] = { 'value' =>  submission.request_options["fragment_size_required_to"] }
-  submission.save(false)
 end


### PR DESCRIPTION
Submissions created through the API do not behave properly if the
request options are set.  They pass the submission level validation but
then fail at the request graph generation.  There are also problems
where the default options from the template do not get maintained and
are actually seen as different when they do appear.

This ensures that all of the numeric fields are treated as such, and
that API submissions get their options properly merged into the
defaults.
