### PR TITLE
[#38269813] Give asset links referential integrity

### DIFF
--- a/db/migrate/20121024075818_remove_invalid_asset_links.rb
+++ b/db/migrate/20121024075818_remove_invalid_asset_links.rb
@@ -1,0 +1,18 @@
+class RemoveInvalidAssetLinks < ActiveRecord::Migration
+  def self.up
+    # Remove any asset links that reference an asset that no longer exists
+    ActiveRecord::Base.transaction do
+      connection.update(%Q{
+        DELETE asset_links
+        FROM asset_links
+        LEFT JOIN assets AS ancestors   ON asset_links.ancestor_id=ancestors.id
+        LEFT JOIN assets AS descendants ON asset_links.descendant_id=descendants.id
+        WHERE ancestors.id IS NULL OR descendants.id IS NULL
+      })
+    end
+  end
+
+  def self.down
+    # Do nothing
+  end
+end

--- a/db/migrate/20121024075904_add_foreign_keys_from_asset_links.rb
+++ b/db/migrate/20121024075904_add_foreign_keys_from_asset_links.rb
@@ -1,0 +1,17 @@
+class AddForeignKeysFromAssetLinks < ActiveRecord::Migration
+  def self.up
+    connection.update(%Q{
+      ALTER TABLE asset_links
+      ADD FOREIGN KEY ancestor_fk(ancestor_id)     REFERENCES assets(id),
+      ADD FOREIGN KEY descendant_fk(descendant_id) REFERENCES assets(id)
+    })
+  end
+
+  def self.down
+    connection.update(%Q{
+      ALTER TABLE asset_links
+      DROP FOREIGN KEY ancestor_fk,
+      DROP FOREIGN KEY descendant_fk
+    })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20121023121041) do
+ActiveRecord::Schema.define(:version => 20121024075904) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
Asset links have turned up that reference assets that no longer exist.
These migrations remove those, as they cannot be recovered, and add
foreign key constraints to the asset_links table so that it will not
happen again.
