### PR TITLE
32018991 new read length for miseqs

### DIFF
--- a/app/models/mi_seq_sequencing_request.rb
+++ b/app/models/mi_seq_sequencing_request.rb
@@ -1,5 +1,5 @@
 class MiSeqSequencingRequest < SequencingRequest
-  READ_LENGTHS = [25, 50, 130, 150]
+  READ_LENGTHS = [25, 50, 130, 150, 250]
   has_metadata :as => Request  do
     #redundant with library creation , but THEY are using it .
     attribute(:fragment_size_required_from, :required =>true, :integer => true)

--- a/db/migrate/20120629131720_add250_read_length_to_miseq.rb
+++ b/db/migrate/20120629131720_add250_read_length_to_miseq.rb
@@ -1,0 +1,23 @@
+class Add250ReadLengthToMiseq < ActiveRecord::Migration
+  def self.up
+    SubmissionTemplate.find(:all, :conditions => 'name LIKE "%MiSeq%"').each do |submission_template|
+      submission_template.submission_parameters[:input_field_infos].select do |variable|
+        variable.ivars["display_name"] == "Read length"
+      end.each do |variable|
+        variable.ivars["parameters"][:selection]<<"250"
+      end
+      submission_template.save!
+    end
+  end
+
+  def self.down
+    SubmissionTemplate.find(:all, :conditions => 'name LIKE "%MiSeq%"').each do |submission_template|
+      submission_template.submission_parameters[:input_field_infos].select do |variable|
+        variable.ivars["display_name"] == "Read length"
+      end.each do |variable|
+        variable.ivars["parameters"][:selection].delete("250")
+      end
+      submission_template.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120628113423) do
+ActiveRecord::Schema.define(:version => 20120629131720) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
Adds a 250bp read length to MiSeq requests, and associated submission templates.
