### PR TITLE
[fixes #23274619] Allow full plate tagging to ignore pools.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: git+ssh://git@github.com/sanger/alter_table.git
-  revision: 109850bb109a3a4deb97f6d39174f8d6c8e8263f
+  revision: 5a4782a9edac1edde739855afbacc98d5f77618d
   specs:
     alter_table (0.0.1)
       rails (~> 2.3.11)

--- a/app/api/io/tag_layout.rb
+++ b/app/api/io/tag_layout.rb
@@ -9,5 +9,6 @@ class ::Io::TagLayout < ::Core::Io::Base
     substitutions <=> substitutions
         tag_group  => tag_group
         direction  => direction
+       walking_by  => walking_by
   })
 end

--- a/app/api/io/tag_layout_template.rb
+++ b/app/api/io/tag_layout_template.rb
@@ -7,5 +7,6 @@ class ::Io::TagLayoutTemplate < ::Core::Io::Base
                  name  => name
             tag_group  => tag_group
             direction  => direction
+           walking_by  => walking_by
   })
 end

--- a/app/models/tag_layout.rb
+++ b/app/models/tag_layout.rb
@@ -27,40 +27,14 @@ class TagLayout < ActiveRecord::Base
   belongs_to :plate
   validates_presence_of :plate
 
+  # After loading the record from the database, inject the behaviour.
+  def after_initialize
+    extend(direction_algorithm.constantize) unless direction_algorithm.blank?
+    extend(walking_algorithm.constantize)   unless walking_algorithm.blank?
+  end
+
   # After creating the instance we can layout the tags into the wells.
   after_create :layout_tags_into_wells
-
-  def walk_wells(&block)
-    # Adjust each of the groups so that any wells that are in the same pool as those at the same position
-    # in the group to the left are moved to a non-clashing position.  Effectively this makes the view of the
-    # plate slightly jagged.
-    group_size      = direction.to_sym == :column ? Map.plate_length(plate.size) : Map.plate_width(plate.size)
-    wells_in_groups = plate.wells.send(:"in_#{direction}_major_order").with_pool_id.in_groups_of(group_size).map do |wells|
-      wells.map { |well| [ well, well.pool_id ] }
-    end
-    wells_in_groups.each_with_index do |current_group, group|
-      next if group == 0
-      prior_group = wells_in_groups[group-1]
-
-      current_group.each_with_index do |well_and_pool, index|
-        break if prior_group.size <= index
-
-        # Assume that, if the current well isn't in a pool, that it is in the same pool as the well prior
-        # to it in the group.  That way empty wells are treated as though they are part of the pool.
-        well_and_pool[-1] ||= (index.zero? ? prior_group.last : current_group[index-1]).last
-        next unless prior_group[index].last == well_and_pool.last
-
-        current_group.push(well_and_pool)                # Move the well to the end of the group
-        current_group[index] = [nil, well_and_pool.last] # Blank out the well at the current position but maintain the pool
-      end
-    end
-
-    # Now we can walk the wells in the groups, skipping any that have been nil'd by the above code.
-    wells_in_groups.each do |group|
-      group.each_with_index { |(well, _), index| yield(well, index) unless well.nil? }
-    end
-  end
-  private :walk_wells
 
   # Convenience mechanism for laying out tags in a particular fashion.
   def layout_tags_into_wells

--- a/app/models/tag_layout/in_columns.rb
+++ b/app/models/tag_layout/in_columns.rb
@@ -1,5 +1,8 @@
 # Lays out the tags so that they are column ordered.
-class TagLayout::InColumns < TagLayout
-  class_inheritable_reader :direction
-  write_inheritable_attribute(:direction, 'column')
+module TagLayout::InColumns
+  extend self
+
+  def direction
+    'column'
+  end
 end

--- a/app/models/tag_layout/in_rows.rb
+++ b/app/models/tag_layout/in_rows.rb
@@ -1,5 +1,8 @@
 # Lays out the tags so that they are row ordered.
