### PR TITLE
[fixes #24161163] Add billing to pulldown requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "db-charmer"
 # 1.1 activated by rails
 #gem "rack", "~>1.2"
 
-gem "aasm", "2.1.5"
+gem "aasm", "~>2.4.0"
 gem "acts_as_audited"
 gem "ar-extensions"
 gem "configatron"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,8 @@ GEM
   remote: http://gems.github.com/
   specs:
     Platform (0.4.0)
-    aasm (2.1.5)
+    aasm (2.4.0)
+      activerecord
     actionmailer (2.3.11)
       actionpack (= 2.3.11)
     actionpack (2.3.11)
@@ -209,7 +210,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aasm (= 2.1.5)
+  aasm (~> 2.4.0)
   activemessaging
   activerecord-oracle_enhanced-adapter (= 1.2.3)
   acts-as-dag!

--- a/app/models/billing_event.rb
+++ b/app/models/billing_event.rb
@@ -24,48 +24,65 @@ class BillingEvent < ActiveRecord::Base
 #  validates_uniqueness_of :reference, :if => :charge?
 #  validates_uniqueness_of :reference, :if => :charge_internally? 
 
+  named_scope :charged_to_project, { :conditions => { :kind => 'charge' } }
+  named_scope :charged_internally, { :conditions => { :kind => 'charge_internally' } }
+  named_scope :refunded_to_project, { :conditions => { :kind => 'refund' } }
+  named_scope :for_reference, lambda { |reference| { :conditions => { :reference => reference } } }
+
   named_scope :related_to_reference, lambda { |reference| { :conditions => [ 'reference LIKE ?', "#{reference}%" ] } }
   named_scope :only_these_kinds, lambda { |*kinds| { :conditions => { :kind => kinds } } }
 
-  #uniqueness of [reference , kind] , validate_uniqueness doesn't work-> see "still test"
-  def validate
-      case
-      when charge?
-        match = self.class.charge_for_reference(self.reference)
-        if match and match != self
-          errors.add_to_base("Reference #{reference} as already a charge billing event")
-        end
-      when charge_internally?
-        match = self.class.charge_internally_for_reference(reference)
-        if match and match != self
-          errors.add_to_base("Reference #{reference} as already a charge_internally billing event")
-        end
-      end
-
+  def self.charge_for_reference(ref)
+    self.charged_to_project.for_reference(ref).first
   end
 
-  def before_validation_on_create #:nodoc:
-    self.entry_date = Time.now
-    if refund?
-      # Do not allow refunds for non-existent charges
-      matching_charge = BillingEvent.charge_for_reference(self.reference)
-      errors.add_to_base("billing_events.exceptions.uncharged_refund") if matching_charge.nil?
-      raise BillingException::UnchargedRefund.new(I18n.t("billing_events.exceptions.uncharged_refund")) if matching_charge.nil?
+  def self.charge_internally_for_reference(ref)
+    self.charged_internally.for_reference(ref).first
+  end
 
-      # Do not allow refunding more if all the refunds are in
-      if matching_charge.quantity_left_to_refund <= 0
-        errors.add_to_base("billing_events.exceptions.duplicate_refund")
-        raise BillingException::DuplicateRefund.new(I18n.t("billing_events.exceptions.duplicate_refund"))
-      end
+  def self.refunds_for_reference(ref)
+    self.refunded_to_project.for_reference(ref).all
+  end
 
-      # Do not allow refunding a quantity more than amount available to refund
-      if matching_charge.quantity_left_to_refund < self.quantity
-        errors.add_to_base("billing_events.exceptions.over_refund")
-        raise BillingException::OverRefund.new(I18n.t("billing_events.exceptions.over_refund",
-          :refunds => matching_charge.quantity_left_to_refund))
-      end
+  #uniqueness of [reference , kind] , validate_uniqueness doesn't work-> see "still test"
+  validate :unique_charge_reference, :if => :charge?
+  validate :unique_internal_charge_reference, :if => :charge_internally?
 
+  def unique_charge_reference
+    match = self.class.charge_for_reference(self.reference)
+    errors.add_to_base("Reference #{reference} as already a charge billing event") if match and match != self
+  end
+  private :unique_charge_reference
+
+  def unique_internal_charge_reference
+    match = self.class.charge_internally_for_reference(reference)
+    errors.add_to_base("Reference #{reference} as already a charge_internally billing event") if match and match != self
+  end
+  private :unique_internal_charge_reference
+
+  before_validation :prevent_invalid_refunds, :on => :create, :if => :refund?
+  def prevent_invalid_refunds
+    # Do not allow refunds for non-existent charges
+    matching_charge = BillingEvent.charge_for_reference(self.reference)
+    errors.add_to_base("billing_events.exceptions.uncharged_refund") if matching_charge.nil?
+    raise BillingException::UnchargedRefund.new(I18n.t("billing_events.exceptions.uncharged_refund")) if matching_charge.nil?
+
+    # Do not allow refunding more if all the refunds are in
+    if matching_charge.quantity_left_to_refund <= 0
+      errors.add_to_base("billing_events.exceptions.duplicate_refund")
+      raise BillingException::DuplicateRefund.new(I18n.t("billing_events.exceptions.duplicate_refund"))
     end
+
+    # Do not allow refunding a quantity more than amount available to refund
+    if matching_charge.quantity_left_to_refund < self.quantity
+      errors.add_to_base("billing_events.exceptions.over_refund")
+      raise BillingException::OverRefund.new(I18n.t("billing_events.exceptions.over_refund", :refunds => matching_charge.quantity_left_to_refund))
+    end
+  end
+  private :prevent_invalid_refunds
+
+  before_validation :on => :create do |record|
+    record.entry_date = Time.now
   end
 
   # charge? returns true if the BillingEvent is a charge (debit) made against the project.
@@ -83,16 +100,20 @@ class BillingEvent < ActiveRecord::Base
     self.kind == "refund"
   end
 
-  def self.charge_for_reference(ref)
-    BillingEvent.find_by_reference_and_kind(ref, "charge")
+  # quantity_refunded returns the number of refunds that a charge has received.
+  # It will return nil if called on a refund.
+  def quantity_refunded
+    return nil unless charge?
+    BillingEvent.refunded_to_project.for_reference(self.reference).sum(:quantity)
   end
 
-  def self.charge_internally_for_reference(ref)
-    BillingEvent.find_by_reference_and_kind(ref, "charge_internally")
-  end
-
-  def self.refunds_for_reference(ref)
-    BillingEvent.find_all_by_reference_and_kind(ref, "refund")
+  # quantity_left_to_refund returns the number of refunds that a charge can still accept.
+  # It will return nil if called on a refund.
+  def quantity_left_to_refund
+    return nil unless charge?
+    charged  = BillingEvent.charged_to_project.for_reference(self.reference).sum(:quantity)
+    refunded = BillingEvent.refunded_to_project.for_reference(self.reference).sum(:quantity)
+    charged - refunded
   end
 
   def self.build_reference(request, aliquot_info=nil)
@@ -107,114 +128,91 @@ class BillingEvent < ActiveRecord::Base
     reference
   end
 
-  def self.construct_from_request(kind, event_type, request, aliquot_info, entry_date=Time.now)
-    description = "#{request.request_type.name} #{event_type}"
-    #TODO create on event per Aliquot
-    project_id = aliquot_info.aliquot.try(:project_id)  || request.initial_project_id
+  class << self
+    def bill_projects_for(request)
+      map_for_each_aliquot(request) do |aliquot_info|
+        reference = self.build_reference(request, aliquot_info)
+        raise BillingException::DuplicateCharge if self.charge_for_reference(reference).present?
+        construct_from_request("charge", "passed", request, aliquot_info).tap do |billing_event|
+          billing_event.save!
+        end
+      end
+    end
+    alias_method(:generate_pass_event, :bill_projects_for)
 
-    self.new :kind => kind,
-      :reference => self.build_reference(request, aliquot_info),
-      :project_id => project_id,
-      :entry_date => entry_date,
-      :created_by => request.user ? request.user.name : "Unknown",
-      :description => description,
-      :quantity    => 1.0/aliquot_info.number,
-      :request    => request
-  end
+    def bill_internally_for(request)
+      map_for_each_aliquot(request) do |aliquot_info|
+        reference = self.build_reference(request, aliquot_info)
+        raise BillingException::DuplicateChargeInternally if self.charge_internally_for_reference(reference).present?
+        construct_internal_charge(request, aliquot_info, self.cancel_charged_event_by_reference(reference))
+      end
+    end
+    alias_method(:generate_fail_event, :bill_internally_for)
 
-  def self.map_for_each_aliquot(request, &block)
-    aliquots = request.asset.try(:aliquots)
-    aliquots = [nil]  if aliquots.blank?
-    number_of_aliquots = aliquots.size
-    aliquots.each_with_index.map do |a,i|
-      info = OpenStruct.new(:aliquot => a, :indice => i+1, :number => number_of_aliquots)
-      block.call(info)
+    def refund_projects_for(request)
+      map_for_each_aliquot(request) do |aliquot_info|
+        reference     = self.build_reference(request, aliquot_info)
+        charged_event = self.charge_for_reference(reference) or raise BillingException::IllegalRefund
+        construct_internal_charge(request, aliquot_info, construct_refund(charged_event))
+      end
+    end
+
+    def cancel_charged_event_by_reference(reference)
+      construct_refund(BillingEvent.charge_for_reference(reference))
+    end
+
+    def change_decision_refund(reference, description, user)
+      construct_refund(BillingEvent.charge_for_reference(reference)) do |billing_event|
+        billing_event.description = description
+        billing_event.created_by  = user
+      end
     end
   end
 
-  def self.generate_pass_event(request)
-    map_for_each_aliquot(request) do |aliquot_info|
-      reference = BillingEvent.build_reference(request, aliquot_info)
+  class << self
+    def construct_from_request(kind, event_type, request, aliquot_info, entry_date=Time.now)
+      description = "#{request.request_type.name} #{event_type}"
+      #TODO create on event per Aliquot
+      project_id = aliquot_info.aliquot.try(:project_id)  || request.initial_project_id
 
-      #check if  a billing event already exist
-      matching_event = BillingEvent.charge_for_reference(reference)
-      raise BillingException::DuplicateCharge if matching_event
-
-      b = construct_from_request("charge", "passed", request, aliquot_info)
-      b.save!
-      b
+      self.new :kind => kind,
+        :reference => self.build_reference(request, aliquot_info),
+        :project_id => project_id,
+        :entry_date => entry_date,
+        :created_by => request.user ? request.user.name : "Unknown",
+        :description => description,
+        :quantity    => 1.0/aliquot_info.number,
+        :request    => request
     end
-  end
+    private :construct_from_request
 
-  def self.generate_fail_event(request)
-    map_for_each_aliquot(request) do |aliquot_info|
-      reference = BillingEvent.build_reference(request, aliquot_info)
-
-      charged_event = BillingEvent.charge_for_reference(reference)
-      refund = BillingEvent.cancel_charged_event_by_reference(reference)
-      matching_event = BillingEvent.charge_internally_for_reference(reference)
-      raise BillingException::DuplicateChargeInternally if matching_event
-      b = construct_from_request("charge_internally", "failed", request, aliquot_info)
-      b.quantity = refund.quantity if refund
-      b.save!
-      b
+    def map_for_each_aliquot(request, &block)
+      aliquots = request.asset.try(:aliquots)
+      aliquots = [nil]  if aliquots.blank?
+      number_of_aliquots = aliquots.size
+      aliquots.each_with_index.map do |a,i|
+        info = OpenStruct.new(:aliquot => a, :indice => i+1, :number => number_of_aliquots)
+        block.call(info)
+      end
     end
-  end
+    private :map_for_each_aliquot
 
-  def self.cancel_charged_event_by_reference(reference)
-    charged_event = BillingEvent.charge_for_reference(reference)
-
-    if charged_event
-      #copy the attributes of event to cancel
-      attributes = charged_event.attributes
-      attributes["kind"] = "refund"
-      attributes["entry_date"] = Time.now
-      quantity = charged_event.quantity_left_to_refund
-      attributes["quantity"] = quantity
-
-      refund = BillingEvent.create attributes
+    def construct_internal_charge(request, aliquot_info, refund)
+      construct_from_request("charge_internally", "failed", request, aliquot_info).tap do |billing_event|
+        billing_event.quantity = refund.quantity if refund.present?
+        billing_event.save!
+      end
     end
-  end
- 
-  def self.change_decision_refund(reference, description, user)
-    charged_event = BillingEvent.charge_for_reference(reference)
+    private :construct_internal_charge
 
-    if charged_event
-      #copy the attributes of event to cancel
-      attributes = charged_event.attributes
-      attributes["kind"] = "refund"
-      attributes["entry_date"] = Time.now
-      quantity = charged_event.quantity_left_to_refund
-      attributes["quantity"] = quantity
-      attributes["description"] = description
-      attributes["created_by"] = user
-
-      refund = BillingEvent.create attributes
+    def construct_refund(charged_event, &block)
+      return nil if charged_event.nil?
+      self.create(charged_event.attributes.merge(
+        'kind'       => 'refund',
+        'entry_date' => Time.now,
+        'quantity'   => charged_event.quantity_left_to_refund
+      ), &block)
     end
+    private :construct_refund
   end
-
-  # quantity_refunded returns the number of refunds that a charge has received.
-  # It will return nil if called on a refund.
-  def quantity_refunded
-    if charge?
-      BillingEvent.refunds_for_reference(self.reference)
-      refunds_made = BillingEvent.sum('quantity', :conditions => {:reference => self.reference, :kind => "refund"})
-    else
-      nil
-    end
-  end
-
-  # quantity_left_to_refund returns the number of refunds that a charge can still accept.
-  # It will return nil if called on a refund.
-  def quantity_left_to_refund
-    if charge?
-      BillingEvent.refunds_for_reference(self.reference)
-      initially_charged = BillingEvent.charge_for_reference(self.reference).quantity
-      refunds_made = BillingEvent.sum('quantity', :conditions => {:reference => self.reference, :kind => "refund"})
-      initially_charged - refunds_made
-    else
-      nil
-    end
-  end
-
 end

--- a/app/models/billing_exception.rb
+++ b/app/models/billing_exception.rb
@@ -17,5 +17,7 @@ module BillingException
   end                                     
 #rescue BillingException::DuplicateCharge => exception  
 #rescue BillingException::Base => exception 
+
+  IllegalRefund = Class.new(Base)
 end
 

--- a/app/models/multiplexed_library_tube.rb
+++ b/app/models/multiplexed_library_tube.rb
@@ -13,13 +13,16 @@ class MultiplexedLibraryTube < Tube
     requests_as_target.where_is_a?(TransferRequest).all
   end
 
+  STATE_TO_STATEMACHINE_EVENT = { 'started' => 'start!', 'passed' => 'pass!', 'failed' => 'fail!', 'cancelled' => 'cancel!' }
+
   # Transitioning an MX library tube to a state involves updating the state of the transfer requests.  If the
   # state is anything but "started" or "pending" then the pulldown library creation request should also be
   # set to the same state
   def transition_to(state, _ = nil)
     update_all_requests = ![ 'started', 'pending' ].include?(state)
+    event               = STATE_TO_STATEMACHINE_EVENT[state] or raise StandardError, "Illegal state #{state.inspect}"
     requests_as_target.each do |request|
-      request.update_attributes!(:state => state) if update_all_requests or request.is_a?(TransferRequest)
+      request.send(event) if update_all_requests or request.is_a?(TransferRequest)
     end
   end
 

--- a/app/models/pulldown/requests.rb
+++ b/app/models/pulldown/requests.rb
@@ -15,10 +15,28 @@ module Pulldown::Requests
     end
   end
 
+  # This is the billing strategy for the pulldown requests, which mimics the behaviour of the
+  # general billing behaviour.
+  module BillingStrategy
+    def charge_to_project
+      BillingEvent.bill_projects_for(self) if request_type.billable?
+    end
+
+    def charge_internally
+      BillingEvent.bill_internally_for(self) if request_type.billable?
+    end
+
+    def refund_project
+      BillingEvent.refund_projects_for(self) if request_type.billable?
+    end
+  end
+
   # Override the behaviour of Request so that we do not copy the aliquots from our source asset
   # to the target when we are passed.  This is actually done by the TransferRequest from plate
   # to plate as it goes through being processed.
   class LibraryCreation < Request
+    include BillingStrategy
+
     def on_started
       # Override the default behaviour to not do the transfer
     end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -36,6 +36,7 @@ class Request < ActiveRecord::Base
   has_many :quotas, :through => :request_quotas
 
   belongs_to :request_type
+  delegate :billable?, :to => :request_type, :allow_nil => true
   belongs_to :workflow, :class_name => "Submission::Workflow"
 
   belongs_to :user

--- a/app/models/request/billing_strategy.rb
+++ b/app/models/request/billing_strategy.rb
@@ -1,0 +1,19 @@
+# This is the billing standardised billing strategy, which actually does nothing because all of that
+# is handled externally to most request types.  However, if you have request classes that need to do something
+# unusual (like Pulldown requests as they are not batched) then override these methods in your class.
+module Request::BillingStrategy
+  # This is called when the project should be billed for the request.
+  def charge_to_project
+
+  end
+
+  # This is called when the charge for the request should be absorbed internally.
+  def charge_internally
+
+  end
+
+  # This is called when the project should be refunded for this request.
+  def refund_project
+
+  end
+end

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -16,6 +16,10 @@ class RequestType < ActiveRecord::Base
   has_many :requests
   has_many :pipelines
 
+  # Couple of named scopes for finding billable types
+  named_scope :billable, { :conditions => { :billable => true } }
+  named_scope :non_billable, { :conditions => { :billable => false } }
+
   # Defines the acceptable plate purposes or the request type.  Essentially this is used to limit the
   # cherrypick plate types when going into pulldown to the correct list.
   has_many :plate_purposes, :class_name => 'RequestType::RequestTypePlatePurpose'

--- a/db/migrate/20120126111327_add_billable_to_request_types.rb
+++ b/db/migrate/20120126111327_add_billable_to_request_types.rb
@@ -1,0 +1,9 @@
+class AddBillableToRequestTypes < ActiveRecord::Migration
+  def self.up
+    add_column :request_types, :billable, :boolean, :default => false
+  end
+
+  def self.down
+    remove_column :request_types, :billable
+  end
+end

--- a/db/migrate/20120126111428_set_billable_information_for_request_types.rb
+++ b/db/migrate/20120126111428_set_billable_information_for_request_types.rb
@@ -1,0 +1,30 @@
+class SetBillableInformationForRequestTypes < ActiveRecord::Migration
+  class RequestType < ActiveRecord::Base
+    set_table_name(:request_types)
+  end
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      RequestType.update_all(
+        'billable = TRUE', [
+          '`key` IS NOT NULL AND `key` NOT IN (?)', [
+            # Sample logistics
+            'dna_qc',
+            'genotyping',
+            'cherrypick',
+            'cherrypick_for_pulldown',
+            'create_asset',
+
+            # PacBio
+            'pacbio_sample_prep',
+            'pacbio_sequencing'
+          ]
+        ]
+      )
+    end
+  end
+
+  def self.down
+    # Nothing to do as it will be dropped by the previous migration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120111142240) do
+ActiveRecord::Schema.define(:version => 20120126111428) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -783,6 +783,7 @@ ActiveRecord::Schema.define(:version => 20120111142240) do
     t.text     "request_parameters"
     t.integer  "morphology",                       :default => 0
     t.boolean  "for_multiplexing",                 :default => false
+    t.boolean  "billable",                         :default => false
   end
 
   create_table "requests", :force => true do |t|

--- a/db/seeds/0001_workflows.rb
+++ b/db/seeds/0001_workflows.rb
@@ -82,6 +82,7 @@ LibraryCreationPipeline.create!(:name => 'Library preparation') do |pipeline|
   pipeline.location = Location.first(:conditions => { :name => 'Library creation freezer' }) or raise StandardError, "Cannot find 'Library creation freezer' location"
 
   pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'library_creation', :name => 'Library creation') do |request_type|
