### PR TITLE
24567269 insert size labels missing for pulldown requests

### DIFF
--- a/app/models/attributable.rb
+++ b/app/models/attributable.rb
@@ -49,9 +49,10 @@ module Attributable
   end
 
   module ClassMethods
-    def attribute(name, options = {})
+    def attribute(name, options = {}, override_previous = false)
       attribute = Attribute.new(self, name, options)
       attribute.configure(self)
+      attribute_details.delete_if { |a| a.name == name } if override_previous
       attribute_details.push(attribute)
     end
     

--- a/app/models/pulldown/requests.rb
+++ b/app/models/pulldown/requests.rb
@@ -46,12 +46,13 @@ module Pulldown::Requests
     # that here.
     def self.fragment_size_details(minimum, maximum)
       class_eval do
+        include Request::LibraryManufacture
+
         has_metadata :as => Request do
           # Redefine the fragment size attributes as they are fixed
-          attribute(:fragment_size_required_from, :required => true, :default => minimum, :integer => true)
-          attribute(:fragment_size_required_to,   :required => true, :default => maximum, :integer => true)
+          attribute(:fragment_size_required_from, { :required => true, :default => minimum, :integer => true }, :override_library_manufacture)
+          attribute(:fragment_size_required_to,   { :required => true, :default => maximum, :integer => true }, :override_library_manufacture)
         end
-        include Request::LibraryManufacture
       end
       const_get(:Metadata).class_eval do
         def fragment_size_required_from

--- a/app/models/request/library_manufacture.rb
+++ b/app/models/request/library_manufacture.rb
@@ -6,7 +6,7 @@ module Request::LibraryManufacture
       attribute(:fragment_size_required_from, :required => true, :integer => true)
       attribute(:fragment_size_required_to,   :required => true, :integer => true)
 
-      attribute(:library_type,                :in => base::LIBRARY_TYPES, :default => base::DEFAULT_LIBRARY_TYPE, :required => true)
+      attribute(:library_type, { :in => base::LIBRARY_TYPES, :default => base::DEFAULT_LIBRARY_TYPE, :required => true }, :override_previous_value)
     end
 
     base.class_eval do

--- a/config/locales/metadata/en.yml
+++ b/config/locales/metadata/en.yml
@@ -51,6 +51,15 @@ en:
     pulldown_library_creation:
       <<: *REQUEST
 
+    pulldown:
+      requests:
+        wgs_library_request:
+          <<: *REQUEST
+        sc_library_request:
+          <<: *REQUEST
+        isc_library_request:
+          <<: *REQUEST
+
     sample:
       metadata:
         organism:


### PR DESCRIPTION
Missing a couple of pieces of text for the fragment size labels in
pulldown & removed the duplication of this information by allowing
attributes to override previous settings.
