### PR TITLE
27518361 changing the state of the pulldown mx tube overrides request states

### DIFF
--- a/app/models/amqp_observer.rb
+++ b/app/models/amqp_observer.rb
@@ -113,4 +113,4 @@ class ActiveRecord::Base
     end
     alias_method_chain(:transaction, :amqp)
   end
-end
+end if ActiveRecord::Base.observers.include?(:amqp_observer)

--- a/app/models/multiplexed_library_tube.rb
+++ b/app/models/multiplexed_library_tube.rb
@@ -21,7 +21,7 @@ class MultiplexedLibraryTube < Tube
   def transition_to(state, _ = nil)
     update_all_requests = ![ 'started', 'pending' ].include?(state)
     event               = STATE_TO_STATEMACHINE_EVENT[state] or raise StandardError, "Illegal state #{state.inspect}"
-    requests_as_target.each do |request|
+    requests_as_target.open.each do |request|
       request.send(event) if update_all_requests or request.is_a?(TransferRequest)
     end
   end

--- a/app/models/pulldown/initial_plate_purpose.rb
+++ b/app/models/pulldown/initial_plate_purpose.rb
@@ -13,7 +13,7 @@ class Pulldown::InitialPlatePurpose < PlatePurpose
   # Ensure that the pulldown library creation request is started
   def start_pulldown_library_requests(plate)
     each_well_and_its_library_request(plate) do |_, request|
-      request.update_attributes!(:state => 'started')
+      request.start!
     end
   end
   private :start_pulldown_library_requests

--- a/features/api/pulldown/bottom_of_the_pipeline.feature
+++ b/features/api/pulldown/bottom_of_the_pipeline.feature
@@ -158,3 +158,103 @@ Feature: The bottom of the pulldown pipeline
       | Pulldown WGS |
       | Pulldown SC  |
       | Pulldown ISC |
+
+  @authorised
+  Scenario Outline: Changing the tube state when requests are not "open"
+    Given "A1-H6" of the plate with UUID "00000000-1111-2222-3333-000000000001" have been submitted to "Pulldown WGS - HiSeq Paired end sequencing"
+      And "A7-H12" of the plate with UUID "00000000-1111-2222-3333-000000000001" have been submitted to "Pulldown WGS - HiSeq Paired end sequencing"
+
+    Given all submissions have been worked until the last plate of the "Pulldown WGS" pipeline
+      And all plates have sequential UUIDs based on "00000000-1111-2222-3333"
+      And all multiplexed library tubes have sequential UUIDs based on "00000000-1111-2222-3333-9999"
+
+    # Find the last plate by barcode
+    Then log "Find the last plate by barcode" for debugging
+    When I POST the following JSON to the API path "/33333333-4444-5555-6666-000000000001/first":
+      """
+      {
+        "search": {
+          "barcode": "1221000002781"
+        }
+      }
+      """
+    Then the HTTP response should be "301 Moved Permanently"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "plate": {
+          "name": "Plate 1000002",
+          "uuid": "00000000-1111-2222-3333-000000000002"
+        }
+      }
+      """
+
+    # Make the transfers from the plate to the appropriate MX library tubes
+    Then log "Make the transfers from the plate to the appropriate MX library tubes" for debugging
+    When I make an authorised POST with the following JSON to the API path "/22222222-3333-4444-5555-000000000001":
+      """
+      {
+        "transfer": {
+          "user": "99999999-8888-7777-6666-555555555555",
+          "source": "00000000-1111-2222-3333-000000000002"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "transfer": {
+          "source": {
+            "uuid": "00000000-1111-2222-3333-000000000002"
+          },
+          "transfers": {
+            "A1": { "uuid": "00000000-1111-2222-3333-999900000001" },
+            "B1": { "uuid": "00000000-1111-2222-3333-999900000002" }
+          }
+        }
+      }
+      """
+
+    Then the aliquots of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be the same as the wells "A1-H6" of the plate "Testing the API"
+     And the name of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "DN1000001M A1:H6"
+     And the aliquots of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be the same as the wells "A7-H12" of the plate "Testing the API"
+     And the name of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000002" should be "DN1000001M A7:H12"
+
+    # Change the state of the requests to the tube so that they are in the initial state
+    Given the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" is "<state>"
+    Then log "Change the state of one tube to ensure it doesn't affect the other" for debugging
+    When I make an authorised POST with the following JSON to the API path "/state_changes":
+      """
+      {
+        "state_change": {
+          "user": "99999999-8888-7777-6666-555555555555",
+          "target": "00000000-1111-2222-3333-999900000001",
+          "target_state": "passed"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "state_change": {
+          "target": {
+            "uuid": "00000000-1111-2222-3333-999900000001"
+          },
+          "target_state": "passed",
+          "previous_state": "pending"
+        }
+      }
+      """
+
+    Then the state of the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "passed"
+     And the state of all the transfer requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "passed"
+     And the state of all the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should be "<state>"
+     And all of the pulldown library creation requests to the multiplexed library tube with UUID "00000000-1111-2222-3333-999900000001" should not have billing
+
+    Scenarios:
+      | state     | 
+      | cancelled | 
+      | passed    | 
+      | failed    | 

--- a/features/step_definitions/pulldown_steps.rb
+++ b/features/step_definitions/pulldown_steps.rb
@@ -169,6 +169,12 @@ Then /^all of the pulldown library creation requests to (the multiplexed library
   assert(requests.all? { |r| not r.billing_events.charged_to_project.empty? }, "There are requests that have not billed the project")
 end
 
+Then /^all of the pulldown library creation requests to (the multiplexed library tube .+) should not have billing$/ do |tube|
+  requests = tube.requests_as_target.where_is_a?(Pulldown::Requests::LibraryCreation).all
+  assert(!requests.empty?, "There are expected to be a number of pulldown requests")
+  assert(requests.all? { |r| r.billing_events.empty? }, "There are requests that have billing events")
+end
+
 Given /^all requests are in the last submission$/ do
 	submission = Submission.last or raise StandardError, "There are no submissions!"
 	Request.update_all("submission_id=#{submission.id}")

--- a/features/step_definitions/transfer_steps.rb
+++ b/features/step_definitions/transfer_steps.rb
@@ -60,6 +60,11 @@ def assert_request_state(state, targets, direction, request_class)
   )
 end
 
+def change_request_state(state, targets, direction, request_class)
+  association = (direction == 'to') ? :requests_as_target : :requests_as_source
+  Request.update_all("state=#{state.inspect}", [ 'id IN (?)', Array(targets).map(&association).flatten.select { |r| r.is_a?(request_class) }.map(&:id) ])
+end
+
 {
   'plate'                    => 'target.wells',
   'multiplexed library tube' => 'target'
@@ -72,6 +77,10 @@ end
 
     Then /^the state of all the pulldown library creation requests (to|from) (the #{target} .+) should be "([^"]+)"$/ do |direction, target, state|
       assert_request_state(state, #{request_holder}, direction, Pulldown::Requests::LibraryCreation)
+    end
+
+    Given /^the state of all the pulldown library creation requests (to|from) (the #{target} .+) is "([^"]+)"$/ do |direction, target, state|
+      change_request_state(state, #{request_holder}, direction, Pulldown::Requests::LibraryCreation)
     end
   }, __FILE__, line)
 end


### PR DESCRIPTION
When changing the state of a tube only change those requests that are
"open" (pending, started, blocked) to prevent a failed request being
changed to a pass.