+    request_type.billable          = true
     request_type.initial_state     = 'pending'
     request_type.asset_type        = 'SampleTube'
     request_type.order             = 1
@@ -117,6 +118,7 @@ MultiplexedLibraryCreationPipeline.create!(:name => 'MX Library Preparation [NEW
   pipeline.location = Location.first(:conditions => { :name => 'Library creation freezer' }) or raise StandardError, "Cannot find 'Library creation freezer' location"
 
   pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'multiplexed_library_creation', :name => 'Multiplexed library creation') do |request_type|
+    request_type.billable          = true
     request_type.initial_state     = 'pending'
     request_type.asset_type        = 'SampleTube'
     request_type.order             = 1
@@ -152,6 +154,7 @@ PulldownLibraryCreationPipeline.create!(:name => 'Pulldown library preparation')
   pipeline.location = Location.first(:conditions => { :name => 'Library creation freezer' }) or raise StandardError, "Cannot find 'Library creation freezer' location"
 
   pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'pulldown_library_creation', :name => 'Pulldown library creation') do |request_type|
+    request_type.billable          = true
     request_type.initial_state     = 'pending'
     request_type.asset_type        = 'SampleTube'
     request_type.order             = 1
@@ -176,6 +179,7 @@ PulldownLibraryCreationPipeline.create!(:name => 'Pulldown library preparation')
 end
 
 cluster_formation_se_request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'single_ended_sequencing', :name => 'Single ended sequencing') do |request_type|
