### PR TITLE
23022151 bait library broken

### DIFF
--- a/app/models/attributable.rb
+++ b/app/models/attributable.rb
@@ -125,7 +125,7 @@ module Attributable
     def to_field_info(*args)
       FieldInfo.new(
         :display_name  => Attribute::find_display_name(@owner,  name),
-        :key           => self.name,
+        :key           => assignable_attribute_name,
         :kind          => FieldInfo::SELECTION,
         :selection     => @owner.reflections[@name.to_sym].klass.all.map(&@method.to_sym).sort
       )


### PR DESCRIPTION
use assignable_name for the key, as assignable_name is what will be used
to construct request (Which is so far the only place where FieldInfo are
used - in the Submission GUI)

**\* No test written for that. It only occurs on the new Submission GUI
which are not covered yet.
