### PR TITLE
[fixes #28830149] Ensure correct updated_at in JSON.

### DIFF
--- a/features/plain/api/billing_events.feature
+++ b/features/plain/api/billing_events.feature
@@ -13,7 +13,7 @@ Feature: Interacting with billing_events through the API
     Given I have a billing event with UUID "00000000-1111-2222-3333-444444444444"
 
     When I GET the API path "/billing_events"
-    Then ignoring "internal_id|project_internal_id|project_uuid|request_uuid|request_internal_id|reference" the JSON should be:
+    Then ignoring "updated_at|internal_id|project_internal_id|project_uuid|request_uuid|request_internal_id|reference" the JSON should be:
       """
       [
         {
@@ -28,7 +28,6 @@ Feature: Interacting with billing_events through the API
 						"project_cost_code": "Some Cost Code",
 						"entry_date": "2010-09-16T13:45:00+01:00",
             "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
             "price": 100,
             "request_type": "Paired end sequencing",
             "library_type": "Standard",
@@ -52,7 +51,7 @@ Feature: Interacting with billing_events through the API
     Given I have a billing event with UUID "00000000-1111-2222-3333-444444444444"
 
     When I GET the API path "/billing_events/00000000-1111-2222-3333-444444444444"
-    Then ignoring "internal_id|project_internal_id|project_uuid|request_uuid|request_internal_id|reference" the JSON should be:
+    Then ignoring "updated_at|internal_id|project_internal_id|project_uuid|request_uuid|request_internal_id|reference" the JSON should be:
       """
       {
         "billing_event": {
@@ -66,7 +65,6 @@ Feature: Interacting with billing_events through the API
 					"project_cost_code": "Some Cost Code",
 					"entry_date": "2010-09-16T13:45:00+01:00",
           "created_at": "2010-09-16T13:45:00+01:00",
-          "updated_at": "2010-09-16T13:45:00+01:00",
           "price": 100,
           "request_type": "Paired end sequencing",
           "library_type": "Standard",

--- a/features/plain/api/library_tube.feature
+++ b/features/plain/api/library_tube.feature
@@ -63,3 +63,29 @@ Feature: Interacting with library_tubes through the API
         }
       }
       """
+
+  Scenario: When the contents, rather than the tube, have been modified the timestamps should be more current
+    Given a library tube called "Testing the JSON API" exists
+      And all of this is happening at exactly "2012-May-01 14:10"
+      And the aliquots in the library tube called "Testing the JSON API" have been modified
+
+    And the UUID for the library tube "Testing the JSON API" is "00000000-1111-2222-3333-444444444444"
+    When I GET the API path "/library_tubes/00000000-1111-2222-3333-444444444444"
+    Then ignoring "id|sample_name" the JSON should be:
+      """
+      {
+        "library_tube": {
+          "name": "Testing the JSON API",
+          "created_at": "2010-09-16T13:45:00+01:00",
+          "updated_at": "2012-05-01T14:10:00+01:00",
+          "uuid": "00000000-1111-2222-3333-444444444444",
+          "barcode_prefix": "NT", 
+          "scanned_in_date": "",
+          "lanes": "http://localhost:3000/0_5/library_tubes/00000000-1111-2222-3333-444444444444/lanes",
+          "requests": "http://localhost:3000/0_5/library_tubes/00000000-1111-2222-3333-444444444444/requests",
+          "qc_state": "",
+
+          "id": 1
+        }
+      }
+      """

--- a/features/plain/api/plates.feature
+++ b/features/plain/api/plates.feature
@@ -16,7 +16,7 @@ Feature: Interacting with plates through the API
     And the infinium barcode for plate "Testing the JSON API" is "WG123456"
 
     When I GET the API path "/plates"
-    Then ignoring "id|barcode|plate_purpose_uuid|plate_purpose_internal_id" the JSON should be:
+    Then ignoring "updated_at|id|barcode|plate_purpose_uuid|plate_purpose_internal_id" the JSON should be:
       """
       [
         {
@@ -29,7 +29,6 @@ Feature: Interacting with plates through the API
             "location": "Sample logistics freezer",
             
             "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
             "uuid": "00000000-1111-2222-3333-444444444444",
             "barcode": "2",
             "plate_purpose_uuid": "34567",
@@ -50,7 +49,7 @@ Feature: Interacting with plates through the API
     And the infinium barcode for plate "Testing the JSON API" is "WG123456"
 
     When I GET the API path "/plates/00000000-1111-2222-3333-444444444444"
-    Then ignoring "id|barcode|plate_purpose_uuid|plate_purpose_internal_id" the JSON should be:
+    Then ignoring "updated_at|id|barcode|plate_purpose_uuid|plate_purpose_internal_id" the JSON should be:
       """
       {
         "plate": {
@@ -62,7 +61,6 @@ Feature: Interacting with plates through the API
           "location": "Sample logistics freezer",
           
           "created_at": "2010-09-16T13:45:00+01:00",
-          "updated_at": "2010-09-16T13:45:00+01:00",
           "uuid": "00000000-1111-2222-3333-444444444444",
           "barcode": "2",
           "plate_purpose_uuid": "34567",

--- a/features/plain/api/projects.feature
+++ b/features/plain/api/projects.feature
@@ -15,7 +15,7 @@ Feature: Interacting with projects through the API
     And the UUID for the project "Testing the JSON API" is "00000000-1111-2222-3333-444444444444"
 
     When I GET the API path "/projects"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       [
         {
@@ -25,7 +25,6 @@ Feature: Interacting with projects through the API
 				        "collaborators": "No collaborators",
 				        "funding_comments": "External funding",
 				        "uuid": "00000000-1111-2222-3333-444444444444",
-				        "updated_at": "2010-09-16T13:45:00+01:00",
 
 				        "approved": true,
 				        "funding_model": "Internal",
@@ -55,7 +54,7 @@ Feature: Interacting with projects through the API
     And project "Testing the JSON API" has an owner called "abc123"
     And the UUID for the project "Testing the JSON API" is "00000000-1111-2222-3333-444444444444"
     When I GET the API path "/projects/00000000-1111-2222-3333-444444444444"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       {
 			    "project": {
@@ -64,7 +63,6 @@ Feature: Interacting with projects through the API
 			        "collaborators": "No collaborators",
 			        "funding_comments": "External funding",
 			        "uuid": "00000000-1111-2222-3333-444444444444",
-			        "updated_at": "2010-09-16T13:45:00+01:00",
 
 			        "approved": true,
 			        "funding_model": "Internal",

--- a/features/plain/api/requests.feature
+++ b/features/plain/api/requests.feature
@@ -11,7 +11,7 @@ Feature: Interacting with requests through the API
     Given I have an active study called "Study testing the JSON API"
     And the UUID for the study "Study testing the JSON API" is "22222222-2222-3333-4444-ffffffffffff"
 
-  And the UUID of the next submission created will be "11111111-2222-3333-4444-111111111111"
+    Given the UUID of the next submission created will be "11111111-2222-3333-4444-111111111111"
 
   Scenario: The list of requests is always empty if no type of tube is requested
     When I retrieve the JSON for all requests
@@ -25,7 +25,7 @@ Feature: Interacting with requests through the API
     And all samples have sequential UUIDs based on "bbbbbbbb-1111-2222-3333"
 
     When I retrieve the JSON for all requests related to the sample tube "Tube"
-    Then ignoring "((source_asset|source_asset_sample|target_asset|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "((source_asset|source_asset_sample|target_asset|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       [
         {
@@ -39,7 +39,6 @@ Feature: Interacting with requests through the API
             "target_asset_state": "",
             "created_at": "2010-09-16T16:15:00+01:00",
             "source_asset_two_dimensional_barcode": null,
-            "updated_at": "2010-09-16T16:15:00+01:00",
             "target_asset_type": "sample_tubes",
             "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
             "project_url": "http://localhost:3000/0_5/projects/11111111-2222-3333-4444-ffffffffffff",
@@ -90,7 +89,7 @@ Feature: Interacting with requests through the API
     And all samples have sequential UUIDs based on "bbbbbbbb-1111-2222-3333"
 
     When I retrieve the JSON for all requests related to the library tube "Tube"
-    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       [
         {
@@ -104,7 +103,6 @@ Feature: Interacting with requests through the API
             "target_asset_state": "",
             "created_at": "2010-09-16T16:15:00+01:00",
             "source_asset_two_dimensional_barcode": null,
-            "updated_at": "2010-09-16T16:15:00+01:00",
             "target_asset_type": "library_tubes",
             "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
             "project_url": "http://localhost:3000/0_5/projects/11111111-2222-3333-4444-ffffffffffff",
@@ -152,7 +150,7 @@ Feature: Interacting with requests through the API
     And all assets have sequential UUIDs based on "aaaaaaaa-1111-2222-3333"
 
     When I retrieve the JSON for the last request in the study "Study testing the JSON API"
-    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       {
         "request": {
@@ -161,7 +159,6 @@ Feature: Interacting with requests through the API
 
           "request_type": "<request type>",
           "created_at": "2010-09-16T16:15:00+01:00",
-          "updated_at": "2010-09-16T16:15:00+01:00",
 
           "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
           "project_url": "http://localhost:3000/0_5/projects/11111111-2222-3333-4444-ffffffffffff",
@@ -221,7 +218,7 @@ Feature: Interacting with requests through the API
     And all assets have sequential UUIDs based on "aaaaaaaa-1111-2222-3333"
 
     When I retrieve the JSON for the last request in the study "Study testing the JSON API"
-    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       {
         "request": {
@@ -230,7 +227,6 @@ Feature: Interacting with requests through the API
 
           "request_type": "<request type>",
           "created_at": "2010-09-16T16:15:00+01:00",
-          "updated_at": "2010-09-16T16:15:00+01:00",
 
           "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
           "project_url": "http://localhost:3000/0_5/projects/11111111-2222-3333-4444-ffffffffffff",
@@ -292,7 +288,7 @@ Feature: Interacting with requests through the API
      And all requests have a priority flag
 
     When I retrieve the JSON for the last request in the study "Study testing the JSON API"
-    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "((source_asset|target_asset|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       {
         "request": {
@@ -301,7 +297,6 @@ Feature: Interacting with requests through the API
 
           "request_type": "Single ended sequencing",
           "created_at": "2010-09-16T16:15:00+01:00",
-          "updated_at": "2010-09-16T16:15:00+01:00",
 
           "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
           "project_url": "http://localhost:3000/0_5/projects/11111111-2222-3333-4444-ffffffffffff",
@@ -357,7 +352,7 @@ Feature: Interacting with requests through the API
     And all samples have sequential UUIDs based on "bbbbbbbb-1111-2222-3333"
 
     When I retrieve the JSON for all requests related to the sample tube "Tube"
-    Then ignoring "^((source_asset.*|target_asset.*|project|study|submission)_(internal_id|barcode)|id)" the JSON should be:
+    Then ignoring "^((source_asset.*|target_asset.*|project|study|submission)_(internal_id|barcode)|id|updated_at)" the JSON should be:
       """
       [
         {
@@ -371,7 +366,6 @@ Feature: Interacting with requests through the API
             "target_asset_state": "",
             "created_at": "2010-09-16T16:15:00+01:00",
             "source_asset_two_dimensional_barcode": null,
-            "updated_at": "2010-09-16T16:15:00+01:00",
             "target_asset_type": "sample_tubes",
             "project_uuid": "11111111-2222-3333-4444-ffffffffffff",
             "study_name": "Study testing the JSON API",

--- a/features/plain/api/samples.feature
+++ b/features/plain/api/samples.feature
@@ -31,7 +31,7 @@ Feature: Interacting with samples through the API
       }
       """
     Then the HTTP response should be "201 Created"
-    And ignoring "id|uuid|sample_tubes" the JSON should be:
+    And ignoring "updated_at|id|uuid|sample_tubes" the JSON should be:
       """
       {
         "sample": {
@@ -64,7 +64,6 @@ Feature: Interacting with samples through the API
           "updated_by_manifest": null,
 
           "created_at": "2010-09-08T09:00:00+01:00",
-          "updated_at": "2010-09-08T09:00:00+01:00",
 
           "id": "1",
           "uuid": "00000000-1111-2222-3333-444444444444",
@@ -88,7 +87,7 @@ Feature: Interacting with samples through the API
 
     When I GET the API path "/samples"
     Then the HTTP response should be "200 OK"
-    And ignoring "id" the JSON should be:
+    And ignoring "updated_at|id" the JSON should be:
       """
       [
         {
@@ -126,7 +125,6 @@ Feature: Interacting with samples through the API
             "updated_by_manifest": null,
 
             "created_at": "2010-09-08T09:00:00+01:00",
-            "updated_at": "2010-09-08T09:00:00+01:00",
             "new_name_format": true,
 
             "id": 1
@@ -144,7 +142,7 @@ Feature: Interacting with samples through the API
 
     When I GET the API path "/studies/00000000-1111-2222-3333-555555555555/samples"
     Then the HTTP response should be "200 OK"
-    And ignoring "id" the JSON should be:
+    And ignoring "updated_at|id" the JSON should be:
       """
       [
         {
@@ -179,7 +177,6 @@ Feature: Interacting with samples through the API
             "updated_by_manifest": null,
 
             "created_at": "2010-09-08T09:00:00+01:00",
-            "updated_at": "2010-09-08T09:00:00+01:00",
             "new_name_format": true,
 
             "id": 1
@@ -194,7 +191,7 @@ Feature: Interacting with samples through the API
 
     When I GET the API path "/samples/00000000-1111-2222-3333-444444444444"
     Then the HTTP response should be "200 OK"
-    And ignoring "id" the JSON should be:
+    And ignoring "updated_at|id" the JSON should be:
       """
       {
         "sample": {
@@ -228,7 +225,6 @@ Feature: Interacting with samples through the API
           "updated_by_manifest": null,
 
           "created_at": "2010-09-08T09:00:00+01:00",
-          "updated_at": "2010-09-08T09:00:00+01:00",
           "new_name_format": true,
 
           "id": 1
@@ -246,7 +242,7 @@ Feature: Interacting with samples through the API
     And the sanger sample id for sample "00000000-1111-2222-3333-444444444444" is "1STDY123"
 
     When I GET the API path "/samples/00000000-1111-2222-3333-444444444444"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       {
         "sample": {
@@ -283,7 +279,6 @@ Feature: Interacting with samples through the API
           "updated_by_manifest": null,
 
           "created_at": "2010-09-08T09:00:00+01:00",
-          "updated_at": "2010-09-08T09:00:00+01:00",
           "new_name_format": true,
 
           "id": 1
@@ -303,7 +298,7 @@ Feature: Interacting with samples through the API
     And the sample "sample_testing_the_json_api" has a supplier name of "My sample"
 
     When I retrieve the JSON for the sample "sample_testing_the_json_api"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       {
         "sample": {
@@ -340,7 +335,6 @@ Feature: Interacting with samples through the API
           "updated_by_manifest": null,
 
           "created_at": "2010-09-08T09:00:00+01:00",
-          "updated_at": "2010-09-08T09:00:00+01:00",
           "new_name_format": true,
 
           "id": 1

--- a/features/plain/api/studies.feature
+++ b/features/plain/api/studies.feature
@@ -18,7 +18,7 @@ Feature: Interacting with studies through the API
     And the dac accession number for study "Testing the JSON API" is "DAC333"
 
     When I GET the API path "/studies"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       [
         {
@@ -48,8 +48,7 @@ Feature: Interacting with studies through the API
             "samples": "http://localhost:3000/0_5/studies/00000000-1111-2222-3333-444444444444/samples",
 
             "id": 1,
-            "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00"
+            "created_at": "2010-09-16T13:45:00+01:00"
           }
         }
       ]
@@ -65,7 +64,7 @@ Feature: Interacting with studies through the API
     And the faculty sponsor for study "Testing the JSON API" is "John Smith"
 
     When I GET the API path "/studies/00000000-1111-2222-3333-444444444444"
-    Then ignoring "id" the JSON should be:
+    Then ignoring "updated_at|id" the JSON should be:
       """
       {
         "study": {
@@ -91,8 +90,7 @@ Feature: Interacting with studies through the API
           "samples": "http://localhost:3000/0_5/studies/00000000-1111-2222-3333-444444444444/samples",
 
           "id": 1,
-          "created_at": "2010-09-16T13:45:00+01:00",
-          "updated_at": "2010-09-16T13:45:00+01:00"
+          "created_at": "2010-09-16T13:45:00+01:00"
         }
       }
       """

--- a/features/plain/api/submissions.feature
+++ b/features/plain/api/submissions.feature
@@ -40,14 +40,13 @@ Feature: Interacting with submissions through the API
       And the order with UUID "11111111-2222-3333-4444-666666666666" has been added to a submission
       
     When I GET the API path "/orders/11111111-2222-3333-4444-666666666666"
-    Then ignoring "internal_id" the JSON should be:
+    Then ignoring "updated_at|internal_id" the JSON should be:
       """
             {
           "order":
           {
             "uuid": "11111111-2222-3333-4444-666666666666",
             "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
             "created_by": "abc123",
             "template_name":"Library creation - Paired end sequencing",
             "study_name": "Testing submission creation",
@@ -74,14 +73,13 @@ Feature: Interacting with submissions through the API
          } 
       """
     When I GET the API path "/submissions/11111111-2222-3333-4444-555555555555"
-    Then ignoring "internal_id" the JSON should be:
+    Then ignoring "updated_at|internal_id" the JSON should be:
       """
         { 
           "submission":
           {
             "uuid": "11111111-2222-3333-4444-555555555555",
             "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
             "created_by": "abc123",
             "state": "building",
             "study_name": "Testing submission creation",
@@ -105,14 +103,13 @@ Feature: Interacting with submissions through the API
       And the order with UUID "11111111-2222-3333-4444-666666666666" has been added to a submission
 
     When I GET the API path "/orders/11111111-2222-3333-4444-666666666666"
-    Then ignoring "internal_id" the JSON should be:
+    Then ignoring "updated_at|internal_id" the JSON should be:
       """
         { 
           "order":
           {
             "uuid": "11111111-2222-3333-4444-666666666666",
             "created_at": "2010-09-16T13:45:00+01:00",
-            "updated_at": "2010-09-16T13:45:00+01:00",
             "created_by": "abc123",
             "template_name":"Library creation - Paired end sequencing",
             "study_name": "Testing submission creation",
@@ -135,14 +132,13 @@ Feature: Interacting with submissions through the API
         }
       """
     When I GET the API path "/submissions/11111111-2222-3333-4444-555555555555"
-    Then ignoring "internal_id" the JSON should be:
+    Then ignoring "updated_at|internal_id" the JSON should be:
       """
         { 
           "submission":
           {
             "uuid": "11111111-2222-3333-4444-555555555555",
             "created_at": "2010-09-16T13:45:00+01:00",
-        "updated_at": "2010-09-16T13:45:00+01:00",
             "created_by": "abc123",
             "state": "building",
             "study_name": "Testing submission creation",

--- a/features/step_definitions/aliquot_steps.rb
+++ b/features/step_definitions/aliquot_steps.rb
@@ -30,3 +30,8 @@ Given /^the sample tube "([^\"]+)" has (\d+) aliquots$/ do |tube_name, number|
     tube.aliquots.create!(:sample => Factory(:sample, :name => "sample_#{i}_for_tube_#{tube_name}"), :tag => Factory(:tag))
   end
 end
+
+Given /^the aliquots in the library tube called "([^\"]+)" have been modified$/ do |name|
+  tube = LibraryTube.find_by_name(name) or raise "Can't find library tube named #{name.inspect}"
+  tube.aliquots.each { |a| a.updated_at = Time.now ; a.save(false) }
+end


### PR DESCRIPTION
If an association is included in the JSON data for the warehouse
builder, then the updated_at should be the most recent date across all
associations.  For example, the JSON for library tubes depends on the
primary aliquot and, if that changes and the tube doesn't, then the
updated_at for the tube should be the updated_at for the primary
aliquot.

Essentially the JSON is a view of an entire object and the updated_at
therefore encompasses all minor components of that object.