+  request_type.billable          = true
   request_type.initial_state     = 'pending'
   request_type.asset_type        = 'LibraryTube'
   request_type.order             = 2
@@ -266,6 +270,7 @@ end.tap do |pipeline|
 end
 
 single_ended_hi_seq_sequencing = RequestType.create!(:workflow => next_gen_sequencing, :key => 'single_ended_hi_seq_sequencing', :name => 'Single ended hi seq sequencing') do |request_type|
+  request_type.billable          = true
   request_type.initial_state     = 'pending'
   request_type.asset_type        = 'LibraryTube'
   request_type.order             = 2
@@ -328,6 +333,7 @@ end.tap do |pipeline|
 end
 
 cluster_formation_pe_request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'paired_end_sequencing', :name => 'Paired end sequencing') do |request_type|
+  request_type.billable          = true
   request_type.initial_state     = 'pending'
   request_type.asset_type        = 'LibraryTube'
   request_type.order             = 2
@@ -480,6 +486,7 @@ SequencingPipeline.create!(:name => 'HiSeq Cluster formation PE (no controls)') 
   pipeline.location        = Location.first(:conditions => { :name => 'Cluster formation freezer' }) or raise StandardError, "Cannot find 'Cluster formation freezer' location"
 
   pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'hiseq_paired_end_sequencing', :name => 'HiSeq Paired end sequencing') do |request_type|
