### PR TITLE
[fixes #28937311] All for unsaved records to have no UUID

### DIFF
--- a/app/models/bait_library_layout.rb
+++ b/app/models/bait_library_layout.rb
@@ -75,6 +75,7 @@ class BaitLibraryLayout < ActiveRecord::Base
   def self.preview!(attributes = {}, &block)
     new(attributes, &block).tap do |layout|
       raise ActiveRecord::RecordInvalid, layout unless layout.valid?
+      layout.unsaved_uuid!
       layout.send(:generate_for_preview)
     end
   end

--- a/app/models/submission/delayed_job_behaviour.rb
+++ b/app/models/submission/delayed_job_behaviour.rb
@@ -23,7 +23,7 @@ module Submission::DelayedJobBehaviour
     # retry later. Therefore the DelayedJob should fail
     raise sql_exception
   rescue => exception
-    fail_set_message_and_save($!.to_yaml)
+    fail_set_message_and_save("#{exception.message}\n#{exception.backtrace.join("\n")}")
   end
   
   def finalize_build!

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -201,6 +201,7 @@ class Transfer < ActiveRecord::Base
   def self.preview!(attributes)
     new(attributes) do |transfer|
       raise ActiveRecord::RecordInvalid, transfer unless transfer.valid?
+      transfer.unsaved_uuid!
       transfer.send(:each_transfer) do |source, destination|
         # Needs to do nothing at all as the transfers will be recorded
       end

--- a/app/models/uuid.rb
+++ b/app/models/uuid.rb
@@ -22,7 +22,7 @@ class Uuid < ActiveRecord::Base
     # UUIDs.
     if ['test', 'cucumber'].include?(RAILS_ENV)
       def ensure_uuid_created
-        self.uuid_object ||= Uuid.create!(:resource => self)
+        self.uuid_object = Uuid.create!(:resource => self) if self.uuid_object(true).nil?
       end
     else
       def ensure_uuid_created
@@ -30,6 +30,16 @@ class Uuid < ActiveRecord::Base
       end
     end
     private :ensure_uuid_created
+
+    # Marks a record as being unsaved and hence the UUID is not present.  This is not something we
+    # want to actually happen without being explicitly told; hence, the 'uuid' method below will
+    # error if the record is unsaved as that's exactly what should happen.
+    #
+    # It also means that marking a record by calling this method, and then attempting to save it,
+    # will result in another validation exception.  Again, exactly what we want.
+    def unsaved_uuid!
+      self.uuid_object = Uuid.new(:external_id => nil)
+    end
 
     #--
     # You cannot give a UUID to something that hasn't been saved, which means that the UUID can't be


### PR DESCRIPTION
If a record does not have a UUID then one is created for it;
unfortunately this doesn't work when the record is unsaved, as the ID
information is nil and that violates a DB constraint.  This commit
adds the ability for the code to say "this record should not have a
UUID", and then that will not cause errors, except if they try to save
this marked record (which is an error in itself).  Hence the integrity
of UUIDs should be maintained and the ability to preview stuff (like
bait library assignment and transfers) is supported.