-class TagLayout::InRows < TagLayout
-  class_inheritable_reader :direction
-  write_inheritable_attribute(:direction, 'row')
+module TagLayout::InRows
+  extend self
+
+  def direction
+    'row'
+  end
 end

--- a/app/models/tag_layout/walk_wells_by_pools.rb
+++ b/app/models/tag_layout/walk_wells_by_pools.rb
@@ -1,0 +1,41 @@
+module TagLayout::WalkWellsByPools
+  def self.walking_by
+    'wells in pools'
+  end
+
+  def walking_by
+    TagLayout::WalkWellsByPools.walking_by
+  end
+
+  def walk_wells(&block)
+    # Adjust each of the groups so that any wells that are in the same pool as those at the same position
+    # in the group to the left are moved to a non-clashing position.  Effectively this makes the view of the
+    # plate slightly jagged.
+    group_size      = direction.to_sym == :column ? Map.plate_length(plate.size) : Map.plate_width(plate.size)
+    wells_in_groups = plate.wells.send(:"in_#{direction}_major_order").with_pool_id.in_groups_of(group_size).map do |wells|
+      wells.map { |well| [ well, well.pool_id ] }
+    end
+    wells_in_groups.each_with_index do |current_group, group|
+      next if group == 0
+      prior_group = wells_in_groups[group-1]
+
+      current_group.each_with_index do |well_and_pool, index|
+        break if prior_group.size <= index
+
+        # Assume that, if the current well isn't in a pool, that it is in the same pool as the well prior
+        # to it in the group.  That way empty wells are treated as though they are part of the pool.
+        well_and_pool[-1] ||= (index.zero? ? prior_group.last : current_group[index-1]).last
+        next unless prior_group[index].last == well_and_pool.last
+
+        current_group.push(well_and_pool)                # Move the well to the end of the group
+        current_group[index] = [nil, well_and_pool.last] # Blank out the well at the current position but maintain the pool
+      end
+    end
+
+    # Now we can walk the wells in the groups, skipping any that have been nil'd by the above code.
+    wells_in_groups.each do |group|
+      group.each_with_index { |(well, _), index| yield(well, index) unless well.nil? }
+    end
+  end
+  private :walk_wells
+end

--- a/app/models/tag_layout/walk_wells_of_plate.rb
+++ b/app/models/tag_layout/walk_wells_of_plate.rb
@@ -1,0 +1,16 @@
+module TagLayout::WalkWellsOfPlate
+  def self.walking_by
+    'wells of plate'
+  end
+
+  def walking_by
+    TagLayout::WalkWellsOfPlate.walking_by
+  end
+
+  def walk_wells(&block)
+    plate.wells.send(:"in_#{direction}_major_order").each_with_index do |well, index|
+      yield(well, index) unless well.nil?
+    end
+  end
+  private :walk_wells
+end

--- a/app/models/tag_layout_template.rb
+++ b/app/models/tag_layout_template.rb
@@ -9,17 +9,33 @@ class TagLayoutTemplate < ActiveRecord::Base
   validates_presence_of :name
   validates_uniqueness_of :name
 
-  validates_presence_of :layout_class_name
+  validates_presence_of :direction_algorithm
+  validates_presence_of :walking_algorithm
 
-  delegate :direction, :to => :layout_class
+  delegate :direction, :to => :direction_algorithm_class
+  delegate :walking_by, :to => :walking_algorithm_class
 
-  def layout_class
-    layout_class_name.constantize
+  def direction_algorithm_class
+    direction_algorithm.constantize
   end
-  private :layout_class
+  private :direction_algorithm_class
+
+  def walking_algorithm_class
+    walking_algorithm.constantize
+  end
+  private :walking_algorithm_class
+
+  def tag_layout_attributes
+    {
+      :tag_group => tag_group,
+      :direction_algorithm => direction_algorithm,
+      :walking_algorithm => walking_algorithm
+    }
+  end
+  private :tag_layout_attributes
 
   # Create a TagLayout instance that does the actual work of laying out the tags.
   def create!(attributes = {}, &block)
-    layout_class.create!(attributes.merge(:tag_group => tag_group), &block)
+    TagLayout.create!(attributes.merge(tag_layout_attributes), &block)
   end
 end