+    request_type.billable          = true
     request_type.initial_state     = 'pending'
     request_type.asset_type        = 'LibraryTube'
     request_type.order             = 2
@@ -639,6 +646,7 @@ PulldownMultiplexLibraryPreparationPipeline.create!(:name => 'Pulldown Multiplex
   pipeline.location = Location.first(:conditions => { :name => 'Pulldown freezer' }) or raise StandardError, "Cannot find 'Pulldown freezer' location"
 
   pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :key => 'pulldown_multiplexing', :name => 'Pulldown Multiplex Library Preparation') do |request_type|
+    request_type.billable          = true
     request_type.asset_type        = 'Well'
     request_type.target_asset_type = 'PulldownMultiplexedLibraryTube'
     request_type.order             = 1
@@ -741,6 +749,7 @@ set_pipeline_flow_to('PacBio Sample Prep' => 'PacBio Sequencing')
     pipeline.location   = Location.find_by_name('Pulldown freezer') or raise StandardError, "Pulldown freezer does not appear to exist!"
 
     pipeline.request_type = RequestType.create!(:workflow => next_gen_sequencing, :name => pipeline_name) do |request_type|
+      request_type.billable          = true
       request_type.key               = pipeline_name.downcase.gsub(/\s+/, '_')
       request_type.initial_state     = 'pending'
       request_type.asset_type        = 'Well'

