### PR TITLE
20479903 duplicate lanes with multiple sequencing requests

### DIFF
--- a/db/migrate/20111102140039_duplicate_lanes_with_multiple_sequencing_requests.rb
+++ b/db/migrate/20111102140039_duplicate_lanes_with_multiple_sequencing_requests.rb
@@ -1,0 +1,39 @@
+class DuplicateLanesWithMultipleSequencingRequests < ActiveRecord::Migration
+  def self.up
+    ActiveRecord::Base.transaction do
+      Lane.find_each(:joins => :requests_as_target, :group => 'id', :having => 'COUNT(*) > 1') do |lane|
+        original_request, *requests = lane.requests_as_target.all
+
+        say_with_time("Duplicating for lane #{lane.id}, original request #{original_request.id}, duplicates #{requests.map(&:id).inspect}") do
+          requests.each do |request|
+            # Duplicate the lane
+            duplicated_lane = request.target_asset.clone.tap do |duplicated_lane|
+              duplicated_lane.aliquots = request.target_asset.aliquots.map(&:clone)
+              duplicated_lane.save!
+
+              duplicated_lane.comments.create!(
+                :title       => 'De-duplicating lane that has multiple sequencing requests',
+                :description => "This lane is a clone of #{original_request.target_asset.id}"
+              )
+              original_request.comments.create!(
+                :title       => 'De-duplicating lane that has multiple sequencing requests',
+                :description => "The lane #{duplicated_lane.id} is a clone of this one"
+              )
+            end
+
+            # Update the request so that we can track the change
+            request.update_attributes!(:target_asset => duplicated_lane)
+            request.comments.create!(
+              :title       => 'De-duplicating lane that has multiple sequencing requests',
+              :description => "The target lane #{request.target_asset.id} is a clone of #{original_request.target_asset.id}"
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def self.down
+    # Nothing to do here
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111026151521) do
+ActiveRecord::Schema.define(:version => 20111102140039) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
[fixes 20479903] De-duplicate lanes that have multiple sequencing requests

Lanes should not have multiple sequencing requests, which has occurred
because we duplicated the requests that were in multiple batches.  This
ensures that each lane that has multiple requests leading to it get
duplicated.
