### PR TITLE
20409753 disable certain plate purposes from cherrypicking

### DIFF
--- a/app/models/plate_purpose.rb
+++ b/app/models/plate_purpose.rb
@@ -35,6 +35,8 @@ class PlatePurpose < ActiveRecord::Base
 
   include Relationship::Associations
 
+  named_scope :cherrypickable, :conditions => { :cherrypickable_target => true }
+
   # The state of a plate is based on the transfer requests.
   def state_of(plate)
     plate.send(:state_from, plate.transfer_requests)

--- a/app/models/tasks/plate_purpose_behavior.rb
+++ b/app/models/tasks/plate_purpose_behavior.rb
@@ -4,7 +4,7 @@ module Tasks
     def plate_purpose_options(batch)
       requests       = batch.requests.map { |r| r.submission ? r.submission.next_requests(r) : [] }.flatten
       plate_purposes = requests.map(&:request_type).compact.uniq.map(&:acceptable_plate_purposes).flatten.uniq
-      plate_purposes = PlatePurpose.all if plate_purposes.empty?  # Fallback situation for the moment
+      plate_purposes = PlatePurpose.cherrypickable.all if plate_purposes.empty?  # Fallback situation for the moment
       plate_purposes.map { |p| [p.name, p.id] }.sort
     end
   end

--- a/db/migrate/20111108085135_add_cherrypickable_target_to_plate_purpose.rb
+++ b/db/migrate/20111108085135_add_cherrypickable_target_to_plate_purpose.rb
@@ -1,0 +1,9 @@
+class AddCherrypickableTargetToPlatePurpose < ActiveRecord::Migration
+  def self.up
+    add_column :plate_purposes, :cherrypickable_target, :boolean, :null => false, :default => true
+  end
+
+  def self.down
+    remove_column :plate_purposes, :cherrypickable_target
+  end
+end

--- a/db/migrate/20111108085356_disable_certain_plate_purposes_from_cherrypicking.rb
+++ b/db/migrate/20111108085356_disable_certain_plate_purposes_from_cherrypicking.rb
@@ -1,0 +1,39 @@
+class DisableCertainPlatePurposesFromCherrypicking < ActiveRecord::Migration
+  class PlatePurpose < ActiveRecord::Base
+    class Relationship < ActiveRecord::Base
+      set_table_name('plate_purpose_relationships')
+      belongs_to :parent, :class_name => 'DisableCertainPlatePurposesFromCherrypicking::PlatePurpose'
+      belongs_to :child, :class_name => 'DisableCertainPlatePurposesFromCherrypicking::PlatePurpose'
+    end
+
+    set_table_name('plate_purposes')
+
+    has_many :child_relationships, :class_name => 'DisableCertainPlatePurposesFromCherrypicking::PlatePurpose::Relationship', :foreign_key => :parent_id, :dependent => :destroy
+    has_many :child_plate_purposes, :through => :child_relationships, :source => :child
+  end
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      # All of the internal plate types for pulldown are not cherrypickable
+      [ 'WGS', 'SC', 'ISC' ].each do |pipeline|
+        root = PlatePurpose.find_by_name("#{pipeline} stock DNA") or raise StandardError, "Cannot find the #{pipeline} stock DNA plate type"
+        plate_purposes = root.child_plate_purposes
+        until plate_purposes.empty?
+          plate_purpose = plate_purposes.shift
+          plate_purpose.update_attributes!(:cherrypickable_target => false)
+          plate_purposes.concat(plate_purpose.child_plate_purposes)
+        end
+      end
+
+      # Disable the legacy plate types that should not be being cherrypicked to
+      PlatePurpose.find_by_name("Seqcap WG").tap do |seqcap_wgs|
+        raise StandardError, "Cannot find the Seqcap WG plate type" if seqcap_wgs.nil?
+        seqcap_wgs.update_attributes!(:cherrypickable_target => false)
+      end
+    end
+  end
+
+  def self.down
+    # Do nothing as it's not really relevant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111107214502) do
+ActiveRecord::Schema.define(:version => 20111108085356) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -616,6 +616,7 @@ ActiveRecord::Schema.define(:version => 20111107214502) do
     t.boolean  "can_be_considered_a_stock_plate",               :default => false,     :null => false
     t.string   "default_state",                                 :default => "pending"
     t.integer  "barcode_printer_type_id",                       :default => 2
+    t.boolean  "cherrypickable_target",                         :default => true,      :null => false
   end
 
   add_index "plate_purposes", ["qc_display"], :name => "index_plate_purposes_on_qc_display"

--- a/db/seeds/0006_plate_purposes.rb
+++ b/db/seeds/0006_plate_purposes.rb
@@ -474,6 +474,10 @@ ActiveRecord::Base.transaction do
     end
   end
 
+  # A couple of legacy pulldown types
+  PlatePurpose.create!(:name => 'SEQCAP WG', :cherrypickable_target => false)  # Superceded by Pulldown WGS below (here for transition period)
+  PlatePurpose.create!(:name => 'SEQCAP SC')
+
   # And here is pulldown
   Pulldown::PlatePurposes::PULLDOWN_PLATE_PURPOSE_FLOWS.each do |flow|
     # We're using a different plate purpose for each pipeline, which means we need to attach that plate purpose to the request
@@ -486,7 +490,7 @@ ActiveRecord::Base.transaction do
     # Now we can build from the stock plate through to the end
     initial_purpose = stock_plate_purpose.child_plate_purposes.create!(:type => 'Pulldown::InitialPlatePurpose', :name => flow.shift)
     flow.inject(initial_purpose) do |parent, child_plate_name|
-      options = { :name => child_plate_name }
+      options = { :name => child_plate_name, :cherrypickable_target => false }
       options[:type] = 'Pulldown::LibraryPlatePurpose' if child_plate_name =~ /^(WGS|SC|ISC) library plate$/
       parent.child_plate_purposes.create!(options)
     end

--- a/test/unit/assign_plate_purpose_task_test.rb
+++ b/test/unit/assign_plate_purpose_task_test.rb
@@ -12,6 +12,12 @@ class AssignPlatePurposeTaskTest < ActiveSupport::TestCase
       @params = {:batch_id => @batch.id, :workflow_id => @workflow.id}
     end
 
+    context "#plate_purpose_options" do
+      should 'return only the cherrypickable plate purposes' do
+        assert_equal(PlatePurpose.cherrypickable.all.map { |p| [p.name, p.id] }.sort, @assign_plate_purpose_task.plate_purpose_options(@batch))
+      end
+    end
+
     context "#partial" do
       should "return the name of the partial used to display this task, 'assign_plate_purpose'" do
         assert_equal 'assign_plate_purpose', @assign_plate_purpose_task.partial


### PR DESCRIPTION
This ensures that the cherrypicking UI doesn't contain the plate types
that shouldn't be cherrypicked onto in the first place.
