### PR TITLE
Override the CSS applied by tablesorter which obscures some user feedback

### DIFF
--- a/public/javascripts/assigntags.js
+++ b/public/javascripts/assigntags.js
@@ -74,7 +74,7 @@
             taggers.slice(taggers.index($(this)) + 1).each(function () {
                     $(this).prop("selectedIndex",chosenTagIndex+1);
                     // A little animation to highlight the changed rows
-                    $(this).closest('tr').effect('highlight',3000);
+                    $(this).closest('tr').find("td").effect('highlight',3000);
                     chosenTagIndex++;
             });
         }

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1325,7 +1325,10 @@ div.characterisation fieldset{
   border: none;
 }
 tr.duplicate-error {
-  background: #FFB0B0;
+  background: #FFB0B0 !important
+}
+tr.duplicate-error td {
+  background: #FFB0B0 !important
 }
 
 #increment-tags-info {


### PR DESCRIPTION
Fixes a colour highlight issue which I somehow missed before. (The whole row of the table was not being highlighted when there was a duplicate tag assignment).
