### PR TITLE
15313119 fix priority flag handling

### DIFF
--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -214,21 +214,13 @@ class PipelinesController < ApplicationController
 
   # to modify when next_request will be ready
   def update_priority
-    request = Request.find(params[:request_id])
-    pipeline = Pipeline.find(params[:pipeline_id])
+    request  = Request.find(params[:request_id])
     ActiveRecord::Base.transaction do 
-      request.update_priority(pipeline)
+      request.update_priority
       render :text => '', :layout => false 
     end
   rescue ActiveRecord::RecordInvalid => exception
     render :text => '', :layout => false, :status => :unprocessable_entity
-  end
-
-  # to modify when next_request will be ready
-  def update_priority_mx
-    @request  = Request.find(params[:request_id])
-    @request.update_priority_mx
-    render :layout => false
   end
 
   private

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -235,26 +235,10 @@ class Request < ActiveRecord::Base
     self.batch_request.nil? && (pending? || blocked?)
   end
 
-  def update_priority(pipeline)
-    priority = ( self.priority + 1 ) % 2
-    @asset = self.asset
-    @asset.requests.each do |request|
-      request.priority = priority
-      request.save!
-      next_request = request.next_requests(pipeline)
-      next_request.each do |request_next|
-        request_next.priority = priority
-        request_next.save!
-      end
-    end
-  end
-
-  def update_priority_mx
-    requests = Request.find_all_by_submission_id(self.submission_id)
-    priority  = ( self.priority + 1 ) % 2
-    requests.each do |request|
-      request.priority = priority
-      request.save!
+  def update_priority
+    priority = (self.priority + 1) % 2
+    submission.requests.each do |request|
+      request.update_attributes!(:priority => priority)
     end
   end
   

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     <script type="text/javascript">
       jQuery.noConflict();
     </script>
-    <%= javascript_include_tag 'tablesorter/jquery.tablesorter.min.js' %>
+    <%= javascript_include_tag 'tablesorter/jquery.tablesorter.js' %>
     <%= javascript_include_tag 'tablesorter/jquery.metadata.js' %>
     <link rel="shortcut icon" href="/images/favicon.ico" type="image/vnd.microsoft.icon" />
     <link rel="icon" href="/images/favicon.ico" type="image/vnd.microsoft.icon" />

--- a/app/views/pipelines/_grouped_requests.html.erb
+++ b/app/views/pipelines/_grouped_requests.html.erb
@@ -1,20 +1,10 @@
-<table width="100%" bgcolor="#edf5ff" cellpadding="2" cellspacing="0" class="sortable">
+<table width="100%" bgcolor="#edf5ff" cellpadding="2" cellspacing="0" class="sortable" id="pipeline_inbox">
   <thead>
     <tr>
       <th class='label' style='text-align: left' width='2%'>&nbsp;</th>
       <th class='label' style='text-align: left' width='2%'>&nbsp;</th>
       <% if current_user.is_lab_manager? %>
-          <th id="priority_flag" class='label' style='text-align: center' width='5%'><%= link_to image_tag("icon_0_flag.png", :size=>"16x16"), "javascript:void(0);" %></th>
-          <th class='label' style="display:none">
-           <input type="hidden" id="upFlag" value = 0>
-           <input type="hidden" id = "setFlagPriority" value="0">
-           <%= observe_field 'upFlag',
-            :url => { :action => :update_priority_mx, :controller => :pipelines },
-            :frequency => 0.5,
-            :update => "setFlagPriority",
-            :with => "'request_id='+ escape($('setFlagPriority').value)+'&pipeline_id="+@pipeline.id.to_s+"'"
-           -%>
-        </th>
+        <th id="priority_flag" class='label' style='text-align: center' width='5%'><%= link_to image_tag("icon_0_flag.png", :size=>"16x16"), "javascript:void(0);" %></th>
       <% end %>
       <th class='label' width='5%'><%= link_to "Item ID", "javascript:void(0);" %></th>
       <th style="display:none" class='label' width='5%'><%= link_to "", "javascript:void(0);" %></th>
@@ -47,8 +37,9 @@
 		      </td>
           <td class="request" width='2%'><a href="javascript:void(0)" onclick="showElement(<%=  request.submission_id %>,<%= requests.size %>); return false;"><%= image_tag "information.png", :size =>"13x13" %></a></td>
           <% if current_user.is_lab_manager? %>
