### PR TITLE
[fixes #24225869] Use plate_purpose to fix pending stock plates.

### DIFF
--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -31,8 +31,6 @@ class Plate < Asset
   def iteration
     return nil if parent.nil?  # No parent means no iteration, not a 0 iteration.
 
-    plate_classes = [ Plate, *Class.subclasses_of(Plate) ].map(&:name)
-
     # NOTE: This is how to do row numbering with MySQL!  It essentially joins the assets and asset_links
     # tables to find all of the child plates of our parent that have the same plate purpose, numbering
     # those rows to give the iteration number for each plate.


### PR DESCRIPTION
The only plates that can have no incoming requests and still be
considered pending are stock plates, so this query should check that the
plate is actually a stock.  This reduces the inbox for pulldown by about
15% that are incorrectly identified as such.
