### PR TITLE
[fixes #24841329] Charge to the request project first.

### DIFF
--- a/app/models/billing_event.rb
+++ b/app/models/billing_event.rb
@@ -173,7 +173,7 @@ class BillingEvent < ActiveRecord::Base
     def construct_from_request(kind, event_type, request, aliquot_info, entry_date=Time.now)
       description = "#{request.request_type.name} #{event_type}"
       #TODO create on event per Aliquot
-      project_id = aliquot_info.aliquot.try(:project_id)  || request.initial_project_id
+      project_id = request.initial_project_id || aliquot_info.aliquot.try(:project_id)
 
       self.new :kind => kind,
         :reference => self.build_reference(request, aliquot_info),


### PR DESCRIPTION
Re-sequencing was causing the project that paid for the original
sequencing to be charged, instead of the project requesting the
resequencing.  This commit swaps the order of preference to the project
referenced from the request, which is currently limited to only one,
over the one set on the aliquots.
