### PR TITLE
[#35525863] Repair migrations so that they are more rigorous

### DIFF
--- a/app/models/illumina_b/plate_purposes.rb
+++ b/app/models/illumina_b/plate_purposes.rb
@@ -59,12 +59,24 @@ module IlluminaB::PlatePurposes
       end
     end
 
+    def destroy_tube_purposes
+      IlluminaB::PlatePurposes::TUBE_PURPOSE_FLOWS.each do |flow|
+        Tube::Purpose.find_all_by_name(flow.flatten).map(&:destroy)
+      end
+    end
+
     def create_plate_purposes
       IlluminaB::PlatePurposes::PLATE_PURPOSE_FLOWS.each do |flow|
         stock_plate = create_plate_purpose(flow.shift, :can_be_considered_a_stock_plate => true, :default_state => 'passed', :cherrypickable_target => true)
         request_type_for(stock_plate).acceptable_plate_purposes << stock_plate
 
         flow.each(&method(:create_plate_purpose))
+      end
+    end
+
+    def destroy_plate_purposes
+      IlluminaB::PlatePurposes::PLATE_PURPOSE_FLOWS.each do |flow|
+        PlatePurpose.find_all_by_name(flow.flatten).map(&:destroy)
       end
     end
 
@@ -78,9 +90,13 @@ module IlluminaB::PlatePurposes
       end
     end
 
+    def destroy_branches
+
+    end
+
     def request_type_for(stock_plate)
       # Only have one at the moment
-      RequestType.find_by_key('illumina_b_std')
+      RequestType.find_by_key('illumina_b_std') or raise "Cannot find Illumina B STD request type"
     end
     private :request_type_for
 

--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -95,15 +95,15 @@ class RequestType < ActiveRecord::Base
   end
 
   def self.dna_qc
-    find_by_key("dna_qc")
+    find_by_key("dna_qc") or raise "Cannot find dna_qc request type"
   end
 
   def self.genotyping
-    find_by_key("genotyping")
+    find_by_key("genotyping") or raise "Cannot find genotyping request type"
   end
 
   def self.transfer
-    find_by_key("transfer")
+    find_by_key("transfer") or raise "Cannot find transfer request type"
   end
 
   def extract_metadata_from_hash(request_options)

--- a/db/migrate/20120525083146_add_new_request_types_for_plate_based_illumina_b_mx_library_creation.rb
+++ b/db/migrate/20120525083146_add_new_request_types_for_plate_based_illumina_b_mx_library_creation.rb
@@ -1,5 +1,7 @@
-
 class AddNewRequestTypesForPlateBasedIlluminaBMxLibraryCreation < ActiveRecord::Migration
+  class RequestType < ActiveRecord::Base
+    set_table_name('request_types')
+  end
 
   def self.up
     ActiveRecord::Base.transaction do
@@ -23,7 +25,7 @@ class AddNewRequestTypesForPlateBasedIlluminaBMxLibraryCreation < ActiveRecord::
 
   def self.down
     ActiveRecord::Base.transaction do
-      RequestType.find_by_key('Illumina-B STD').destroy
+      RequestType.find_by_key('illumina_b_std').destroy
     end
   end
 

--- a/db/migrate/20120606131512_deprecate_old_request_types.rb
+++ b/db/migrate/20120606131512_deprecate_old_request_types.rb
@@ -1,4 +1,8 @@
 class DeprecateOldRequestTypes < ActiveRecord::Migration
+  class RequestType < ActiveRecord::Base
+    set_table_name('request_types')
+  end
+
   def self.up
     ActiveRecord::Base.transaction do
       RequestType.update_all({:deprecated => true}, ['`key` = ?', 'illumina_b_multiplexed_library_creation'])

--- a/db/migrate/20120712092358_set_standard_purposes_on_request_type.rb
+++ b/db/migrate/20120712092358_set_standard_purposes_on_request_type.rb
@@ -4,6 +4,18 @@ class SetStandardPurposesOnRequestType < ActiveRecord::Migration
     'LibraryTube'            => 'Standard library'
   }
 
+  class Tube
+    class Purpose < ActiveRecord::Base
+      set_table_name('plate_purposes')
+      set_inheritance_column(nil)
+    end
+  end
+
+  class RequestType < ActiveRecord::Base
+    set_table_name('request_types')
+    belongs_to :target_purpose, :class_name => 'SetStandardPurposesOnRequestType::Tube::Purpose'
+  end
+
   def self.up
     ActiveRecord::Base.transaction do
       TARGET_ASSET_TYPES_TO_PURPOSES.each do |target_type, purpose_name|

