### PR TITLE
Refactor amqp controls

### DIFF
--- a/app/models/amqp_observer.rb
+++ b/app/models/amqp_observer.rb
@@ -6,42 +6,81 @@ class AmqpObserver < ActiveRecord::Observer
     :asset, :asset_link
   )
 
-  # The basic behaviour is to buffer any record that we receive for broadcast.
-  def buffer_record(record)
-    buffer << record
-  end
-  private :buffer_record
-
   # Ensure we capture records being saved as well as deleted.
   #
   # NOTE: Oddly you can't alias_method the after_destroy, it has to be physically defined!
   [ :after_save, :after_destroy ].each do |name|
-    class_eval(%Q{def #{name}(record) ; buffer_record(record) ; end})
+    class_eval(%Q{def #{name}(record) ; self << record ; true ; end})
   end
 
+  # A transaction is (potentially) a bulk send of messages and hence we can create a buffer that
+  # will be written to during changes.  But transactions can be nested, which means that only the
+  # very outter one should do any publishing.
   def transaction(&block)
-    Thread.current[:buffer] ||= (current_buffer = [])
+    Thread.current[:buffer] ||= (current_buffer = MostRecentBuffer.new)
     yield.tap do
       activate_exchange do
-        current_buffer.map(&method(:<<))
-      end unless current_buffer.nil?
+        current_buffer.map(&method(:publish))
+      end unless current_buffer.blank?
     end
   ensure
     Thread.current[:buffer] = nil unless current_buffer.nil?
   end
 
-  def buffer
-    Thread.current[:buffer] || self
-  end
-  private :buffer
-
   def <<(record)
+    buffer << record
+    self  # Ensure we can chain these if necessary!
+  end
+
+  # A simple buffer class that will only retain the most recent version of any object pushed
+  # into it.  Assumes that equality is what you want for checking for things, which works fine
+  # with ActiveRecord.
+  class MostRecentBuffer
+    def initialize
+      @buffer = Set.new
+    end
+
+    delegate :map, :to => :@buffer
+
+    def <<(record)
+      self.tap do
+        @buffer.delete(record)
+        @buffer << record
+      end
+    end
+  end
+
+  # A very simply proxy around the observer such that it will ensure the exchange is activated.
+  # This should mean that `AmqpObserver.instance << record` will work, even without the surrounding
+  # transaction.
+  class Proxy
+    def initialize(observer)
+      @observer = observer
+    end
+
+    delegate :activate_exchange, :publish, :to => :@observer
+    private :activate_exchange, :publish
+
+    def <<(record)
+      activate_exchange { publish(record) }
+    end
+  end
+
+  def publish(record)
     exchange.publish(
       record.to_json,
       :key        => "#{Rails.env}.saved.#{record.class.name.underscore}.#{record.id}",
-      :persistent => true
+      :persistent => configatron.amqp.persistent
     )
   end
+  private :publish
+
+  # The buffer that should be written to is either the one created within the transaction, or it is a
+  # wrapper around ourselves.
+  def buffer
+    Thread.current[:buffer] || Proxy.new(self)
+  end
+  private :buffer
 
   attr_reader :exchange
   private :exchange
@@ -50,7 +89,9 @@ class AmqpObserver < ActiveRecord::Observer
   # the Mongrel process will start killing threads because of too many open files.  This method,
   # therefore, enables transactional support for connecting to the exchange.
   def activate_exchange(&block)
-    client = Bunny.new(configatron.amqp_url, :spec => '09')
+    return yield unless @exchange.nil?
+
+    client = Bunny.new(configatron.amqp.url, :spec => '09')
     begin
       client.start
       @exchange = client.exchange('psd.sequencescape', :passive => true)

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,7 @@
 development:
-    amqp_url: amqp://localhost:5672/
+    amqp:
+      url: amqp://localhost:5672/
+      persistent: false
     accession_login: "accession_login"
     accession_url: http://localhost:9999/accession_service/
     accession_view_url: http://localhost:9999/view_accession/


### PR DESCRIPTION
- Message persistence comes from the configuration file
- Message publishing being done in a safer fashion
- Only broadcast the most recent update within a transaction
- Ensure failures in callbacks don't prevent record saving
- Allow chaining of sends
