### PR TITLE
[fixes #30397785] Moves HiSeq Spiked in controls to bottom

### DIFF
--- a/db/migrate/20120628113423_move_spiked_in_controls_to_bottom.rb
+++ b/db/migrate/20120628113423_move_spiked_in_controls_to_bottom.rb
@@ -1,0 +1,9 @@
+class MoveSpikedInControlsToBottom < ActiveRecord::Migration
+  def self.up
+    Pipeline.find_by_name('HiSeq Cluster formation PE (spiked in controls)').update_attributes!(:sorter=>9)
+  end
+
+  def self.down
+    Pipeline.find_by_name('HiSeq Cluster formation PE (spiked in controls)').update_attributes!(:sorter=>8)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120627095520) do
+ActiveRecord::Schema.define(:version => 20120628113423) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false

--- a/db/seeds/0001_workflows.rb
+++ b/db/seeds/0001_workflows.rb
@@ -502,7 +502,7 @@ end
 
 SequencingPipeline.create!(:name => 'HiSeq Cluster formation PE (spiked in controls)', :request_types => [ cluster_formation_pe_request_type ]) do |pipeline|
   pipeline.asset_type      = 'Lane'
-  pipeline.sorter          = 8
+  pipeline.sorter          = 9
   pipeline.automated       = false
   pipeline.active          = true
   pipeline.group_by_parent = false


### PR DESCRIPTION
Very simple fix, sort order is defined in the database, so a simple migration change should move the pipeline to the bottom.
