### PR TITLE
20662837 remove unnecessary information from batch xml

### DIFF
--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -40,8 +40,6 @@ xml.batch {
             "id"         => request.asset.id,                                 # TODO: remove
             "name"       => request.asset.name,                               # TODO: remove
             "request_id" => request.id,
-            "study_id"   => request.target_asset.primary_aliquot.study_id,    # TODO: remove
-            "project_id" => request.target_asset.primary_aliquot.project_id,  # TODO: remove
             "qc_state"   => request.target_asset.compatible_qc_state
           ) {
             non_spiked_phiX, spiked_in_phiX = target_asset_aliquots, request.target_asset.spiked_in_buffer
@@ -53,11 +51,8 @@ xml.batch {
           # any aliquots that are tagged from the view.
           xml.library(
             "id"         => request.target_asset.primary_aliquot.library_id,  # TODO: remove
-            "sample_id"  => request.target_asset.primary_aliquot.sample_id,   # TODO: remove
             "name"       => request.asset.name,                               # TODO: remove
             "request_id" => request.id,
-            "study_id"   => request.target_asset.primary_aliquot.study_id,    # TODO: remove
-            "project_id" => request.target_asset.primary_aliquot.project_id,  # TODO: remove
             "qc_state"   => request.target_asset.compatible_qc_state
           ) {
             target_asset_aliquots.each do |aliquot|

--- a/test/functional/batches_controller_test.rb
+++ b/test/functional/batches_controller_test.rb
@@ -55,9 +55,7 @@ class BatchesControllerTest < ActionController::TestCase
         should "have api version attribute on root object" do
           assert_response :success
           assert_tag :tag => 'lane', :attributes => { :position => 1, :id => @lane.id, :priority => 99 }
-          assert_tag :tag => "library", :attributes => {:sample_id => @sample.id, :request_id => @request_one.id}
-          assert_tag :tag => "library", :attributes => {:project_id => @project.id, :study_id => @study.id}
-          assert_tag :tag => "library", :attributes => {:qc_state => "fail"}
+          assert_tag :tag => "library", :attributes => {:request_id => @request_one.id, :qc_state => 'fail'}
         end
 
         should 'expose the library information correctly' do


### PR DESCRIPTION
The study_id, project_id and sample_id can be removed from the pool and
library elements as these do not apply for cross study/project
information.
