### PR TITLE
[fixes #24424013] Force non-readonly for pulldown pooling.

### DIFF
--- a/app/api/core/service/error_handling.rb
+++ b/app/api/core/service/error_handling.rb
@@ -87,6 +87,11 @@ class ActiveRecord::ConfigurationError
   self.api_error_code = 500
 end
 
+class ActiveRecord::ReadOnlyRecord
+  include ::Core::Service::Error::Behaviour
+  self.api_error_code = 500
+end
+
 class ActiveRecord::RecordInvalid
   def api_error(response)
     io_handler = ::Core::Io::Registry.instance.lookup_for_object(self.record)

--- a/app/models/plate_purpose.rb
+++ b/app/models/plate_purpose.rb
@@ -53,7 +53,7 @@ class PlatePurpose < ActiveRecord::Base
   end
 
   def pool_wells(wells)
-    _pool_wells(wells).all(:select => 'assets.*, submission_id AS pool_id').tap do |wells_with_pool|
+    _pool_wells(wells).all(:select => 'assets.*, submission_id AS pool_id', :readonly => false).tap do |wells_with_pool|
       raise StandardError, "Cannot deal with a well in multiple pools" if wells_with_pool.group_by(&:id).any? { |_, multiple_pools| multiple_pools.uniq.size > 1 }
     end
   end


### PR DESCRIPTION
The change to the pooling strategy for Pulldown combines a JOIN with a
SELECT of specific fields, which forces ActiveRecord to use
':readonly => true'.  This then breaks the creation of the transfers, so
use ':readonly => false' to force the correct behaviour.
