### PR TITLE
[fixes #28875163] Properly underscore role names

### DIFF
--- a/app/models/api/plate_io.rb
+++ b/app/models/api/plate_io.rb
@@ -10,7 +10,7 @@ class Api::PlateIO < Api::Base
       base.class_eval do
         extend ClassMethods
 
-        named_scope :including_associations_for_json, { :include => [:uuid_object, :plate_metadata, :barcode_prefix, { :plate_purpose => :uuid_object } ] }
+        named_scope :including_associations_for_json, { :include => [:uuid_object, :plate_metadata, :barcode_prefix, :location, { :plate_purpose => :uuid_object } ] }
         alias_method(:json_root, :url_name)
       end
     end

--- a/app/models/api/study_io.rb
+++ b/app/models/api/study_io.rb
@@ -40,7 +40,7 @@ class Api::StudyIO < Api::Base
     json_attributes["abbreviation"] = object.abbreviation
 
     object.roles.each do |role|
-      json_attributes[role.name.underscore] = role.users.map do |user|
+      json_attributes[role.name.gsub(/\s+/, '_')] = role.users.map do |user|
         { :login => user.login, :email => user.email, :name  => user.name }
       end
     end if object.respond_to?(:roles)


### PR DESCRIPTION
Role names need to have whitespace properly converted to underscores, as
x.underscore does not appear to work in these cases.
