### PR TITLE
[fixes 20472069] Workflow stage 'cancel' should return to batch

### DIFF
--- a/app/views/workflows/_cherrypick_batches.html.erb
+++ b/app/views/workflows/_cherrypick_batches.html.erb
@@ -19,25 +19,21 @@
     <% @plate_rows.times { |row_index| plate_ids << "plate[#{index}][#{row_index}]" } %>
   <% end -%>
 
-  <%= render :partial => "scratch_pad", :locals => {:plate_cols =>@plate_cols, :plate_rows => @plate_rows,:plate_class => plate_class} %>
+  <%= render :partial => "scratch_pad", :locals => {:plate_cols =>@plate_cols, :plate_rows => @plate_rows,:plate_class => plate_class, :plate_ids => plate_ids } %>
 
-  <% (@plate_rows/2).times { |row_index| plate_ids << "scratch_[#{row_index}]" } %>
-  <% plate_ids << "control_[0]" -%>
-  <% plate_ids << "control_[1]" -%>
-
-  <% if @plate.nil? -%>
-    <script type="text/javascript">
-      window.onload = (function() {
-          /* 
-           * Sortable only supports direct child elements, which have to have an 'id' attribute.  Hence this Sortable's of each
-           * row in the the plate tables, and allows dragging between them and the scratch pad.
-           */
-          <% plate_ids.each do |plate| %>
-            Sortable.create('<%= plate %>', { containment: ['<%= plate_ids.join("','") %>'], tag: 'td', overlap: 'horizontal' });
-          <% end%>
-          })();
-    </script>
-  <% end -%>
+<% if @plate.nil? -%>
+  <script type="text/javascript">
+    (function($, undefined) {
+      /* 
+       * Sortable only supports direct child elements, which have to have an 'id' attribute.  Hence this Sortable's of each
+       * row in the the plate tables, and allows dragging between them and the scratch pad.
+       */
+      <% plate_ids.each do |plate| %>
+      Sortable.create('<%= plate %>', { containment: ['<%= plate_ids.join("','") %>'], tag: 'td', overlap: 'horizontal' });
+      <% end%>
+    })($);
+  </script>
+<% end -%>
 
   <%= hidden_field_tag 'minimum_volume', @minimum_volume    %>
   <%= hidden_field_tag 'maximum_volume', @maximum_volume    %>
@@ -47,53 +43,36 @@
   <%= hidden_field_tag 'volume_required', @volume_required %>
   <%= hidden_field_tag 'concentration_required', @concentration_required %>
   <%= hidden_field_tag 'micro_litre_volume_required', @micro_litre_volume_required %>
-  <input type='button' value="Submit" id='stage_button' onclick='verifyplate(<%= @plate_cols %>,<%= @plate_rows %>,<%= @plates.size %>)' />
-  <span id='stage_loading' style='display: none;'><%= image_tag 'ajax-loader.gif', :size => "10x10", :alt => 'Saving' %> Saving</span>
-  <span id="stage_links"> or <%= link_to "cancel", pipeline_path(@batch.pipeline) %></span>
+
+  <%= render(:partial => 'next_stage_submit', :locals => { :check_selection => true }) %>
 <% end %>
 
 <script type="text/javascript">
