### PR TITLE
24572723 insert size change breaks cherrypicking

### DIFF
--- a/app/api/model_extensions/order.rb
+++ b/app/api/model_extensions/order.rb
@@ -127,13 +127,15 @@ module ModelExtensions::Order
   def request_options_structured=(values)
     @request_options_structured = NonNilHash.new.tap do |attributes|
       NonNilHash.new(:stringify_keys).deep_merge(values).tap do |json|
-        attributes[:read_length]                 = json['read_length']
-        attributes[:library_type]                = json['library_type']
-        attributes[:fragment_size_required_from] = json['fragment_size_required', 'from']
-        attributes[:fragment_size_required_to]   = json['fragment_size_required', 'to']
-        attributes[:bait_library_name]           = json['bait_library']
-        attributes[:sequencing_type]             = json['sequencing_type']
-        attributes[:insert_size]                 = json['insert_size']
+        # NOTE: Be careful with the names here to ensure that they match up, exactly with what is in a template.
+        # If the template uses symbol names then these need to be symbols too.
+        attributes[:read_length]                  = json['read_length']
+        attributes['library_type']                = json['library_type']
+        attributes['fragment_size_required_from'] = json['fragment_size_required', 'from']
+        attributes['fragment_size_required_to']   = json['fragment_size_required', 'to']
+        attributes[:bait_library_name]            = json['bait_library']
+        attributes[:sequencing_type]              = json['sequencing_type']
+        attributes[:insert_size]                  = json['insert_size']
         request_type_multiplier { |id| attributes[:multiplier, id] = json['number_of_lanes'] }
       end
     end.to_hash

--- a/app/models/attributable.rb
+++ b/app/models/attributable.rb
@@ -52,8 +52,13 @@ module Attributable
     def attribute(name, options = {}, override_previous = false)
       attribute = Attribute.new(self, name, options)
       attribute.configure(self)
-      attribute_details.delete_if { |a| a.name == name } if override_previous
-      attribute_details.push(attribute)
+
+      if override_previous
+        attribute_details.delete_if { |a| a.name == name }
+        attribute_details.push(attribute)
+      elsif attribute_details.detect { |a| a.name == name }.nil?
+        attribute_details.push(attribute)
+      end
     end
     
     def association(name, instance_method, options = {})

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -175,11 +175,11 @@ class BulkSubmission < ActiveRecord::Base
         }
       }
       
-      attributes[:request_options][:library_type]                  = details['library type']       unless details['library type'].blank?
-      attributes[:request_options][:fragment_size_required_from]   = details['fragment size from'] unless details['fragment size from'].blank?
-      attributes[:request_options][:fragment_size_required_to]     = details['fragment size to']   unless details['fragment size to'].blank?
-      attributes[:request_options][:bait_library_name]             = details['bait library name']  unless details['bait library name'].blank?
-      attributes[:request_options][:bait_library_name]           ||= details['bait library']       unless details['bait library'].blank?
+      attributes[:request_options]['library_type']                  = details['library type']       unless details['library type'].blank?
+      attributes[:request_options]['fragment_size_required_from']   = details['fragment size from'] unless details['fragment size from'].blank?
+      attributes[:request_options]['fragment_size_required_to']     = details['fragment size to']   unless details['fragment size to'].blank?
+      attributes[:request_options][:bait_library_name]              = details['bait library name']  unless details['bait library name'].blank?
+      attributes[:request_options][:bait_library_name]            ||= details['bait library']       unless details['bait library'].blank?
 
       # Deal with the asset group: either it's one we should be loading, or one we should be creating.
       begin

--- a/app/models/pulldown/requests.rb
+++ b/app/models/pulldown/requests.rb
@@ -46,13 +46,13 @@ module Pulldown::Requests
     # that here.
     def self.fragment_size_details(minimum, maximum)
       class_eval do
-        include Request::LibraryManufacture
-
         has_metadata :as => Request do
           # Redefine the fragment size attributes as they are fixed
-          attribute(:fragment_size_required_from, { :required => true, :default => minimum, :integer => true }, :override_library_manufacture)
-          attribute(:fragment_size_required_to,   { :required => true, :default => maximum, :integer => true }, :override_library_manufacture)
+          attribute(:fragment_size_required_from, { :required => true, :default => minimum, :integer => true })
+          attribute(:fragment_size_required_to,   { :required => true, :default => maximum, :integer => true })
         end
+
+        include Request::LibraryManufacture
       end
       const_get(:Metadata).class_eval do
         def fragment_size_required_from

--- a/app/models/request/library_manufacture.rb
+++ b/app/models/request/library_manufacture.rb
@@ -6,7 +6,7 @@ module Request::LibraryManufacture
       attribute(:fragment_size_required_from, :required => true, :integer => true)
       attribute(:fragment_size_required_to,   :required => true, :integer => true)
 
-      attribute(:library_type, { :in => base::LIBRARY_TYPES, :default => base::DEFAULT_LIBRARY_TYPE, :required => true }, :override_previous_value)
+      attribute(:library_type, { :in => base::LIBRARY_TYPES, :default => base::DEFAULT_LIBRARY_TYPE, :required => true })
     end
 
     base.class_eval do

--- a/db/seeds/0007_submission_templates.rb
+++ b/db/seeds/0007_submission_templates.rb
@@ -22,9 +22,9 @@ def create_pulldown_submission_templates
   ]
 
   request_types_to_defaults = {
-    'Pulldown WGS' => { :library_type => 'Standard',         :fragment_size_required_from => 300, :fragment_size_required_to => 500 },
-    'Pulldown SC'  => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 },
-    'Pulldown ISC' => { :library_type => 'Agilent Pulldown', :fragment_size_required_from => 100, :fragment_size_required_to => 400 }
+    'Pulldown WGS' => { 'library_type' => 'Standard',         'fragment_size_required_from' => 300, 'fragment_size_required_to' => 500 },
+    'Pulldown SC'  => { 'library_type' => 'Agilent Pulldown', 'fragment_size_required_from' => 100, 'fragment_size_required_to' => 400 },
+    'Pulldown ISC' => { 'library_type' => 'Agilent Pulldown', 'fragment_size_required_from' => 100, 'fragment_size_required_to' => 400 }
   }
 
   workflow   = Submission::Workflow.find_by_key('short_read_sequencing') or raise StandardError, 'Cannot find Next-gen sequencing workflow'


### PR DESCRIPTION
Ensure that the attribute names in the submission templates match those
from form parameters, i.e. they are strings.  This then prevents the
duplication of the values when people enter something different.

Then we need to ensure that if attributable classes override behaviour
that they must force it to happen, this ensures that the fixed fragment
size information for pulldown requests comes in correctly.
