### PR TITLE
[fixes #31829175] Do not access study reports tables until they exist

### DIFF
--- a/app/controllers/studies_controller.rb
+++ b/app/controllers/studies_controller.rb
@@ -449,7 +449,7 @@ class StudiesController < ApplicationController
      
    def study_reports
      @study = Study.find(params[:id])
-     @study_reports = StudyReport.paginate(:conditions => ["study_id=?",@study.id],  :page => params[:page], :order => "id desc")
+     @study_reports = StudyReport.without_files.for_study(@study).paginate(:page => params[:page], :order => 'id DESC')
    end
    
 

--- a/app/controllers/study_reports_controller.rb
+++ b/app/controllers/study_reports_controller.rb
@@ -2,7 +2,7 @@ class StudyReportsController < ApplicationController
   before_filter :login_required
 
   def index
-    @study_reports = StudyReport.paginate(:page => params[:page], :order => "id desc")
+    @study_reports = StudyReport.without_files.paginate(:page => params[:page], :order => "id desc")
     @studies = Study.all(:order => "name ASC")
   end
   

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
   
   def study_reports
     @user = User.find(params[:id])
-    @study_reports = StudyReport.paginate(:conditions => ["user_id=?",@user.id],  :page => params[:page], :order => "id desc")
+    @study_reports = StudyReport.without_files.for_user(@user).paginate(:page => params[:page], :order => "id desc")
   end
 
 end

--- a/app/models/study_report.rb
+++ b/app/models/study_report.rb
@@ -7,7 +7,10 @@ class StudyReport < ActiveRecord::Base
   @@per_page = 50
 
   has_attached_file :report, :storage => :database
-  default_scope select_without_file_columns_for(:report)
+
+  named_scope :for_study, lambda { |study| { :conditions => { :study_id => study.id } } }
+  named_scope :for_user, lambda { |user| { :conditions => { :user_id => user.id } } }
+  named_scope :without_files, lambda { select_without_file_columns_for(:report) }
 
   attr_accessor :report_file_name
   attr_accessor :report_content_type

--- a/vendor/plugins/paperclip/lib/paperclip.rb
+++ b/vendor/plugins/paperclip/lib/paperclip.rb
@@ -358,7 +358,7 @@ module Paperclip
     def setup_file_columns name
       (attachment_definitions[name][:file_columns] = file_columns(name)).each do | style, column |
         raise PaperclipError.new("#{name} is not an allowed column name; please choose another column name.") if column == name.to_s
-        raise PaperclipError.new("#{self} model does not have required column '#{column}'") unless column_names.include? column
+        #raise PaperclipError.new("#{self} model does not have required column '#{column}'") unless column_names.include? column
       end
     end
     


### PR DESCRIPTION
The problem with paperclip, when using the database storage engine, is
that it needs the underlying tables to exist.  If they don't then
everything falls over.  This happens when using the observers that
import various other classes, one of which is StudyReport and that uses
paperclip, and you have yet to do 'rake db:create db:schema:load'.

This pushes the column detection into a named_scope to alleviate this
problem for the moment.
