### PR TITLE
[fixes 20539207] Fix pipeline inbox sorting under IE.

### DIFF
--- a/app/views/pipelines/_requests.html.erb
+++ b/app/views/pipelines/_requests.html.erb
@@ -116,7 +116,7 @@
         // If the node has an IMG element underneath it then its 'alt' attribute is used, otherwise it's the innerHTML of the node.
         var imgNode = $('img', node);
         return (imgNode.size() > 0 ? imgNode.attr('alt') : $(node).text());
-      },
+      }
     });
   });
 })(jQuery);


### PR DESCRIPTION
IE is slightly more stringent about Javascript layout, so the stray
comma was causing a problem.
