### PR TITLE
20808511 npg unable to pass lane

### DIFF
--- a/app/models/billing_event.rb
+++ b/app/models/billing_event.rb
@@ -102,7 +102,7 @@ class BillingEvent < ActiveRecord::Base
   def self.construct_from_request(kind, event_type, request, entry_date=Time.now)
     description = "#{request.request_type.name} #{event_type}"
     #TODO create on event per Aliquot
-    project_id = request.try(:asset).try(:primary_aliquot).try(:project)  || request.initial_project_id
+    project_id = request.try(:asset).try(:primary_aliquot).try(:project_id)  || request.initial_project_id
 
     self.new :kind => kind,
       :reference => self.build_reference(request),

--- a/test/unit/billing_event_test.rb
+++ b/test/unit/billing_event_test.rb
@@ -248,7 +248,30 @@ class BillingEventTest < ActiveSupport::TestCase
         assert_equal [], BillingEvent.refunds_for_reference(@reference)
         assert BillingEvent.charge_internally_for_reference(@reference)
       end
-    end
+    end 
+    context "without an initial project" do
+      setup do
+        @request = Factory :request
+        project = @request.initial_project
+        @request.asset.aliquots.each do |al|
+          al.project = project
+          al.save!
+        end
+        @request.initial_project=nil
+        @request.save!
+        @reference = BillingEvent.build_reference(@request)
+      end
+      context "passing" do
+        setup do
+          BillingEvent.generate_pass_event @request
+        end
+        should "generate a charge event" do
+          assert BillingEvent.charge_for_reference(@reference)
+          assert_equal [], BillingEvent.refunds_for_reference(@reference)
+          assert_nil BillingEvent.charge_internally_for_reference(@reference)
+        end
+      end
+    end 
   end
   context "A request" do
     setup do
@@ -290,5 +313,6 @@ class BillingEventTest < ActiveSupport::TestCase
         end
       end
     end
+
   end
 end


### PR DESCRIPTION
Billing event needs a project.
The bug appears when a request doesn't have a project
and we need to get asset one instead
