### PR TITLE
[#34792267] Allow changes in user relationships to be observed

### DIFF
--- a/app/models/api/study_io.rb
+++ b/app/models/api/study_io.rb
@@ -40,8 +40,11 @@ class Api::StudyIO < Api::Base
     json_attributes["abbreviation"] = object.abbreviation
 
     object.roles.each do |role|
-      json_attributes[role.name.downcase.gsub(/\s+/, '_')] = role.users.map do |user|
-        { :login => user.login, :email => user.email, :name  => user.name }
+      json_attributes[role.name.downcase.gsub(/\s+/, '_')] = role.user_roles.map do |user_role|
+        { :login => user_role.user.login, :email => user_role.user.email, :name  => user_role.user.name }.tap do
+          json_attributes['updated_at'] ||= user_role.updated_at
+          json_attributes['updated_at']   = user_role.updated_at if json_attributes['updated_at'] < user_role.updated_at
+        end
       end
     end if object.respond_to?(:roles)
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,7 +3,15 @@
 # "moderator" for an instance of a model (i.e., an object), a model class,
 # or without any specification at all.
 class Role < ActiveRecord::Base
-  has_and_belongs_to_many :users
+  class UserRole < ActiveRecord::Base
+    set_table_name('roles_users')
+    belongs_to :role
+    belongs_to :user
+  end
+
+  has_many :user_role_bindings, :class_name => 'Role::UserRole'
+  has_many :users, :through => :user_role_bindings, :source => :user
+
   belongs_to :authorizable, :polymorphic => true
 
   validates_presence_of :name

--- a/app/observers/amqp_observer.rb
+++ b/app/observers/amqp_observer.rb
@@ -8,7 +8,7 @@ class AmqpObserver < ActiveRecord::Observer
     Metadata::Base,
     :billing_event,
     :batch, :batch_request,
-    :role
+    :role, 'Role::UserRole'
   )
 
   # Ensure we capture records being saved as well as deleted.
@@ -66,6 +66,7 @@ class AmqpObserver < ActiveRecord::Observer
       when record.is_a?(WellAttribute)  then yield(record.well,  nil)
       when record.is_a?(Metadata::Base) then yield(record.owner, nil)
       when record.is_a?(Role)           then determine_record_to_broadcast(record.authorizable, &block)
+      when record.is_a?(Role::UserRole) then determine_record_to_broadcast(record.role, &block)
       else                                   yield(record,       record)
       end
     end

--- a/db/migrate/20121011104707_add_timestamps_to_roles_users.rb
+++ b/db/migrate/20121011104707_add_timestamps_to_roles_users.rb
@@ -1,0 +1,15 @@
+class AddTimestampsToRolesUsers < ActiveRecord::Migration
+  def self.up
+    alter_table(:roles_users) do |t|
+      t.add_column(:created_at, :timestamp, :null => false)
+      t.add_column(:updated_at, :timestamp, :null => false)
+    end
+  end
+
+  def self.down
+    alter_table(:roles_users) do |t|
+      t.remove_column(:created_at)
+      t.remove_column(:updated_at)
+    end
+  end
+end

--- a/db/migrate/20121011104934_add_id_column_to_roles_users.rb
+++ b/db/migrate/20121011104934_add_id_column_to_roles_users.rb
@@ -1,0 +1,9 @@
+class AddIdColumnToRolesUsers < ActiveRecord::Migration
+  def self.up
+    add_column(:roles_users, :id, :primary_key)
+  end
+
+  def self.down
+    remove_column(:roles_users, :id)
+  end
+end