--- a/db/migrate/20120719101810_add_illumina_b_plate_and_tube_purposes.rb
+++ b/db/migrate/20120719101810_add_illumina_b_plate_and_tube_purposes.rb
@@ -1,12 +1,17 @@
 class AddIlluminaBPlateAndTubePurposes < ActiveRecord::Migration
   def self.up
-    ActiveRecord::Base.transaction do
-      IlluminaB::PlatePurposes.create_tube_purposes
-      IlluminaB::PlatePurposes.create_plate_purposes
-      IlluminaB::PlatePurposes.create_branches
-    end
+    do_it(:create)
   end
 
   def self.down
+    do_it(:destroy)
+  end
+
+  def self.do_it(action)
+    ActiveRecord::Base.transaction do
+      IlluminaB::PlatePurposes.send(:"#{action}_tube_purposes")
+      IlluminaB::PlatePurposes.send(:"#{action}_plate_purposes")
+      IlluminaB::PlatePurposes.send(:"#{action}_branches")
+    end
   end
 end

--- a/db/migrate/20120719102558_set_ilb_std_mx_tube_purpose_on_request_type.rb
+++ b/db/migrate/20120719102558_set_ilb_std_mx_tube_purpose_on_request_type.rb
@@ -1,4 +1,16 @@
 class SetIlbStdMxTubePurposeOnRequestType < ActiveRecord::Migration
+  class RequestType < ActiveRecord::Base
+    set_table_name('request_types')
+    belongs_to :target_purpose, :class_name => 'SetIlbStdMxTubePurposeOnRequestType::IlluminaB::MxTubePurpose'
+  end
+
+  module IlluminaB
+    class MxTubePurpose < ActiveRecord::Base
+      set_table_name('plate_purposes')
+      set_inheritance_column(nil)
+    end
+  end
+
   def self.up
     change do |request_type, tube_purpose|
       request_type.update_attributes!(:target_asset_type => nil, :target_purpose => tube_purpose)

--- a/db/migrate/20120822153953_drop_visible_column_from_submission_templates.rb
+++ b/db/migrate/20120822153953_drop_visible_column_from_submission_templates.rb
@@ -1,7 +1,7 @@
 class DropVisibleColumnFromSubmissionTemplates < ActiveRecord::Migration
   class SubmissionTemplate < ActiveRecord::Base
     set_table_name('submission_templates')
-    named_scope :should_be_hidden, :conditions => 'superceded_by != -1'
+    named_scope :should_be_hidden, :conditions => 'superceded_by_id != -1'
   end
 
   def self.up

--- a/db/migrate/20120828134537_add_cherrypick_for_illumina_request_type.rb
+++ b/db/migrate/20120828134537_add_cherrypick_for_illumina_request_type.rb
@@ -37,7 +37,9 @@ class AddCherrypickForIlluminaRequestType < ActiveRecord::Migration
     end
 
     def old_request_type
-      @old_request_type ||= RequestType.find_by_key('illumina_a_cherrypick_for_pulldown')
+      @old_request_type ||=
+        RequestType.find_by_key('illumina_a_cherrypick_for_pulldown') or
+          raise "Cannot find illumina_a_cherrypick_for_pulldown request type"
     end
 
     # Find submission_templates using the old request_type_id
@@ -53,7 +55,9 @@ class AddCherrypickForIlluminaRequestType < ActiveRecord::Migration
         # and UnDeprecate the old request_type
         old_request_type.update_attributes(:deprecated => false)
 
-        new_request_type = RequestType.find_by_key('cherrypick_for_illumina')
+        new_request_type =
+          RequestType.find_by_key('cherrypick_for_illumina') or
+            raise "Cannot find cherrypick_for_illumina request type"
 
         templates_using_request_type(new_request_type).each do |template|
           template.submission_parameters[:request_type_ids_list].shift
@@ -65,7 +69,7 @@ class AddCherrypickForIlluminaRequestType < ActiveRecord::Migration
 
         cherrypick_pipeline.request_types.delete(new_request_type)
 
-        new_request_type.destroy!
+        new_request_type.destroy
 
       end
     end


### PR DESCRIPTION
For some reason the migrations before this change were not correctly
setting the target_purpose_id information on request types.  These
changes effectively define RequestType inside migrations and ensure that
RequestType#find_by_key return result is checked for nil.
