### PR TITLE
29767381 order causes duplication of asset group asset associations

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -55,12 +55,12 @@ class Order < ActiveRecord::Base
   def all_samples
     # slightly less naive way
     all_assets.map do |asset|
-      asset.respond_to?(:aliquots) ? asset.aliquots : []
+      asset.aliquots
     end.flatten.map(&:sample).uniq
   end
 
   def all_assets
-    (asset_group.try(:assets) || []).concat(assets)
+    ((asset_group.try(:assets) || []) + (assets)).uniq
   end
 
   named_scope :for_studies, lambda {|*args| {:conditions => { :study_id => args[0]} } }

--- a/test/unit/study_test.rb
+++ b/test/unit/study_test.rb
@@ -183,7 +183,7 @@ class StudyTest < ActiveSupport::TestCase
     context "#unprocessed_submissions?" do
       setup do
         @study = Factory :study
-        @asset = Factory :asset
+        @asset = Factory :sample_tube
       end
       context "with submissions still unprocessed" do
         setup do


### PR DESCRIPTION
Avoids adding additional copies of assets to an asset
group on order validation. In addition, assumes that order
will only be dealing with receptacles

Includes adjusted test to use sample_tube rather than an asset
