### PR TITLE
[fixes 18332883] Display cherrypicking errors to user.

### DIFF
--- a/app/models/cherrypick.rb
+++ b/app/models/cherrypick.rb
@@ -1,0 +1,7 @@
+module Cherrypick
+  # Various types of error that can occur during cherrypicking
+  Error              = Class.new(StandardError)
+  VolumeError        = Class.new(Error)
+  ConcentrationError = Class.new(Error)
+  AmountError        = Class.new(Error)
+end

--- a/app/models/cherrypick/volume_by_micro_litre.rb
+++ b/app/models/cherrypick/volume_by_micro_litre.rb
@@ -13,12 +13,8 @@ module Cherrypick::VolumeByMicroLitre
   end
   
   def check_inputs_to_volume_to_cherrypick_by_micro_litre!(volume_required)
-    [volume_required].each do |input_value|
-      raise "Invalid parameter for working out what volume to cherrypick" if input_value.blank? || input_value.to_f <= 0.0
-    end
-    
-    nil
+    raise Cherrypick::VolumeError, "Volume required (#{volume_required.inspect}) is invalid for cherrypicking by micro litre" if volume_required.blank? || volume_required.to_f <= 0.0
   end
-  
+  private :check_inputs_to_volume_to_cherrypick_by_micro_litre!
 end
 

--- a/app/models/cherrypick/volume_by_nano_grams.rb
+++ b/app/models/cherrypick/volume_by_nano_grams.rb
@@ -1,16 +1,18 @@
 module Cherrypick::VolumeByNanoGrams
-  
   def check_inputs_to_volume_to_cherrypick_by_nano_grams!(minimum_volume, maximum_volume, target_ng, source_well)
-    raise "Well not found" if source_well.nil?
-    raise "Invalid volumes" if minimum_volume.blank? || minimum_volume <= 0.0 || maximum_volume.blank? || maximum_volume <= 0.0
-    raise "Invalid target nano grams" if target_ng.blank? || target_ng <= 0.0
-    source_concentration = source_well.well_attribute.concentration
-    source_volume = source_well.well_attribute.measured_volume
-    raise "Missing measured volume for Well #{source_well.id}" if source_volume.blank? || source_volume <= 0.0
-    raise "Missing measured concentration for Well #{source_well.id}" if source_concentration.blank? || source_concentration <= 0.0 
-    
-    nil
+    raise "Source well not found" if source_well.nil?
+
+    raise Cherrypick::VolumeError, "Minimum volume (#{minimum_volume.inspect}) is invalid for cherrypick by nano grams"          if minimum_volume.blank? || minimum_volume <= 0.0
+    raise Cherrypick::VolumeError, "Maximum volume (#{maximum_volume.inspect}) is invalid for cherrypick by nano grams"          if maximum_volume.blank? || maximum_volume <= 0.0
+    raise Cherrypick::VolumeError, "Maximum volume (#{maximum_volume.inspect}) is less than minimum (#{minimum_volume.inspect})" if maximum_volume < minimum_volume
+
+    raise Cherrypick::AmountError, "Target nano grams (#{target_ng.inspect}) is invalid for cherrypick by nano grams" if target_ng.blank? || target_ng <= 0.0
+
+    source_concentration, source_volume = source_well.well_attribute.concentration, source_well.well_attribute.measured_volume
+    raise Cherrypick::VolumeError, "Missing measured volume for well #{source_well.display_name}(#{source_well.id})"        if source_volume.blank? || source_volume <= 0.0
+    raise Cherrypick::ConcentrationError, "Missing measured concentration for well #{source_well.display_name}(#{source_well.id})" if source_concentration.blank? || source_concentration <= 0.0 
   end
+  private :check_inputs_to_volume_to_cherrypick_by_nano_grams!
   
   def volume_to_cherrypick_by_nano_grams(minimum_volume, maximum_volume, target_ng, source_well)
     check_inputs_to_volume_to_cherrypick_by_nano_grams!(minimum_volume, maximum_volume, target_ng, source_well)
@@ -32,6 +34,5 @@ module Cherrypick::VolumeByNanoGrams
     
     requested_volume
   end
-  
 end
 

