### PR TITLE
21144505 new asset group from existing plates breaks sequencescape

### DIFF
--- a/app/views/studies/asset_groups/index.html.erb
+++ b/app/views/studies/asset_groups/index.html.erb
@@ -3,7 +3,6 @@
   <% if @study.approved? && @study.active? -%>
     <% add :menu, "<strong>Create Submission</strong>" => new_submission_path -%>
   <% end -%>
-  <%- add :menu, "<strong>New asset group from existing plates</strong>" => study_plates_path(@study) -%>
 <% end %>  
 <%- add :menu, "Back to Study" => study_path(@study) -%>
 


### PR DESCRIPTION
[fixes #21144505] Removed link 'New asset group from existing plates'.

Link resulted in retrieval of all known plates, which took mongrel
about 5 minutes to complete. Removed link to avoid unecessary load.

Note: This does not include changes to the studies/plates controller
that will be necessary if the page needs to be reinstated later. Also I
haven't removed the controller, views or associated routes. The
page will still be accessible by visiting the appropriate url directly. I
can change this if necessary.