--- a/features/api/pulldown/bottom_of_the_pipeline.feature
+++ b/features/api/pulldown/bottom_of_the_pipeline.feature
@@ -116,11 +116,11 @@ Feature: The bottom of the pulldown pipeline
 
     Then the state of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "started"
      And the state of all the transfer requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "started"
-     And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "pending"
+     And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "started"
 
     Then the state of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be "pending"
      And the state of all the transfer requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be "pending"
-     And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be "pending"
+     And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be "started"
 
     # Now passing should adjust the state of the pulldown library creation request
     Then log "Now passing should adjust the state of the pulldown library creation request" for debugging
@@ -151,6 +151,7 @@ Feature: The bottom of the pulldown pipeline
     Then the state of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "passed"
      And the state of all the transfer requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "passed"
      And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "passed"
+     And all of the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be billed to their project
 
     Scenarios:
       | pipeline     |

--- a/features/step_definitions/5600990_npg_xml_asset_qc_state_steps.rb
+++ b/features/step_definitions/5600990_npg_xml_asset_qc_state_steps.rb
@@ -16,7 +16,7 @@ end
 Given /^a billing event to the request$/ do
  lane = Lane.find_by_name("NPG_Action_Lane_Test")
  request = lane.source_request
- BillingEvent.map_for_each_aliquot(request) do |aliquot_info|
+ BillingEvent.send(:map_for_each_aliquot, request) do |aliquot_info|
    reference = BillingEvent.build_reference(request, aliquot_info)
    Factory :billing_event, :reference => reference,  :quantity => 1, :kind => "charge"
    Factory :billing_event, :reference => reference,  :quantity => 1, :kind => "refund"