-             <td class='request' style="display:none" width='5%' id="flag_value_<%= request.id.to_s %>"><%= request.priority %></td>
-             <td class='request' style='text-align: center' width='5%'><a href="javascript:void(0)" onclick="changeFlagMxLibrary(<%= request.id %>,<%= request.submission_id %>, <%= requests.size %>); return false;"><%= image_tag "icon_"+request.priority.to_s+"_flag.png", :size =>"16x16", :id => "flag_"+ request.submission_id.to_s %></a></td>
+            <td class='request' style='text-align: center' width='5%'>
+              <%= image_tag "icon_#{request.priority}_flag.png", 'alt' => request.priority, :size => '16x16', :class => 'flag_image', "data-priority" => request.priority, 'data-request-id' => request.id, 'data-submission-id' => request.submission_id %>
+            </td>
           <% end %>
           <td class="request" width='5%'><%= link_to request.submission_id,study_workflow_submission_path(request.study, current_user.workflow, request.submission) %></td>
           <td class="request" width='5%'>&nbsp;</td>
@@ -89,7 +80,9 @@
 		  </td>
           <td style="display:none" class="request" width='5%'><%= link_to request.submission_id,study_workflow_submission_path(request.study, current_user.workflow, request.submission) %></td>
           <% if current_user.is_lab_manager? %>
-           <td class='request' style='text-align: center' width='5%'><%= image_tag "icon_"+request.priority.to_s+"_flag.png", :size =>"16x16", :id => "flag_"+request.submission_id.to_s+"_"+progr.to_s %></a></td>
+            <td class='request' style='text-align: center' width='5%'>
+              <%= image_tag "icon_#{request.priority}_flag.png", 'alt' => request.priority, :size => '16x16', :class => 'related_flag_image', 'data-submission-id' => request.submission_id %>
+            </td>
           <% end %>
           <td class="request" width='5%'><%= link_to request.submission_id,study_workflow_submission_path(request.study, current_user.workflow, request.submission) %></td>
           <td class='request' width='5%'><%= link_to request.id, request_path(request) %></td>

--- a/app/views/pipelines/_requests.html.erb
+++ b/app/views/pipelines/_requests.html.erb
@@ -9,7 +9,6 @@
         <th class='{sorter: false}'>Available requests</th>
         <% if current_user.is_lab_manager? %>
           <th id="priority_flag"  style='text-align: center'><%= link_to image_tag("icon_0_flag.png", :size=>"16x16"), "javascript:void(0);" %></th>
-          <th style="display:none">&nbsp;</th>
           <th><%= link_to "Previous requests", "javascript:void(0);" %></th>
         <% end %>
         <th><%= link_to "Submission ID", "javascript:void(0);" %></th>
@@ -40,15 +39,12 @@
             <%= check_box :request, request.id, :value => request.id, :class => 'grouped_checkbox request_checkbox', :'data-count' => 1 %>
           </td>
           <% if current_user.is_lab_manager? %>
-            <td  style="display:none" width='5%' id="flag_value_<%= request.id.to_s %>"><%= request.priority %></td>
             <td  style='text-align: center' width='5%'>
-                <a href="javascript:void(0)" >
-                <%= image_tag "icon_"+request.priority.to_s+"_flag.png", :size =>"16x16", :class =>"flag_image", :data_request_id => request.id.to_s, :data_priority_column => "flag_value_#{request.id.to_s}" %></a>
+              <%= image_tag "icon_#{request.priority}_flag.png", 'alt' => request.priority, :size => '16x16', :class => 'flag_image', "data-priority" => request.priority, 'data-request-id' => request.id %>
             </td>
             <td  width='10%'>
               <%= render :partial => "previous_failed_requests", :locals => { :request => request } %>
-             </td>
-             
+            </td>
           <% end %>
           <td class="request" width='5%'><%= link_to request.submission_id,study_workflow_submission_path(request.study, current_user.workflow, request.submission) %></td>
           <td  width='5%'><%= link_to request.id, request_path(request) %></td>