--- a/db/migrate/20120111142240_swap_tag_layout_template_to_use_dci.rb
+++ b/db/migrate/20120111142240_swap_tag_layout_template_to_use_dci.rb
@@ -1,0 +1,16 @@
+class SwapTagLayoutTemplateToUseDci < ActiveRecord::Migration
+  def self.up
+    alter_table :tag_layout_templates do
+      rename_column :layout_class_name, :direction_algorithm, :string
+      add_column :walking_algorithm, :string, :default => 'TagLayout::WalkWellsByPools'
+    end
+    alter_table :tag_layouts do
+      rename_column :sti_type, :direction_algorithm, :string
+      add_column :walking_algorithm, :string, :default => 'TagLayout::WalkWellsByPools'
+    end
+  end
+
+  def self.down
+    raise ActiveRecord::IrreversibleMigration, "Because typing is not backwards compatible"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111206152534) do
+ActiveRecord::Schema.define(:version => 20120111142240) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -1183,21 +1183,23 @@ ActiveRecord::Schema.define(:version => 20111206152534) do
   add_index "tag_groups", ["name"], :name => "tag_groups_unique_name", :unique => true
 
   create_table "tag_layout_templates", :force => true do |t|
-    t.string   "layout_class_name"
+    t.string   "direction_algorithm"
     t.integer  "tag_group_id"
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "walking_algorithm",   :default => "TagLayout::WalkWellsByPools"
   end
 
   create_table "tag_layouts", :force => true do |t|
-    t.string   "sti_type"
+    t.string   "direction_algorithm"
     t.integer  "tag_group_id"
     t.integer  "plate_id"
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "substitutions"
+    t.string   "walking_algorithm",   :default => "TagLayout::WalkWellsByPools"
   end
 
   create_table "tags", :force => true do |t|

--- a/db/seeds/0016_tag_layout_templates.rb
+++ b/db/seeds/0016_tag_layout_templates.rb
@@ -1,14 +1,16 @@
 ActiveRecord::Base.transaction do
   TagGroup.find_each do |tag_group|
     TagLayoutTemplate.create!(
-      :name              => "#{tag_group.name} in column major order",
-      :tag_group         => tag_group,
-      :layout_class_name => 'TagLayout::InColumns'
+      :name                => "#{tag_group.name} in column major order",
+      :tag_group           => tag_group,
+      :direction_algorithm => 'TagLayout::InColumns',
+      :walking_algorithm   => 'TagLayout::WalkWellsByPools'
     )
     TagLayoutTemplate.create!(
-      :name              => "#{tag_group.name} in row major order",
-      :tag_group         => tag_group,
-      :layout_class_name => 'TagLayout::InRows'
+      :name                => "#{tag_group.name} in row major order",
+      :tag_group           => tag_group,
+      :direction_algorithm => 'TagLayout::InRows',
+      :walking_algorithm   => 'TagLayout::WalkWellsByPools'
     )
   end
 end

--- a/db/seeds/9999_pulldown_setup.rb
+++ b/db/seeds/9999_pulldown_setup.rb
@@ -23,12 +23,14 @@ if ENV['PULLDOWN']
     TagLayoutTemplate.create!(
       :name => 'Pulldown test 96 template',
       :tag_group => TagGroup.create!(:name => 'Pulldown 96 tags').tap { |g| g.tags << (1..96).map { |i| Tag.create!(:map_id => (g.id*100)+i, :oligo => "ACGT#{i}") } },
-      :layout_class_name => 'TagLayout::InColumns'
+      :direction_algorithm => 'TagLayout::InColumns',
+      :walking_algorithm => 'TagLayout::WalkWellsOfPlate'
     )
     TagLayoutTemplate.create!(
       :name => 'Pulldown test 8 template (in columns)',
       :tag_group => TagGroup.create!(:name => 'Pulldown 8 tags').tap { |g| g.tags << (1..8).map { |i| Tag.create!(:map_id => (g.id*100)+i, :oligo => "ACGT#{i}") } },
-      :layout_class_name => 'TagLayout::InColumns'
+      :direction_algorithm => 'TagLayout::InColumns',
+      :walking_algorithm => 'TagLayout::WalkWellsByPools'
     )
 
     # Rubbish data we need