--- a/test/factories/pulldown_factories.rb
+++ b/test/factories/pulldown_factories.rb
@@ -111,3 +111,42 @@ Factory.define(:plate_creation) do |plate_creation|
     plate_creation.child_plate_purpose  = PlatePurpose.find_by_name('Child plate purpose')  || Factory(:child_plate_purpose)
   end
 end
+
+Factory.define(:bait_library_supplier, :class => BaitLibrary::Supplier) do |supplier|
+  supplier.name 'bait library supplier'
+end
+Factory.define(:bait_library) do |bait_library|
+  bait_library.bait_library_supplier { |target| target.association(:bait_library_supplier) }
+  bait_library.name 'bait library!'
+  bait_library.target_species 'Human'
+end
+
+Factory.define(:pulldown_wgs_request, :class => Pulldown::Requests::WgsLibraryRequest) do |request|
+  request.request_type { |target| RequestType.find_by_name('Pulldown WGS') or raise StandardError, "Could not find 'Pulldown WGS' request type" }
+  request.asset        { |target| target.association(:well_with_sample_and_plate) }
+  request.target_asset { |target| target.association(:empty_well) }
+  request.after_build do |request|
+    request.request_metadata.fragment_size_required_from = 300
+    request.request_metadata.fragment_size_required_to   = 500
+  end
+end
+Factory.define(:pulldown_sc_request, :class => Pulldown::Requests::ScLibraryRequest) do |request|
+  request.request_type { |target| RequestType.find_by_name('Pulldown SC') or raise StandardError, "Could not find 'Pulldown SC' request type" }
+  request.asset        { |target| target.association(:well_with_sample_and_plate) }
+  request.target_asset { |target| target.association(:empty_well) }
+  request.after_build do |request|
+    request.request_metadata.fragment_size_required_from = 100
+    request.request_metadata.fragment_size_required_to   = 400
+    request.request_metadata.bait_library                = Factory(:bait_library)
+  end
+end
+Factory.define(:pulldown_isc_request, :class => Pulldown::Requests::IscLibraryRequest) do |request|
+  request.request_type { |target| RequestType.find_by_name('Pulldown ISC') or raise StandardError, "Could not find 'Pulldown ISC' request type" }
+  request.asset        { |target| target.association(:well_with_sample_and_plate) }
+  request.target_asset { |target| target.association(:empty_well) }
+  request.after_build do |request|
+    request.request_metadata.fragment_size_required_from = 100
+    request.request_metadata.fragment_size_required_to   = 400
+    request.request_metadata.bait_library                = Factory(:bait_library)
+  end
+end

