### PR TITLE
29448369 pulldown calling invalid fail state transitions on transfer requests

### DIFF
--- a/app/models/transfer_request.rb
+++ b/app/models/transfer_request.rb
@@ -1,6 +1,41 @@
 # Every request "moving" an asset from somewhere to somewhere else without really transforming it
 # (chemically) as, cherrypicking, pooling, spreading on the floor etc
 class TransferRequest < Request
+  # Destroy all evidence of the statemachine we've inherited!  Ugly, but it works!
+  instance_variable_set(:@aasm, nil)
+  AASM::StateMachine[self] = AASM::StateMachine.new('')
+
+  # The statemachine for transfer requests is more promiscuous than normal requests, as well
+  # as being more concise as it has less states.
+  aasm_column :state
+  aasm_state :pending
+  aasm_state :started
+  aasm_state :failed
+  aasm_state :passed
+  aasm_state :cancelled
+  aasm_initial_state :pending
+
+  # State Machine events
+  aasm_event :start do
+    transitions :to => :started, :from => [:pending]
+  end
+
+  aasm_event :pass do
+    transitions :to => :passed, :from => [:pending, :started, :failed]
+  end
+
+  aasm_event :fail do
+    transitions :to => :failed, :from => [:pending, :started, :failed]
+  end
+
+  aasm_event :cancel do
+    transitions :to => :cancelled, :from => [:started]
+  end
+
+  aasm_event :detach do
+    transitions :to => :pending, :from => [:pending]
+  end
+
   # Ensure that the source and the target assets are not the same, otherwise bad things will happen!
   validate do |record|
     if record.asset.present? and record.asset == record.target_asset
@@ -15,9 +50,4 @@ class TransferRequest < Request
     target_asset.aliquots << asset.aliquots.map(&:clone) unless asset.failed? or asset.cancelled?
   end
   private :perform_transfer_of_contents
-
-  # TODO: Now that callbacks are in place we probably should do the transfer on passing a request.
-  def on_started
-    # Override the default behaviour to not do the transfer
-  end
 end

--- a/features/api/state_changes.feature
+++ b/features/api/state_changes.feature
@@ -24,8 +24,6 @@ Feature: Access state changes through the API
       And the UUID for the plate "Source plate" is "00000000-1111-2222-3333-000000000001"
       And the UUID for the plate "Destination plate" is "00000000-1111-2222-3333-000000000002"
       And the "Transfer columns 1-12" transfer template has been used between "Source plate" and "Destination plate"
-      And "A1-H12" of the plate "Source plate" have been submitted to "Pulldown WGS - HiSeq paired end sequencing"
-      And all requests are in the last submission
 
   @create
   Scenario Outline: Creating a state change on a plate
@@ -62,17 +60,13 @@ Feature: Access state changes through the API
 
     Then the state of the plate "Destination plate" should be "<state>"
      And the state of all the transfer requests to the plate "Destination plate" should be "<state>"
-     And the state of all the pulldown library creation requests from the plate "Source plate" should be "<library state>"
 
     Scenarios:
-      | state   | library state | 
-      | pending | pending       | 
-      | started | pending       | 
-      | passed  | pending       | 
-
-    Scenarios:
-      | state   | library state | 
-      | failed  | failed        | 
+      | state   |
+      | pending |
+      | started |
+      | passed  |
+      | failed  |
 
   @create
   Scenario: Changing the state of only one well on the plate
@@ -111,9 +105,7 @@ Feature: Access state changes through the API
 
     Then the state of the plate "Destination plate" should be "pending"
      And the state of transfer requests to "A1-A1" on the plate "Destination plate" should be "failed"
-     And the state of pulldown library creation requests from "A1-A1" on the plate "Source plate" should be "failed"
      And the state of transfer requests to "A2-H12" on the plate "Destination plate" should be "pending"
-     And the state of pulldown library creation requests from "A2-H12" on the plate "Source plate" should be "pending"
 
   @read @wip
   Scenario: Reading the JSON for a UUID
@@ -134,3 +126,95 @@ Feature: Access state changes through the API
         }
       }
       """
+
+  @create
+  Scenario: Changing the state of only one well on the plate with pulldown requests
+    Given the UUID of the next state change created will be "11111111-2222-3333-4444-000000000001"
+      And "A1-H12" of the plate "Source plate" have been submitted to "Pulldown WGS - HiSeq paired end sequencing"
+      And all requests are in the last submission
+
+    When I make an authorised POST with the following JSON to the API path "/state_changes":
+      """
+      {
+        "state_change": {
+          "user": "99999999-8888-7777-6666-555555555555",
+          "target": "00000000-1111-2222-3333-000000000002",
+          "contents": [ "A1" ],
+          "target_state": "failed"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "state_change": {
+          "actions": {
+            "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+          },
+          "target": {
+            "actions": {
+              "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+            }
+          },
+          "target_state": "failed",
+          "contents": [ "A1" ],
+          "previous_state": "pending"
+        }
+      }
+      """
+
+    Then the state of the plate "Destination plate" should be "pending"
+     And the state of transfer requests to "A1-A1" on the plate "Destination plate" should be "failed"
+     And the state of transfer requests to "A2-H12" on the plate "Destination plate" should be "pending"
+     And the state of pulldown library creation requests from "A1-A1" on the plate "Source plate" should be "failed"
+     And the state of pulldown library creation requests from "A2-H12" on the plate "Source plate" should be "pending"
+
+  @create
+  Scenario Outline: Creating a state change on a plate with pulldown requests
+    Given the UUID of the next state change created will be "11111111-2222-3333-4444-000000000001"
+      And "A1-H12" of the plate "Source plate" have been submitted to "Pulldown WGS - HiSeq paired end sequencing"
+      And all requests are in the last submission
+
+    When I make an authorised POST with the following JSON to the API path "/state_changes":
+      """
+      {
+        "state_change": {
+          "user": "99999999-8888-7777-6666-555555555555",
+          "target": "00000000-1111-2222-3333-000000000002",
+          "target_state": "<state>"
+        }
+      }
+      """
+    Then the HTTP response should be "201 Created"
+     And the JSON should match the following for the specified fields:
+      """
+      {
+        "state_change": {
+          "actions": {
+            "read": "http://www.example.com/api/1/11111111-2222-3333-4444-000000000001"
+          },
+          "target": {
+            "actions": {
+              "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
+            }
+          },
+          "target_state": "<state>",
+          "previous_state": "pending"
+        }
+      }
+      """
+
+    Then the state of the plate "Destination plate" should be "<state>"
+     And the state of all the transfer requests to the plate "Destination plate" should be "<state>"
+     And the state of all the pulldown library creation requests from the plate "Source plate" should be "<library state>"
+
+    Scenarios:
+      | state   | library state |
+      | pending | pending       |
+      | started | pending       |
+      | passed  | pending       |
+
+    Scenarios:
+      | state   | library state |
+      | failed  | failed        |


### PR DESCRIPTION
TransferRequest has a far less restrictive statemachine, and it's far
simpler too.  This allows the pulldown application to transition much
more simply.

It does not fix the problem where the initial plate is cancelled from
the pending state, which needs the pulldown requests to have a special
statemachine too.
