### PR TITLE
24068307 bad request quotas records

### DIFF
--- a/db/migrate/20120127145549_remove_bad_records_in_request_quotas.rb
+++ b/db/migrate/20120127145549_remove_bad_records_in_request_quotas.rb
@@ -3,7 +3,9 @@ class RequestQuota < ActiveRecord::Base ; end
 
 class RemoveBadRecordsInRequestQuotas < ActiveRecord::Migration
   def self.up
-    ActiveRecord::Base.trascaction do
+    ActiveRecord::Base.transaction do
+      say 'Removing broken join records from request_quotas table...'
+
       bad_request_quotas = RequestQuota.find_by_sql(<<END_OF_SQL
 select request_quotas.*, requests.id as missing_id
 from request_quotas

--- a/db/migrate/20120131140718_add_request_quota_constraints.rb
+++ b/db/migrate/20120131140718_add_request_quota_constraints.rb
@@ -1,0 +1,21 @@
+class RequestQuota < ActiveRecord::Base ; end
+
+class AddRequestQuotaConstraints < ActiveRecord::Migration
+  def self.up
+    ActiveRecord::Base.transaction do
+      say 'Applying null constraints to the request_quotas table...'
+
+      connection.execute('alter table request_quotas modify column request_id int(11) not null;')
+
+      connection.execute('alter table request_quotas modify column quota_id int(11) not null;')
+
+      say 'Applying foreign key constraints to the request_quotas table...'
+      connection.execute('alter table request_quotas add constraint foreign key fk_request_quotas_to_quotas (quota_id) references quotas (id);')
+
+      connection.execute('alter table request_quotas add constraint foreign key fk_request_quotas_to_requests (request_id) references requests(id);')
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
This is two data migrations.  The first removes records from the quota_requests join table for which the are no corresponding requests.

The second migration adds null and foreign key constraints.
