### PR TITLE
Temporarily fix edit submission link

### DIFF
--- a/app/views/submissions/_list.html.erb
+++ b/app/views/submissions/_list.html.erb
@@ -18,8 +18,8 @@
           <td><%= submission.created_at.to_formatted_s(:day_full_with_time) %></td>
           <td><%= link_to "View", submission_path(submission) %></td>
           <% if @current_user.is_administrator? %>
-            <td><%= link_to("Edit", edit_submission_path(submission)) unless submission.ready? || submission.pending? %></td>
-            <td><%= link_to("<span style='color:red;'>Delete</span>", submission_path(submission), :method => :delete, :confirm => "Are you sure?") if current_user.administrator? %></td>
+            <td><%= link_to("Build", edit_submission_path(submission), :confirm => "Are you sure?") unless submission.ready? || submission.pending? %></td>
+            <td><% #TODO[xxx] Reinstate this link link_to("<span style='color:red;'>Delete</span>", submission_path(submission), :method => :delete, :confirm => "Are you sure?") if current_user.administrator? %></td>
           <% end %>
         </tr>
       <% end %>

--- a/public/javascripts/submissions.js
+++ b/public/javascripts/submissions.js
@@ -167,7 +167,7 @@
             //                                        vvvvvvvvvv-- Ugly, ugly, ugly...
             currentPane.find('.project-details').html(tempResult.html());
 
-            debugger;
+             //debugger
 
             currentPane.
               detach().


### PR DESCRIPTION
I've changed the "Edit" link to "Build"  and hidden the "Delete" link for the time being. This will need reverting when the edit interface is done.