+  (function($, undefined) {
+    return $('#stage_button').click(function() {
+      return verifyplate(<%= @plate_cols %>, <%= @plate_rows %>, <%= @plates.size %>);
+    });
+  })(jQuery);
+
+  // WARNING: '$' is using prototype *not* jQuery, and it's as ugly as hell!
   function verifyplate(num_cols,num_rows,num_plates) {
-    var r=0;
-    var p=0;
-    var c=0;
-    var returnvalues ="";
-    for(p =0; p< num_plates; p++)
-    {
-      for(r = 0 ; r< num_rows; r++)
-      {
+    var hiddenFields = '';
+    for(var p =0; p < num_plates; p++) {
+      for(var r = 0 ; r < num_rows; r++) {
         var col_length = $('plate['+p+']['+r+']').children.length;
-        if((col_length-1) > num_cols)
-        {
+        if((col_length-1) > num_cols) {
           alert('All rows must have '+num_cols+' wells ');
-          return;
+          return false;
         }
 
-        for(c =1; c<=num_cols; c++)
-        {
-          var plate_values =document.createElement("input");
-          plate_values.setAttribute("type", "hidden");
-          plate_values.setAttribute("name", 'plate['+p+']['+r+']['+(c-1)+']');
-          if(c >= col_length )
-          {
-            plate_values.setAttribute("value", "");
-          }
-          else
-          {
-            plate_values.setAttribute("value", $('plate['+p+']['+r+']').children[c].id);
-          }
-          $('stage_form').appendChild(plate_values)
+        for(var c = 1; c <= num_cols; c++) {
+          var value = (c >= col_length) ? '' : $('plate['+p+']['+r+']').children[c].id;
+          hiddenFields += '<input type="hidden" name="plate['+p+']['+r+']['+(c-1)+']" value="'+value+'"/>';
         }
       }
     }
 
-    if (samples_are_selected() == true) {
-      $('stage_links').style.display = 'none';
-      $('stage_loading').style.display = 'inline';
-      document.getElementById('stage_form').submit();
-
-    } else {
-      alert('Please select one or more items.')
-    }
+    jQuery('#stage_form').append(hiddenFields);
+    return true;
   }
 </script>

--- a/app/views/workflows/_duplicate_samples_check_batches.html.erb
+++ b/app/views/workflows/_duplicate_samples_check_batches.html.erb
@@ -55,7 +55,5 @@
 		</table>
 	<% end -%>
 
-  <%= form.submit 'Next step' %>
-  <span id='stage_loading' style='display: none;'><%= image_tag 'ajax-loader.gif', :size => "10x10", :alt => 'Saving' %> Saving</span>
-  <span id="stage_links"> or <%= link_to "cancel", pipeline_path( @batch.pipeline) %>
+  <%= render(:partial => 'next_stage_submit') %>
 <% end %>

--- a/app/views/workflows/_next_stage_submit.html.erb
+++ b/app/views/workflows/_next_stage_submit.html.erb
@@ -1,4 +1,25 @@
 <div class="next_step_task">
-<%= submit_tag 'Next step' %>
-<span id="stage_links"> or <%= link_to "cancel", pipeline_path( @batch.pipeline) %></span>
+  <%= submit_tag('Next step', :id => 'stage_button') %>
+  <span id="stage_loading" style="display: none;"><%= image_tag "ajax-loader.gif", :size => "10x10", :alt => "Saving" %> Saving</span>
+  <span id="stage_links"> or <%= link_to "cancel", batch_path(@batch) %></span>
 </div>
+
+<% if (check_selection ||= false) %>
+<script type="text/javascript">
+  (function($, undefined) {
+    $('#stage_button').click(function() {
+      var checkboxes = $('.sample_check:checkbox');
+      if (checkboxes.length == 0) { return true; }
+      if ($('.sample_check:checked').length == 0) {
+        alert('Please select one or more items.');
+        return false;
+      }
+
+      $('#stage_button').disable();
+      $('#stage_links').hide();
+      $('#stage_loading').show();
+      return true;
+    });
+  })(jQuery);
+</script>
+<% end %>

--- a/app/views/workflows/_scratch_pad.html.erb
+++ b/app/views/workflows/_scratch_pad.html.erb
@@ -3,18 +3,16 @@
 <table id="scratch_pad" class="plate" width="100%">
 	<% (plate_rows/2).times do |row| %>
 		<tr id="<%= "scratch_[#{row}" %>]">
-			<% (plate_cols+1).times do |col| %>
-					<td id="" class="empty">Empty</td>
-			<% end %>
+			<% (plate_cols+1).times do |col| %><td id="" class="empty">Empty</td><% end %>
 		</tr>
+    <% plate_ids << "scratch_[#{row}]" %>
 	<% end %>
 </table>
 
-<% control_plate = ControlPlate.first %>
-<% if control_plate%>
-<h3>Controls</h3>
+<% if (control_plate = ControlPlate.first).present? %>
+  <h3>Controls</h3>
   <%= render :partial => 'control_table', :locals => {:table_name => "Illumina", :wells => control_plate.illumina_wells, :control_plate => control_plate,  :plate_class => plate_class, :row_number => 0} %>
-
   <%= render :partial => 'control_table', :locals => {:table_name => "Affy", :wells => control_plate.affy_wells, :control_plate => control_plate,  :plate_class => plate_class, :row_number => 1} %>
+  <% plate_ids << 'control_[0]' << 'control_[1]' %>
 <% end %>
 

--- a/app/views/workflows/_set_characterisation_descriptors.html.erb
+++ b/app/views/workflows/_set_characterisation_descriptors.html.erb
@@ -54,13 +54,5 @@
   <%= hidden_field_tag "workflow_id", @workflow.id %>
   <%= hidden_field_tag "batch_id", @batch.id %>
 
-  <div>
-    <input type="submit" value="Next step" id="stage_button" onclick="submit_stage();" />
-    <span id="stage_loading" style="display: none;"><%= image_tag "ajax-loader.gif", :size => "10x10", :alt => "Saving" %> Saving</span>
-    <span id="stage_links"> or <%= link_to "cancel", workflows_url %>
-  </div>
+  <%= render(:partial => 'next_stage_submit', :locals => { :check_selection => true }) %>
 <% end # End of form_for %>
-
-
-
-

--- a/app/views/workflows/stage.html.erb
+++ b/app/views/workflows/stage.html.erb
@@ -27,35 +27,26 @@
 <% add :back_menu, "Back to pipeline" => pipeline_path(@batch.pipeline) %>
 
 <h1>BATCH <%= @batch.id %>: <%= @task.name %> <% if @batch.failed? %><span style="color: red">(failed)</span><% end %></h1>
-  <%unless @task.partial.blank? %>
+<% if not @task.partial.blank? %>
   <%= render :partial => @task.partial, :locals => { :requests => @batch.requests } %>
-  <% else %>
-    <% unless @batch.processing_in_manual_qc? %>
-      <% form_for :workflow, :url => { :action => "stage", :id => @stage }, :html => { :id => "stage_form"} do |form| %>
-        <%= render :partial => "shared/batch", :locals => { :requests => @batch.ordered_requests, :edit => false, :stage => true } %>
-        <br />
-        <h1>TASK DETAILS</h1>
-          <div class="content">
-            <div class="info">
-              Required fields are marked with a <%= required_marker %>
-            </div>
-            <div id="sample">
-              <%= render :partial => "descriptors" %>
-            </div>
-            <% unless @task.families.empty? -%>
-              <%= render :partial => "assets" %>
-            <% end %>
-          </div>
+<% elsif not @batch.processing_in_manual_qc? %>
+  <% form_for :workflow, :url => { :action => "stage", :id => @stage }, :html => { :id => "stage_form"} do |form| %>
+    <%= render :partial => "shared/batch", :locals => { :requests => @batch.ordered_requests, :edit => false, :stage => true } %>
 
-        <%= hidden_field_tag "next_stage", "true" %>
-        <%= hidden_field_tag "workflow_id", @workflow.id %>
-        <%= hidden_field_tag "batch_id", @batch.id %>
+    <br />
+    <h1>TASK DETAILS</h1>
+    <div class="content">
+      <div class="info">Required fields are marked with a <%= required_marker %></div>
+      <div id="sample"><%= render :partial => "descriptors" %></div>
+      <% unless @task.families.empty? -%><%= render :partial => "assets" %><% end %>
+    </div>
 
-        <input type="submit" value="Next step" id="stage_button" onclick="submit_stage();" />
-        <span id="stage_loading" style="display: none;"><%= image_tag "ajax-loader.gif", :size => "10x10", :alt => "Saving" %> Saving</span>
-        <span id="stage_links"> or <%= link_to "cancel", workflows_url %>
-      <% end %>
-    <% else %>
-      <%= render :partial => "manual_qc_batches", :locals => { :requests => @batch.ordered_requests } %>
-    <% end %>
+    <%= hidden_field_tag "next_stage", "true" %>
+    <%= hidden_field_tag "workflow_id", @workflow.id %>
+    <%= hidden_field_tag "batch_id", @batch.id %>
+
+    <%= render(:partial => 'next_stage_submit', :locals => { :check_selection => true }) %>
+  <% end %>
+<% else %>
+  <%= render :partial => "manual_qc_batches", :locals => { :requests => @batch.ordered_requests } %>
 <% end %>

--- a/features/10808245_cherrypick_stock.feature
+++ b/features/10808245_cherrypick_stock.feature
@@ -177,7 +177,7 @@ Feature: Pick by micro litre (stock transfer) using the Tecan robot
         | Volume  |  <volume>  |
       
      And I press "Next step"
-   	 And I press "Submit"
+   	 And I press "Next step"
    	 And I select "Infinium 670k" from "Plate Purpose"
    	 And I press "Next step"
    	 And I select "Genotyping freezer" from "Location"

--- a/features/batch/6679401_batch_request_recycling_broken.feature
+++ b/features/batch/6679401_batch_request_recycling_broken.feature
@@ -38,7 +38,7 @@ Feature: Recycling requests in the Cherrypicking pipeline
     And I press "Next step"
 
     When I drag <number to remove> wells to the scratch pad
-    When I press "Submit"
+    When I press "Next step"
 
     # The requests in the Cherrypick inbox are grouped by their parent asset, the plate
     When I am on the "Cherrypick" pipeline page

--- a/features/pulldown/javascript.feature
+++ b/features/pulldown/javascript.feature
@@ -43,7 +43,7 @@ Feature: Print barcodes for the cherrypicking for pulldown and pulldown multiple
       | Maximum Volume    | 50   |
       | Quantity to pick  | 1000 |
     And I press "Next step"
-		When I press "Submit"
+		When I press "Next step"
     Given the last batch has a barcode of "550000555760"
     Then the downloaded tecan file for batch "550000555760" and plate "1220099999705" is
     """

--- a/features/slf/11439509_nanograms_capped_at_13.feature
+++ b/features/slf/11439509_nanograms_capped_at_13.feature
@@ -45,7 +45,7 @@ Feature: Picking more than 13 minimum volume should render in tecan file
       | Maximum Volume    | 150   |
       | Quantity to pick  | 10000 |
     And I press "Next step"
-		When I press "Submit"
+		When I press "Next step"
 		And I press "Next step"
 		And I press "Next step"
     

--- a/features/slf/6628187_tests_for_fix_tecan_volumes.feature
+++ b/features/slf/6628187_tests_for_fix_tecan_volumes.feature
@@ -29,7 +29,7 @@ Feature: The Tecan file has the wrong buffer volumes, defaulting to 13 total vol
   Scenario: volume of 65 is required
     When I fill in "Volume Required" with "65"
     When I press "Next step"
-  	When I press "Submit"
+  	When I press "Next step"
   	When I select "Infinium 670k" from "Plate Purpose"
   	And I press "Next step"
   	When I select "Genotyping freezer" from "Location"

--- a/features/slf/complete_slf_pipeline.feature
+++ b/features/slf/complete_slf_pipeline.feature
@@ -203,7 +203,7 @@ Feature: I wish to create samples and push them all the way through QC in SLF
 		And I fill in "Volume Required" with "13"
 		And I fill in "Concentration Required" with "50"
 		When I press "Next step"
-		When I press "Submit"
+		When I press "Next step"
 
 		When I select "Infinium 670k" from "Plate Purpose"
 		And I press "Next step"

--- a/features/step_definitions/genotyping_steps.rb
+++ b/features/step_definitions/genotyping_steps.rb
@@ -81,7 +81,7 @@ When /^I complete the cherrypicking batch with "([^"]*)" plate purpose but dont 
   When %Q{I follow "Start batch"}
   When %Q{I select "testtemplate" from "Plate Template"}
   When %Q{I press "Next step"}
-  When %Q{I press "Submit"}
+  When %Q{I press "Next step"}
   When %Q{I select "#{plate_purpose_name}" from "Plate Purpose"}
   And %Q{I press "Next step"}
   When %Q{I select "Genotyping freezer" from "Location"}

--- a/features/step_definitions/robot_verification_steps.rb
+++ b/features/step_definitions/robot_verification_steps.rb
@@ -13,7 +13,7 @@ Given /^I have a released cherrypicking batch with (\d+) samples$/ do |number_of
 	And %Q{I fill in "Volume Required" with "13"}
 	And %Q{I fill in "Concentration Required" with "50"}
 	When %Q{I press "Next step"}
-	When %Q{I press "Submit"}
+	When %Q{I press "Next step"}
 	When %Q{I select "Infinium 670k" from "Plate Purpose"}
 	And %Q{I press "Next step"}
 	When %Q{I select "Genotyping freezer" from "Location"}
@@ -54,7 +54,7 @@ Given /^I have a released cherrypicking batch with 3 plates$/ do
 	And %Q{I fill in "Volume Required" with "13"}
 	And %Q{I fill in "Concentration Required" with "50"}
 	When %Q{I press "Next step"}
-	When %Q{I press "Submit"}
+	When %Q{I press "Next step"}
 	When %Q{I select "Infinium 670k" from "Plate Purpose"}
 	And %Q{I press "Next step"}
 	When %Q{I select "Genotyping freezer" from "Location"}

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -58,33 +58,6 @@ function deselect_all(){
   });
 }
 
-function samples_are_selected() {
-  var checkboxes = $$('input[type="checkbox"].sample_check');
-  var selected = $$('input[type="checkbox"]:checked.sample_check');
-  var found = false;
-  if (selected.length > 0){
-    found = true;
-  }
-  if (checkboxes.length == 0) {
-    found = true;
-  }
-  return found;
-}
-
-function submit_stage() {
-  if (samples_are_selected() == true) {
-    $('stage_button').disabled = true;
-    $('stage_links').style.display = 'none';
-    $('stage_loading').style.display = 'inline';
-    document.getElementById('stage_form').submit();
-
-    // alert(form);
-    // $('stage_form').submit();
-  } else {
-    alert('Please select one or more items.');
-  }
-}
-
 function disable_cr_and_change_focus(event, current_field, next_field) {
 	if (event.keyCode !=13) { return; }
   $(next_field).focus();


### PR DESCRIPTION
Makes the 'cancel' link return to the batch, rather than the pipeline
inbox.

Tidies up the views so that they call the same partial to render the
submit and cancel controls, and can uniformly control the form
submission behaviour.

Reworked the cherrypicking Javascript a bit to make is somewhat more
readable, but there's a lot of work needed on it.