--- a/db/migrate/20121011104935_reset_timestamps_on_roles_users.rb
+++ b/db/migrate/20121011104935_reset_timestamps_on_roles_users.rb
@@ -1,0 +1,14 @@
+class ResetTimestampsOnRolesUsers < ActiveRecord::Migration
+  def self.up
+    ActiveRecord::Base.transaction do
+      Role::UserRole.find_each do |role_user|
+        role_user.created_at = role_user.updated_at = Time.now
+        role_user.save(false)
+      end
+    end
+  end
+
+  def self.down
+    # Do nothing!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120926081529) do
+ActiveRecord::Schema.define(:version => 20121011104935) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false
@@ -886,9 +886,11 @@ ActiveRecord::Schema.define(:version => 20120926081529) do
   add_index "roles", ["authorizable_id"], :name => "index_roles_on_authorizable_id"
   add_index "roles", ["name"], :name => "index_roles_on_name"
 
-  create_table "roles_users", :id => false, :force => true do |t|
-    t.integer "role_id"
-    t.integer "user_id"
+  create_table "roles_users", :force => true do |t|
+    t.integer  "role_id"
+    t.integer  "user_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   add_index "roles_users", ["role_id"], :name => "index_roles_users_on_role_id"

--- a/test/unit/observers/amqp_observer_test.rb
+++ b/test/unit/observers/amqp_observer_test.rb
@@ -69,19 +69,37 @@ class AmqpObserverTest < ActiveSupport::TestCase
           end
         end
 
-        should 'send the authorized record for roles' do
-          object, role = mock('Object to broadcast'), mock('Role being updated')
+        context 'role related' do
+          setup do
+            @object, @role = mock('Object to broadcast'), mock('Role being updated')
 
-          role.stubs(:destroyed?).returns(false)
-          OWNED_CLASSES.each { |c,_| role.stubs(:is_a?).with(c).returns(false) }
-          role.stubs(:is_a?).with(Role).returns(true)
-          role.stubs(:authorizable).returns(object)
+            @role.stubs(:destroyed?).returns(false)
+            OWNED_CLASSES.each { |c,_| @role.stubs(:is_a?).with(c).returns(false) }
+            @role.stubs(:is_a?).with(Role).returns(true)
+            @role.stubs(:authorizable).returns(@object)
 
-          OWNED_CLASSES.each { |c,_| object.stubs(:is_a?).with(c).returns(false) }
-          object.stubs(:is_a?).with(Role).returns(false)
-          @target.expects(:publish).with(object).once
+            OWNED_CLASSES.each { |c,_| @object.stubs(:is_a?).with(c).returns(false) }
+            @object.stubs(:is_a?).with(Role).returns(false)
+            @object.stubs(:is_a?).with(Role::UserRole).returns(false)
 
-          @target << role
+            @target.expects(:publish).with(@object).once
+          end
+
+          should 'send the authorized record for roles' do
+            @target << @role
+          end
+
+          should 'send the authorized record for a user role addition' do
+            user_role = mock('User role being added')
+
+            user_role.stubs(:destroyed?).returns(false)
+            OWNED_CLASSES.each { |c,_| user_role.stubs(:is_a?).with(c).returns(false) }
+            user_role.stubs(:is_a?).with(Role).returns(false)
+            user_role.stubs(:is_a?).with(Role::UserRole).returns(true)
+            user_role.stubs(:role).returns(@role)
+
+            @target << user_role
+          end
         end
       end
 

--- a/vendor/plugins/rails-authorization-plugin/lib/publishare/object_roles_table.rb
+++ b/vendor/plugins/rails-authorization-plugin/lib/publishare/object_roles_table.rb
@@ -11,7 +11,9 @@ module Authorization
 
       module ClassMethods
         def acts_as_authorized_user(roles_relationship_opts = {})
-          has_and_belongs_to_many :roles, roles_relationship_opts
+          has_many :user_role_bindings, :class_name => 'Role::UserRole'
+          has_many :roles, roles_relationship_opts.merge(:through => :user_role_bindings, :source => :role)
+#          has_and_belongs_to_many :roles, roles_relationship_opts
           include Authorization::ObjectRolesTable::UserExtensions::InstanceMethods
           include Authorization::Identity::UserExtensions::InstanceMethods   # Provides all kinds of dynamic sugar via method_missing
         end


### PR DESCRIPTION
This should enable the AMQP broadcast observer to see the changes that
occur between users and authorizable objects, studies in particular.