--- a/test/unit/billing_event_test.rb
+++ b/test/unit/billing_event_test.rb
@@ -15,7 +15,7 @@ class BillingEventTest < ActiveSupport::TestCase
     # should_validate_uniqueness_of :reference
     should_allow_values_for :kind, "charge", "refund", "charge_internally"
 
-    should_validate_presence_of :kind, :entry_date, :reference
+    should_validate_presence_of :kind, :reference
     should_validate_presence_of :created_by
     should_validate_presence_of :project
     should_validate_presence_of :quantity
@@ -289,7 +289,7 @@ context "A request with no billing events and 2 aliquots " do
       BillingEvent.generate_pass_event @request
     end
     should "generate a charge event per aliquot" do
-      BillingEvent.map_for_each_aliquot(@request) do |ai|
+      BillingEvent.send(:map_for_each_aliquot, @request) do |ai|
         reference = BillingEvent.build_reference(@request, ai)
         event = BillingEvent.charge_for_reference(reference)
         assert event
@@ -305,7 +305,7 @@ context "A request with no billing events and 2 aliquots " do
       BillingEvent.generate_fail_event @request
     end
     should "generate a charge internally event" do
-      BillingEvent.map_for_each_aliquot(@request) do |ai|
+      BillingEvent.send(:map_for_each_aliquot, @request) do |ai|
         reference = BillingEvent.build_reference(@request, ai)
         assert_nil BillingEvent.charge_for_reference(reference)
         assert_equal [], BillingEvent.refunds_for_reference(reference)

