### PR TITLE
18272943 prevent mx batches from being completed without tags

### DIFF
--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -161,6 +161,9 @@ class PipelinesController < ApplicationController
 
   def finish
     @batch.complete!(current_user)
+  rescue ActiveRecord::RecordInvalid => exception
+    flash[:error] = exception.record.errors.full_messages
+    redirect_to(url_for(:controller => 'batches', :action => 'show', :id => @batch.id))
   end
 
   def release

--- a/app/models/batch/pipeline_behaviour.rb
+++ b/app/models/batch/pipeline_behaviour.rb
@@ -17,6 +17,11 @@ module Batch::PipelineBehaviour
 
       # The batch requires positions on it's requests if the pipeline does
       delegate :requires_position?, :to => :pipeline
+
+      # Ensure that the batch is valid to be marked as completed
+      validate(:if => :completed?) do |record|
+        record.pipeline.validation_of_batch_for_completion(record)
+      end
     end
   end
 

--- a/app/models/multiplexed_library_creation_pipeline.rb
+++ b/app/models/multiplexed_library_creation_pipeline.rb
@@ -6,4 +6,12 @@ class MultiplexedLibraryCreationPipeline < LibraryCreationPipeline
   def inbox_partial
     INBOX_PARTIAL
   end
+
+  # For a batch to be valid for completion in this pipeline it must have had the tags assigned to the
+  # target assets of the requests.
+  def validation_of_batch_for_completion(batch)
+    batch.errors.add_to_base('This batch appears to have not been properly tagged') if batch.requests.any? do |r|
+      r.target_asset.aliquots.map(&:tag).compact.size != r.target_asset.aliquots.size
+    end
+  end
 end

--- a/app/models/pipeline/batch_validation.rb
+++ b/app/models/pipeline/batch_validation.rb
@@ -16,4 +16,10 @@ module Pipeline::BatchValidation
     yield('has incorrect type')          if requests.map(&:request_type_id).uniq != [ request_type_id ]
   end
   private :validation_of_requests
+
+  # Overridden by pipeline implementations to ensure that the batch is valid for completion.  By
+  # default this does nothing.
+  def validation_of_batch_for_completion(batch)
+
+  end
 end

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -1,6 +1,7 @@
 class Tube < Aliquot::Receptacle
   include LocationAssociation::Locatable
   include Barcode::Barcodeable
+  include Tag::Associations
 
   named_scope :include_scanned_into_lab_event, :include => :scanned_into_lab_event
 

--- a/db/seeds/0001_workflows.rb
+++ b/db/seeds/0001_workflows.rb
@@ -107,7 +107,7 @@ end.tap do |pipeline|
   create_request_information_types(pipeline, 'fragment_size_required_from', 'fragment_size_required_to', 'library_type')
 end
 
-LibraryCreationPipeline.create!(:name => 'MX Library Preparation [NEW]') do |pipeline|
+MultiplexedLibraryCreationPipeline.create!(:name => 'MX Library Preparation [NEW]') do |pipeline|
   pipeline.asset_type          = 'LibraryTube'
   pipeline.sorter              = 0
   pipeline.automated           = false

--- a/features/batch/4759010_bug_on_reset_batches.feature
+++ b/features/batch/4759010_bug_on_reset_batches.feature
@@ -1,4 +1,4 @@
-@batch
+@batch @javascript
 Feature: Resetting a batch and creating an "identical" batch
   Background:
     Given sequencescape is setup for 4759010
@@ -9,9 +9,10 @@ Feature: Resetting a batch and creating an "identical" batch
     Given a batch in "MX Library Preparation [NEW]" has been setup for feature 4759010
     When I go to the edit page for the last batch
     And I press "Reset"
+    And I accept the action
     Then I should be on the "MX Library Preparation [NEW]" pipeline page
 
-    When I select all requests
+    When I check "Select Request Group 0"
     And I select "Create Batch" from "Action to perform"
     And I press "Submit"
 

--- a/features/step_definitions/web_form_steps.rb
+++ b/features/step_definitions/web_form_steps.rb
@@ -120,3 +120,7 @@ Then /^I expect an exception to be raised when I press "([^"]*)"(?: within "([^"
     # Good, that was expected
   end
 end
+
+When /^I accept the action$/ do
+  page.driver.browser.switch_to.alert.accept
+end

--- a/test/unit/batch_test.rb
+++ b/test/unit/batch_test.rb
@@ -916,7 +916,17 @@ class BatchTest < ActiveSupport::TestCase
         end
       end
     end
-    
-    
+  end
+
+  context "completing a batch" do
+    setup do
+      @batch, @user = Factory(:batch), Factory(:user)
+      @batch.start!(@user)
+    end
+
+    should "check that with the pipeline that the batch is valid" do
+      @batch.pipeline.expects(:validation_of_batch_for_completion).with(@batch)
+      @batch.complete!(@user)
+    end
   end
 end

--- a/test/unit/multiplexed_library_creation_pipeline_test.rb
+++ b/test/unit/multiplexed_library_creation_pipeline_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class MultiplexedLibraryCreationPipelineTest < ActiveSupport::TestCase
+  def setup
+    @pipeline = Pipeline.find_by_name('MX Library Preparation [NEW]') or raise StandardError, "Cannot find the MX library creation pipeline"
+    @user     = Factory(:user)
+  end
+
+  context 'batch interaction' do
+    setup do
+      @batch = Factory(:batch, :pipeline => @pipeline)
+      @batch.requests << (1..5).map { |_| Factory(:request_suitable_for_starting, :request_type => @batch.pipeline.request_type) }
+    end
+
+    context 'for completion' do
+      setup do
+        @batch.start!(@user)
+      end
+
+      should 'add errors if there are untagged target asset aliquots' do
+        @batch.requests.map(&:target_asset).map(&:untag!)
+
+        assert_raise(ActiveRecord::RecordInvalid) do
+          @batch.complete!(@user)
+        end
+
+        assert(!@batch.errors.empty?, "There are no errors on the batch")
+      end
+
+      should 'not error if all of the target asset aliquots are tagged' do
+        @batch.requests.each_with_index { |r,i| Factory(:tag, :map_id => i).tag!(r.target_asset) }
+        @batch.complete!(@user)
+
+        assert(@batch.errors.empty?, "There are errors on the batch")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Batches that have not been tagged should not be allowed to be completed
in the MX library creation pipeline.  So this code adds a final
validation when the batch is in that state to check.

In the process I discovered that the MX library creation pipeline in
the seeds file was of the wrong type, which lead to a bug in the batch
reset feature!