@@ -88,81 +84,42 @@
   </table>
 <script type="text/javascript" id="js">
 (function($) {
-        
-$.tablesorter.addWidget({
+  $.tablesorter.addWidget({
     id: 'jFilter',
-    format: function(element){
-        var __jFilter = this;
+    format: function(element) {
+      var __jFilter = this;
 
-        $('#filter-for-'+$(element).attr('id')).bind('keyup',function(ev){
-            __jFilter.jFilterRun(element,$('#filter-for-'+$(element).attr('id')).val());
-        });
+      $('#filter-for-'+$(element).attr('id')).bind('keyup',function(ev){
+        __jFilter.jFilterRun(element,$('#filter-for-'+$(element).attr('id')).val());
+      });
     },
     jFilterRun: function(table, s){
-        $('tbody tr:hidden', table).show();
-        $('tbody tr',$(table)).each(function(n,r){
-            var content = false;
-            $('td',$(r)).each(function(i,f){
-                if (($(f).html() || $(f).text()).toLowerCase().indexOf(s.toLowerCase()) >= 0)
-                  if (f.title=='read_length')
-                     content = true;
-            });
-            if (content) $(r).show(); else $(r).hide();
+      $('tbody tr:hidden', table).show();
+      $('tbody tr',$(table)).each(function(n,r){
+        var content = false;
+        $('td',$(r)).each(function(i,f){
+          if (($(f).html() || $(f).text()).toLowerCase().indexOf(s.toLowerCase()) >= 0)
+            if (f.title=='read_length')
+              content = true;
         });
-        }
-});   
+        if (content) $(r).show(); else $(r).hide();
+      });
+    }
+  });
 
   $(document).ready(function() {
     $("#pipeline_inbox").tablesorter({ 
-        sortList: [[1,1], [2,0]],
-        widgets: ['zebra','jFilter'] 
+      sortList: [[1,1], [2,0]],
+      widgets: ['zebra', 'jFilter'],
+
+      textExtraction: function(node) {
+        // If the node has an IMG element underneath it then its 'alt' attribute is used, otherwise it's the innerHTML of the node.
+        var imgNode = $('img', node);
+        return (imgNode.size() > 0 ? imgNode.attr('alt') : $(node).text());
+      },
     });
-    
-
-
-   $("#priority_flag").click(function() {
-        $("#pipeline_inbox").trigger("reSort");
-        $("#pipeline_inbox").trigger("appendCache");
-        return false; 
-   });
-   
-
-   $(".flag_image").bind("click", function() { 
-       img = $(this);
-       flag_value = $("#"+img.attr("data_priority_column"));
-       
-       if (img.attr("src").indexOf("icon_0_flag.png")>0) { 
-         image_on_success ="/images/icon_1_flag.png";
-         flag_value_on_success = '1';
-       } else { 
-         image_on_success = "/images/icon_0_flag.png";
-         flag_value_on_success = '0';
-       }
-
-       answer = true;
-       if (img.attr("src").indexOf("icon_1_flag.png")>0)
-         answer = confirm ("Are you sure you want to set this to normal priority ?");
-       
-       if (answer) {
-         jQuery.ajax( 
-               { 
-                 url: '/pipelines/update_priority',
-                 type: 'POST',
-                 data: 'request_id='+img.attr("data_request_id")+'&pipeline_id='+<%= @pipeline.id%>,
-                 success: function(){
-                            img.attr("src", image_on_success);
-                            flag_value.text(flag_value_on_success);
-                          },
-                 error  : function(){
-                            alert("The request can't be saved properly. Flag not updated.");
-                         }
-                }
-          );
-      } 
-   });
-   
-
-  }); 
+  });
 })(jQuery);
 </script>
 
+<%= javascript_include_tag 'pipeline.js' %>

--- a/public/stylesheets/screen.css
+++ b/public/stylesheets/screen.css
@@ -1367,3 +1367,7 @@ table.checktext_field td {
 #pipeline_inbox {
   background-color: white;
 }
+
+.flag_image {
+  cursor: pointer;
+}


### PR DESCRIPTION
This fixes the issue where the priority flags for MX library creation
requests wasn't working.  It refactors the code so that it goes through
one action and uses one set of Javascript.

It also tidies up the priority ordering of the table so that an
additional column isn't needed, although this appears to have required
the uncompressed version of the tablesorter javascript.