--- a/test/unit/pulldown/requests_test.rb
+++ b/test/unit/pulldown/requests_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Pulldown::RequestsTest < ActiveSupport::TestCase
+  [ :wgs, :sc, :isc ].each do |request_type|
+    context request_type.to_s.upcase do
+      setup do
+        @request = Factory(:"pulldown_#{request_type}_request")
+        @request.asset.aliquots.each { |a| a.update_attributes!(:project => Factory(:project)) }
+      end
+
+      [ 'started', 'failed' ].each do |initial_state|
+        should "charge the project when being passed from #{initial_state}" do
+          @request.update_attributes!(:state => initial_state)
+          @request.pass!
+
+          assert_equal(1, BillingEvent.count, "Expected billing events")
+          assert_equal(1, BillingEvent.charged_to_project.count, "Expected the project to be charged")
+        end
+      end
+
+      should 'charge internally when failing from started' do
+        @request.update_attributes!(:state => 'started')
+        @request.fail!
+
+        assert_equal(1, BillingEvent.count, "Expected billing events")
+        assert_equal(1, BillingEvent.charged_internally.count, "Expected charge to be internal")
+      end
+
+      should 'refund the project when failing from passed' do
+        @request.start! # Start the request ...
+        @request.pass!  # ... so that the charges can be made against the project ...
+        @request.fail!  # ... in order to refund them!
+
+        assert_equal(3, BillingEvent.count, "Expected billing events")
+        assert_equal(1, BillingEvent.charged_to_project.count, "Expected the project to be charged")
+        assert_equal(1, BillingEvent.charged_internally.count, "Expected charge to be internal")
+        assert_equal(1, BillingEvent.refunded_to_project.count, "Expected project to be refunded")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The pulldown requests need to generate billing events based on state
transitions, as all requests should.  Add the concept of billable
request types so that this could be turned on or off for all requests if
that code was included.
