### PR TITLE
24143133 start cherrypicking batch needs to be done as a transaction

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -152,7 +152,7 @@ class WorkflowsController < ApplicationController
     @rits = @batch.pipeline.request_information_types
     @requests = @batch.ordered_requests
     @requests_by_submission = @requests.group_by(&:submission)
-    @batch.start!(current_user) unless @batch.started? or @batch.failed?
+    ActiveRecord::Base.transaction { @batch.start!(current_user) } unless @batch.started? or @batch.failed?
 
     @workflow = LabInterface::Workflow.find(params[:workflow_id], :include => [:tasks])
     @task = task


### PR DESCRIPTION
There are cases where the start of the batch causes an exception to be
thrown and the requests/assets end up in a confused state (assets with
aliquots, requests think they are empty).  This start of the batch needs
to be done transactionally so that this doesn't happen.