--- a/features/api/tag_layout_templates.feature
+++ b/features/api/tag_layout_templates.feature
@@ -38,6 +38,7 @@ Feature: Access tag layout templates through the API
           "uuid": "00000000-1111-2222-3333-444444444444",
           "name": "Test tag layout",
           "direction": "column",
+          "walking_by": "wells in pools",
 
           "tag_group": {
             "name": "Tag group 1",
@@ -219,10 +220,63 @@ Feature: Access tag layout templates through the API
       | H12  | CCGG |
 
   @tag_layout @create @barcode-service
+  Scenario: Creating a tag layout from a tag layout template which ignores pools
+    Given the plate barcode webservice returns "1000001..1000002"
+
+    Given the entire plate tag layout template "Test tag layout" exists
+      And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
+      And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
+      And the tag group for tag layout template "Test tag layout" has tags 1..96
+      And the UUID of the next tag layout created will be "00000000-1111-2222-3333-000000000002"
+
+    Given a "Stock plate" plate called "Testing the API" exists
+      And the UUID for the plate "Testing the API" is "11111111-2222-3333-4444-000000000002"
+      And all wells on the plate "Testing the API" have unique samples
+
+    Given a "Stock plate" plate called "Testing the tagging" exists
+      And the UUID for the plate "Testing the tagging" is "11111111-2222-3333-4444-000000000001"
+      And the wells for the plate "Testing the API" have been pooled in columns to the plate "Testing the tagging"
+
+    When I make an authorised POST with the following JSON to the API path "/00000000-1111-2222-3333-444444444444":
+      """
+      {
+        "tag_layout": {
+          "plate": "11111111-2222-3333-4444-000000000001"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "tag_layout": {
+          "actions": {
+            "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+          },
+          "plate": {
+            "actions": {
+              "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+            }
+          },
+
+          "uuid": "00000000-1111-2222-3333-000000000002",
+          "direction": "column",
+          "walking_by": "wells of plate",
+
+          "tag_group": {
+            "name": "Tag group 1"
+          }
+        }
+      }
+      """
+
+    Then the tags assigned to the plate "Testing the tagging" should be 1..96 for wells "A1-H12"
+
+  @tag_layout @create @barcode-service
   Scenario: Creating a tag layout from a tag layout template where wells have been failed
     Given the plate barcode webservice returns "1000001..1000002"
 
-    Given the column order tag layout template "Test tag layout" exists
+    Given the tag layout template "Test tag layout" exists
       And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
       And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
       And the tag group for tag layout template "Test tag layout" contains the following tags:
@@ -745,7 +799,7 @@ Feature: Access tag layout templates through the API
   Scenario: Creating a tag layout where the pools are factors of the number of rows on the plate
     Given the plate barcode webservice returns "1000001..1000002"
 
-    Given the column order tag layout template "Test tag layout" exists
+    Given the tag layout template "Test tag layout" exists
       And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
       And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
       And the tag group for tag layout template "Test tag layout" contains the following tags:
@@ -916,7 +970,7 @@ Feature: Access tag layout templates through the API
   Scenario: Creating a tag layout where the pools are awkwardly sized and cause overlaps
     Given the plate barcode webservice returns "1000001..1000002"
 
-    Given the column order tag layout template "Test tag layout" exists
+    Given the tag layout template "Test tag layout" exists
       And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
       And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
       And the tag group for tag layout template "Test tag layout" contains the following tags:
@@ -1087,7 +1141,7 @@ Feature: Access tag layout templates through the API
   Scenario: Creating a tag layout of an entire plate using 96 tags
     Given the plate barcode webservice returns "1000001..1000002"
 
-    Given the column order tag layout template "Test tag layout" exists
+    Given the tag layout template "Test tag layout" exists
       And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
       And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
       And the tag group for tag layout template "Test tag layout" has 96 tags
@@ -1214,7 +1268,7 @@ Feature: Access tag layout templates through the API
   Scenario: Creating a tag layout where one of the wells is empty
     Given the plate barcode webservice returns "1000001..1000002"
 
-    Given the column order tag layout template "Test tag layout" exists
+    Given the tag layout template "Test tag layout" exists
       And the UUID for the tag layout template "Test tag layout" is "00000000-1111-2222-3333-444444444444"
       And the tag group for tag layout template "Test tag layout" is called "Tag group 1"
       And the tag group for tag layout template "Test tag layout" has 96 tags

--- a/features/api/tag_layouts.feature
+++ b/features/api/tag_layouts.feature
@@ -39,6 +39,7 @@ Feature: Access tag layouts through the API
 
           "uuid": "00000000-1111-2222-3333-444444444444",
           "direction": "column",
+          "walking_by": "wells in pools",
 
           "tag_group": {
             "name": "Tag group 1",

--- a/features/step_definitions/pulldown_steps.rb
+++ b/features/step_definitions/pulldown_steps.rb
@@ -16,9 +16,29 @@ class WellRange
   end
 
   def include?(well)
-    well_match = WELL_REGEXP.match(well.map.description)
-    @rows.include?(well_match[1]) and @columns.include?(well_match[2].to_i)
+		include_well_location?(well.map.description)
   end
+
+	def include_well_location?(location)
+    well_match = WELL_REGEXP.match(location)
+    @rows.include?(well_match[1]) and @columns.include?(well_match[2].to_i)
+	end
+	private :include_well_location?
+
+	def to_a(&block)
+		[].tap do |wells|
+			(1..12).each do |column|
+				('A'..'H').each do |row|
+					well = "#{row}#{column}"
+					wells << well if include_well_location?(well)
+				end
+			end
+		end
+	end
+
+	def size
+		to_a.size
+	end
 end
 
 Transform /^([A-H]\d+)-([A-H]\d+)$/ do |start, finish|

--- a/test/factories/pulldown_factories.rb
+++ b/test/factories/pulldown_factories.rb
@@ -68,18 +68,27 @@ end
 
 # Tag layouts and their templates
 Factory.define(:tag_layout_template) do |tag_layout_template|
-  tag_layout_template.layout_class_name 'TagLayout::ByPools'
+  tag_layout_template.direction_algorithm 'TagLayout::InColumns'
+  tag_layout_template.walking_algorithm   'TagLayout::WalkWellsByPools'
   tag_layout_template.tag_group { |target| target.association(:tag_group_for_layout) }
 end
-Factory.define(:column_order_tag_layout_template, :class => TagLayoutTemplate) do |tag_layout_template|
-  tag_layout_template.layout_class_name 'TagLayout::InColumns'
+Factory.define(:entire_plate_tag_layout_template, :class => TagLayoutTemplate) do |tag_layout_template|
+  tag_layout_template.direction_algorithm 'TagLayout::InColumns'
+  tag_layout_template.walking_algorithm   'TagLayout::WalkWellsOfPlate'
   tag_layout_template.tag_group { |target| target.association(:tag_group_for_layout) }
 end
 
-Factory.define(:tag_layout, :class => TagLayout::InColumns) do |tag_layout|
+Factory.define(:tag_layout) do |tag_layout|
   tag_layout.user      { |target| target.association(:user) }
   tag_layout.plate     { |target| target.association(:full_plate_with_samples) }
   tag_layout.tag_group { |target| target.association(:tag_group_for_layout)    }
+
+  tag_layout.direction_algorithm 'TagLayout::InColumns'
+  tag_layout.walking_algorithm   'TagLayout::WalkWellsByPools'
+
+  # Factory girl builds things in bits, rather than all at once, so we need to trigger the after_initialize call
+  # after the instance has been built so that the correct behaviours are installed.
+  tag_layout.after_build { |tag_layout| tag_layout.after_initialize }
 end
 
 # Plate creations


### PR DESCRIPTION
This adds code that allows full plate tagging to be performed that
ignores the pools.  Where the existing code will restart each pool at
the first tag, this code puts each unique tag into a well on its own.
