### PR TITLE
20855033 plate creation through pulldown broken

### DIFF
--- a/app/models/plate_creation.rb
+++ b/app/models/plate_creation.rb
@@ -44,7 +44,7 @@ class PlateCreation < ActiveRecord::Base
   private :connect_parent_and_child
 
   def connect_child_to_parent_study
-    RequestFactory.create_asset_requests([ self.child.id ], self.parent.study.id) if self.parent.study.present?
+    RequestFactory.create_assets_requests([ self.child.id ], self.parent.study.id) if self.parent.study.present?
   end
   private :connect_child_to_parent_study
 


### PR DESCRIPTION
This has always been like this, calling the wrong method, but hasn't
been triggered because Plate#study was returning nil in the normal
cases.  As that is no longer true this now needs to call the correctly
named method.
