### PR TITLE
[fixes 21648007] Improve the plate JSON rendering performance

### DIFF
--- a/app/api/io/plate.rb
+++ b/app/api/io/plate.rb
@@ -1,22 +1,22 @@
 class Io::Plate < Io::Asset
   set_model_for_input(::Plate)
   set_json_root(:plate)
-  set_eager_loading { |model| model.include_wells_with_aliquots.include_plate_purpose }
+  set_eager_loading { |model| model.include_plate_metadata.include_plate_purpose }
 
   define_attribute_and_json_mapping(%Q{
-                                    size <=> size
-                      plate_purpose.name  => plate_purpose.name
-                wells.in_row_major_order  => wells
+                                           size <=> size
+                             plate_purpose.name  => plate_purpose.name
+    wells.for_api_plate_json.in_row_major_order  => wells
 
-                                   state  => state
-                               iteration  => iteration
-                                   pools  => pools
+                                          state  => state
+                                      iteration  => iteration
+                                          pools  => pools
 
-                        stock_plate.uuid  => stock_plate.uuid
-                     stock_plate.barcode  => stock_plate.barcode.number
-       stock_plate.barcode_prefix.prefix  => stock_plate.barcode.prefix
-     stock_plate.two_dimensional_barcode  => stock_plate.barcode.two_dimensional
-               stock_plate.ean13_barcode  => stock_plate.barcode.ean13
-                stock_plate.barcode_type  => stock_plate.barcode.type
+                               stock_plate.uuid  => stock_plate.uuid
+                            stock_plate.barcode  => stock_plate.barcode.number
+              stock_plate.barcode_prefix.prefix  => stock_plate.barcode.prefix
+            stock_plate.two_dimensional_barcode  => stock_plate.barcode.two_dimensional
+                      stock_plate.ean13_barcode  => stock_plate.barcode.ean13
+                       stock_plate.barcode_type  => stock_plate.barcode.type
   })
 end

--- a/app/api/model_extensions/plate.rb
+++ b/app/api/model_extensions/plate.rb
@@ -32,7 +32,7 @@ module ModelExtensions::Plate
   def self.included(base)
     base.class_eval do
       named_scope :include_plate_purpose, :include => :plate_purpose
-      named_scope :include_wells_with_aliquots, :include => ::ModelExtensions::Plate::PLATE_INCLUDES
+      named_scope :include_plate_metadata, :include => :plate_metadata
       delegate :pool_id_for_well, :to => :plate_purpose, :allow_nil => true
     end
   end

--- a/app/api/model_extensions/well.rb
+++ b/app/api/model_extensions/well.rb
@@ -1,0 +1,23 @@
+module ModelExtensions::Well
+  def self.included(base)
+    base.class_eval do
+      named_scope :for_api_plate_json, :include => [
+        :map,
+        :transfer_requests_as_target,
+        :uuid_object, {
+          :aliquots => [
+            :bait_library, {
+              :tag => :tag_group,
+              :sample => [
+                :uuid_object, {
+                  :primary_study   => { :study_metadata => :reference_genome },
+                  :sample_metadata => :reference_genome
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    end
+  end
+end

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -20,6 +20,7 @@ class Aliquot < ActiveRecord::Base
 
     # Named scopes for the future
     named_scope :include_aliquots, :include => { :aliquots => [ :sample, :tag, :bait_library ] }
+    named_scope :with_aliquots, :joins => :aliquots
 
     # Provide some named scopes that will fit with what we've used in the past
     named_scope :with_sample_id, lambda { |id|     { :conditions => { :aliquots => { :sample_id => Array(id)               } }, :joins => :aliquots } }
@@ -128,6 +129,15 @@ class Aliquot < ActiveRecord::Base
   belongs_to :tag
   validates_uniqueness_of :tag_id, :scope => :receptacle_id
   before_validation { |record| record.tag_id ||= UNASSIGNED_TAG }
+
+  def untagged?
+    self.tag_id.nil? or self.tag_id == UNASSIGNED_TAG
+  end
+
+  def tag_with_unassigned_behaviour
+    untagged? ? nil : tag_without_unassigned_behaviour
+  end
+  alias_method_chain(:tag, :unassigned_behaviour)
 
   # It may have a bait library but not necessarily.
   belongs_to :bait_library

--- a/app/models/search/find_pulldown_plates.rb
+++ b/app/models/search/find_pulldown_plates.rb
@@ -2,7 +2,7 @@ class Search::FindPulldownPlates < Search
   def scope(criteria)
     # We find all plates that do not have transfers where they are the source.  Once a plate has been transferred (or marked
     # for transfer) the destination plate becomes the end of the chain.
-    Plate.include_wells_with_aliquots.include_plate_purpose.with_plate_purpose(pulldown_plate_purposes).with_no_outgoing_transfers.in_state(criteria['state'])
+    Plate.include_plate_metadata.include_plate_purpose.with_plate_purpose(pulldown_plate_purposes).with_no_outgoing_transfers.in_state(criteria['state'])
   end
 
   def self.pulldown_plate_purposes

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -1,5 +1,6 @@
 class Well < Aliquot::Receptacle
   include Api::WellIO::Extensions
+  include ModelExtensions::Well
   include Cherrypick::VolumeByNanoGrams
   include Cherrypick::VolumeByNanoGramsPerMicroLitre
   include Cherrypick::VolumeByMicroLitre


### PR DESCRIPTION
The generation of the plate JSON was causing timeouts because it was not
performing certain operations in the most efficient manner.  This commit
improves the state detection and well JSON generation so that it is
about 80% faster.