--- a/app/models/cherrypick/volume_by_nano_grams_per_micro_litre.rb
+++ b/app/models/cherrypick/volume_by_nano_grams_per_micro_litre.rb
@@ -25,12 +25,10 @@ module Cherrypick::VolumeByNanoGramsPerMicroLitre
   end
   
   def check_inputs_to_volume_to_cherrypick_by_nano_grams_per_micro_litre!(volume_required,concentration_required,source_concentration)
-    [volume_required,concentration_required,source_concentration].each do |input_value|
-      raise "Invalid parameter for working out what volume to cherrypick" if input_value.blank? || input_value.to_f <= 0.0
-    end
-    
-    nil
+    raise Cherrypick::VolumeError, "Volume required (#{volume_required.inspect}) is invalid for cherrypick by nano grams per micro litre"                      if volume_required.blank? || volume_required.to_f <= 0.0
+    raise Cherrypick::ConcentrationError, "Concentration required (#{concentration_required.inspect}) is invalid for cherrypick by nano grams per micro litre" if concentration_required.blank? || concentration_required.to_f <= 0.0
+    raise Cherrypick::ConcentrationError, "Source concentration (#{source_concentration.inspect}) is invalid for cherrypick by nano grams per micro litre"     if source_concentration.blank? || source_concentration.to_f <= 0.0
   end
-  
+  private :check_inputs_to_volume_to_cherrypick_by_nano_grams_per_micro_litre!
 end
 

--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -200,6 +200,9 @@ class CherrypickTask < Task
 
   def do_task(workflow, params)
     workflow.do_cherrypick_task(self, params)
+  rescue Cherrypick::Error => exception
+    workflow.send(:flash)[:error] = exception.message
+    return false
   end
 
   def self.parse_uploaded_spreadsheet_layout(layout_data,plate_size)

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -1,5 +1,10 @@
 module Tasks::CherrypickHandler
   def render_cherrypick_task(task, params)
+    unless flash[:error].blank?
+      redirect_to :action => 'stage', :batch_id => @batch.id, :workflow_id => @workflow.id, :id => (@stage -1).to_s
+      return
+    end
+
     plate_template = nil
     unless params[:plate_template].blank?
       plate_template = PlateTemplate.find(params[:plate_template]["0"].to_i)

--- a/features/pulldown/9117483_display_errors_during_cherrypicking.feature
+++ b/features/pulldown/9117483_display_errors_during_cherrypicking.feature
@@ -26,5 +26,5 @@ Feature: Display the errors that occur during cherrypicking for pulldown
     And I press "Next step"
 
     Then I should see "Cherrypick Group By Submission"
-    And I should see "Invalid parameter for working out what volume to cherrypick"
+    And I should see "Source concentration (nil) is invalid for cherrypick by nano grams per micro litre"
 

--- a/features/slf/8573259_cherrypick_in_ng.feature
+++ b/features/slf/8573259_cherrypick_in_ng.feature
@@ -163,7 +163,7 @@ Feature: Pick a ng quantity using the Tecan robot
       | Maximum Volume    | 50   |
       | Quantity to pick  | 1000 |
     And I press "Next step"
-    Then I should see "Missing measured concentration for Well"
+    Then I should see "Missing measured concentration for well DN222J:B2"
   
    Scenario: Try to cherrypick where 1 well has no volume
      Given a plate barcode webservice is available and returns "99999"
@@ -182,7 +182,7 @@ Feature: Pick a ng quantity using the Tecan robot
        | Maximum Volume    | 50   |
        | Quantity to pick  | 1000 |
      And I press "Next step"
-     Then I should see "Missing measured volume for Well"
+    Then I should see "Missing measured volume for well DN222J:B2"
      
    Scenario Outline: Invalid picking options
      Given I have a plate "222" with the following wells:

--- a/test/unit/well_test.rb
+++ b/test/unit/well_test.rb
@@ -183,7 +183,7 @@ class WellTest < ActiveSupport::TestCase
       
       context "with no source concentration" do
         should "raise an error" do
-          assert_raises RuntimeError do
+          assert_raises Cherrypick::ConcentrationError do
             @well.volume_to_cherrypick_by_nano_grams_per_micro_litre(1.1, 2.2, 0.0)
             @well.volume_to_cherrypick_by_nano_grams_per_micro_litre(1.2, 2.2, "")
           end


### PR DESCRIPTION
This adds code that will report the errors in cherrypicking to the user,
at least giving them enough information so that they should be able to
provide enough detail for further diagnosis of the problem.
