### PR TITLE
[#38162815] API forces ordering by ID

### DIFF
--- a/app/api/core/endpoint/base.rb
+++ b/app/api/core/endpoint/base.rb
@@ -24,10 +24,12 @@ class Core::Endpoint::Base
       include Core::Endpoint::BasicHandler::Paged
 
       def _read(request, _)
-        page    = request.path.first.try(:to_i) || 1
-        results = page_of_results(request.io.eager_loading_for(request.target).include_uuid, page, request.target)
-        results.singleton_class.send(:define_method, :model) { request.target }
-        yield(self, results)
+        request.target.send(:with_scope, :find => { :order => 'id ASC' }) do
+          page    = request.path.first.try(:to_i) || 1
+          results = page_of_results(request.io.eager_loading_for(request.target).include_uuid, page, request.target)
+          results.singleton_class.send(:define_method, :model) { request.target }
+          yield(self, results)
+        end
       end
       private :_read
       standard_action(:read)


### PR DESCRIPTION
There is a problem with directly calling Model#paginate in that it does
not enforce an ordering, so plate purposes were going missing because
MySQL was effectively randomly ordering the results between calls.  The
API now forces ordering by at least ID so that this should not occur.
