### PR TITLE
31512729 final pooled plate json performance

### DIFF
--- a/app/api/endpoints/plates.rb
+++ b/app/api/endpoints/plates.rb
@@ -9,6 +9,7 @@ class ::Endpoints::Plates < ::Core::Endpoint::Base
     belongs_to(:plate_purpose,           :json => 'plate_purpose')
 
     has_many(:transfers_as_source,       :json => 'source_transfers', :to => 'source_transfers')
+    has_many(:transfers_to_tubes,        :json => 'transfers_to_tubes', :to => 'transfers_to_tubes')
     belongs_to(:transfer_as_destination, :json => 'creation_transfer')
   end
 end

--- a/app/api/io/multiplexed_library_tube.rb
+++ b/app/api/io/multiplexed_library_tube.rb
@@ -2,7 +2,8 @@ class ::Io::MultiplexedLibraryTube < ::Io::LibraryTube
   set_model_for_input(::MultiplexedLibraryTube)
   set_json_root(:multiplexed_library_tube)
 
-  define_attribute_and_json_mapping(%Q{
-    state  => state
-  })
+  # TODO: Find an efficient way to display state as it kills transfers_to_tubes for plates!
+#  define_attribute_and_json_mapping(%Q{
+#    state  => state
+#  })
 end

--- a/app/api/io/transfer/from_plate_to_tube_by_submission.rb
+++ b/app/api/io/transfer/from_plate_to_tube_by_submission.rb
@@ -1,6 +1,7 @@
 class ::Io::Transfer::FromPlateToTubeBySubmission < ::Core::Io::Base
   set_model_for_input(::Transfer::FromPlateToTubeBySubmission)
   set_json_root(:transfer)
+  set_eager_loading { |model| model.include_source.include_transfers }
 
   define_attribute_and_json_mapping(%Q{
             user <=> user

--- a/app/api/model_extensions/plate.rb
+++ b/app/api/model_extensions/plate.rb
@@ -46,11 +46,13 @@ module ModelExtensions::Plate
   # ignored within the returned result.
   def pools
     ActiveSupport::OrderedHash.new.tap do |pools|
-      wells.walk_in_pools do |pool_id, wells|
+      wells.walk_in_pools do |_, wells|
+        pool_id = wells.first.pool_uuid
         next if pool_id.blank?
-        pool_information = { :wells => wells.map(&:map).map(&:description) }
+
+        pool_information = { :wells => Map.find(wells.map(&:map_id)).map(&:description) }
         wells.first.stock_wells.first.requests_as_source.each { |request| request.update_pool_information(pool_information) }
-        pools[wells.first.pool_uuid] = pool_information
+        pools[pool_id] = pool_information
       end
     end
   end

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -20,7 +20,7 @@ class Plate < Asset
 
   # Transfer requests into a plate are the requests leading into the wells of said plate.
   def transfer_requests
-    wells.map(&:transfer_requests_as_target).flatten
+    wells.all(:include => :transfer_requests_as_target).map(&:transfer_requests_as_target).flatten
   end
 
   def self.derived_classes
@@ -441,7 +441,7 @@ WHERE c.container_id=?
   end
 
   def lookup_stock_plate
-    self.ancestors.all(:order => 'created_at DESC').detect(&:stock_plate?)
+    self.ancestors.all(:order => 'created_at DESC', :include => :plate_purpose).detect(&:stock_plate?)
   end
   private :lookup_stock_plate
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -5,6 +5,7 @@ class Transfer < ActiveRecord::Base
         include Transfer::State
 
         has_many :transfers_as_source,     :class_name => 'Transfer', :foreign_key => :source_id,      :order => 'created_at ASC'
+        has_many :transfers_to_tubes,      :class_name => 'Transfer::FromPlateToTubeBySubmission', :foreign_key => :source_id, :order => 'created_at ASC'
         has_one  :transfer_as_destination, :class_name => 'Transfer', :foreign_key => :destination_id
 
         # This looks odd but it's a LEFT OUTER JOIN, meaning that the rows we would be interested in have no source_id.
@@ -185,6 +186,7 @@ class Transfer < ActiveRecord::Base
   # You can only transfer from one plate to another once, anything else is an error.
   belongs_to :source, :class_name => 'Plate'
   validates_presence_of :source
+  named_scope :include_source, :include => { :source => ModelExtensions::Plate::PLATE_INCLUDES }
 
   # Before creating an instance of this class the appropriate transfers need to be made from a source
   # asset to the destination one.

--- a/app/models/transfer/from_plate_to_tube_by_submission.rb
+++ b/app/models/transfer/from_plate_to_tube_by_submission.rb
@@ -8,7 +8,7 @@ class Transfer::FromPlateToTubeBySubmission < Transfer
     belongs_to :transfer, :class_name => 'Transfer::FromPlateToTubeBySubmission'
     validates_presence_of :transfer
 
-    belongs_to :destination, :class_name => 'Asset'
+    belongs_to :destination, :class_name => 'Tube'
     validates_presence_of :destination
 
     validates_presence_of :source
@@ -18,6 +18,26 @@ class Transfer::FromPlateToTubeBySubmission < Transfer
 
   # Records the transfers from the wells on the plate to the assets they have gone into.
   has_many :well_to_tubes, :class_name => 'Transfer::FromPlateToTubeBySubmission::WellToTube', :foreign_key => :transfer_id
+  named_scope :include_transfers, :include => {
+    :well_to_tubes => {
+      :destination => [
+        :uuid_object, {
+          :aliquots => [
+            :uuid_object,
+            :bait_library, {
+              :tag => :tag_group,
+              :sample => [
+                :uuid_object, {
+                  :primary_study   => { :study_metadata => :reference_genome },
+                  :sample_metadata => :reference_genome
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
 
   def transfers
     Hash[well_to_tubes.map { |t| [ t.source, t.destination ] }]


### PR DESCRIPTION
The performance bottleneck was in the transfers to the tubes, which need
eager loading of their aliquots.
