### PR TITLE
[fixes 20534085] Hide 'create stock assets' from batch view.

### DIFF
--- a/app/models/library_creation_pipeline.rb
+++ b/app/models/library_creation_pipeline.rb
@@ -23,4 +23,8 @@ class LibraryCreationPipeline < Pipeline
     end
     batch
   end
+
+  def can_create_stock_assets?
+    true
+  end
 end

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -252,4 +252,7 @@ class Pipeline < ActiveRecord::Base
     true
   end
 
+  def can_create_stock_assets?
+    false
+  end
 end

--- a/app/models/pipeline/stock_assets.rb
+++ b/app/models/pipeline/stock_assets.rb
@@ -1,0 +1,5 @@
+module Pipeline::StockAssets
+  def can_create_stock_assets?
+    true
+  end
+end

--- a/app/views/batches/show.html.erb
+++ b/app/views/batches/show.html.erb
@@ -12,11 +12,15 @@
   <% elsif @pipeline.is_a?(CherrypickingPipeline) || @pipeline.is_a?(GenotypingPipeline) || @pipeline.is_a?(PacBioSequencingPipeline) -%>
     <% add :menu, "Print plate labels" => url_for(:controller => :batches, :action => :print_plate_labels, :id => @batch.id) -%>
   <% elsif (!@pipeline.is_a?(SequencingPipeline)) -%>
-    <% add :menu, "Print stock labels" => url_for(:controller => :batches, :action => :print_stock_labels, :id => @batch.id) -%>
+    <% if @batch.pipeline.can_create_stock_assets? %>
+      <% add :menu, "Print stock labels" => url_for(:controller => :batches, :action => :print_stock_labels, :id => @batch.id) -%>
+    <% end %>
     <% add :menu, "Print labels" => url_for(:controller => :batches, :action => :print_labels, :id => @batch.id) -%>
   <% end -%>
   <% unless @pipeline.is_a?(SequencingPipeline) -%>
     <% add :menu, "Vol' & Conc'"  => url_for(:controller => :batches, :action => :edit_volume_and_concentration, :id => @batch.id) -%>
+  <% end %>
+  <% if @batch.pipeline.can_create_stock_assets? %>
     <% add :menu, "Create stock tubes"  => url_for(:controller => :batches, :action => :new_stock_assets, :id => @batch.id) -%>
   <% end %>
 

--- a/app/views/workflows/stage.html.erb
+++ b/app/views/workflows/stage.html.erb
@@ -6,12 +6,16 @@
   <% add :menu, "Print stock pool label" => url_for(:controller => :batches, :action => :print_stock_multiplex_labels, :id => @batch.id) -%>
   <% add :menu, "Print labels" => url_for(:controller => :batches, :action => :print_labels, :id => @batch.id) -%>
 <% else -%>
-  <% add :menu, "Print stock labels" => url_for(:controller => :batches, :action => :print_stock_labels, :id => @batch.id) -%>
+  <% if @batch.pipeline.can_create_stock_assets? %>
+    <% add :menu, "Print stock labels" => url_for(:controller => :batches, :action => :print_stock_labels, :id => @batch.id) -%>
+  <% end %>
   <% add :menu, "Print labels" => url_for(:controller => :batches, :action => :print_labels, :id => @batch.id) -%>
 <% end -%>
 
 <% add :menu, "Vol' & Conc'" => url_for(:controller => :assets, :action => :find_by_barcode) -%>
+<% if @batch.pipeline.can_create_stock_assets? %>
 <% add :menu, "Create stock tubes"  => url_for(:controller => :batches, :action => :new_stock_assets, :id => @batch.id) -%>
+<% end %>
 <% add :menu, "Fail batch" => url_for(:controller => :batches, :action => :fail, :id => @batch.id) %>
 
 <% if @batch.workflow.locale == "Internal" && ! @batch.pipeline.sequencing? %> 

--- a/features/batch/print_label_cluster_info_bug.feature
+++ b/features/batch/print_label_cluster_info_bug.feature
@@ -9,16 +9,16 @@ Feature: Change the side links in a batch depending on the pipeline
     Given I have a batch in "<pipeline>"
       And I am on the last batch show page
     Then I should see "Edit"
-      And I <see_or_not_see> "Print stock labels"
-      And I <see_or_not_see_2> "Create stock tubes"
-      And I <see_or_not_see_2> "Vol' & Conc'"
+      And I <stock labels> "Print stock labels"
+      And I <stock tubes> "Create stock tubes"
+      And I <volume and conc> "Vol' & Conc'"
 
     Examples:
-      | pipeline                      |  see_or_not_see | see_or_not_see_2 |
-      | Cluster formation PE          |  should not see | should not see   |
-      | Cluster formation SE          |  should not see | should not see   |
-      | Library preparation           |  should see     | should see       |
-      | Genotyping                    |  should not see | should see       |
-      | MX Library Preparation [NEW]  |  should not see | should see       |
-      | Cherrypick                    |  should not see | should see       |
-      | DNA QC                        |  should not see | should see       |
+      | pipeline                     | stock labels   | stock tubes    | volume and conc |
+      | Cluster formation PE         | should not see | should not see | should not see  |
+      | Cluster formation SE         | should not see | should not see | should not see  |
+      | Library preparation          | should see     | should see     | should see      |
+      | Genotyping                   | should not see | should not see | should see      |
+      | MX Library Preparation [NEW] | should not see | should see     | should see      |
+      | Cherrypick                   | should not see | should not see | should see      |
+      | DNA QC                       | should not see | should not see | should see      |


### PR DESCRIPTION
Hides the 'create stock assets' link from the batches that it just
doesn't make sense for.
