### PR TITLE
[#39777017] Build asset links in background

### DIFF
--- a/app/api/model_extensions/batch.rb
+++ b/app/api/model_extensions/batch.rb
@@ -58,11 +58,10 @@ module ModelExtensions::Batch
       #request.start!
 
       # All links between the two assets as new, so we can bulk create them!
-      asset_links << AssetLink.build_edge(request.asset, request.target_asset)
-
+      asset_links << [request.asset.id, request.target_asset.id]
     end
 
-    AssetLink.import(asset_links, :validate => false) unless asset_links.empty?
+    AssetLink::Bulk.create(asset_links)
 
     Request.import(
       [ :id, :asset_id ],

--- a/app/models/asset_link.rb
+++ b/app/models/asset_link.rb
@@ -1,15 +1,25 @@
 class AssetLink < ActiveRecord::Base
   include Api::AssetLinkIO::Extensions
 
-  # Convenient mechanism for queueing the creation of AssetLink instances for asynchronous processing.
+  # Enables the bulk creation of the asset links defined by the pairs passed as edges.
   # Basically we should be moving away from these and this enables us to ignore them.
-  class Job < Struct.new(:parent, :children)
-    def self.create(parent, children)
-      Delayed::Job.enqueue(new(parent.id, children.map(&:id)))
+  class BuilderJob < Struct.new(:links)
+    def perform
+      ActiveRecord::Base.transaction do
+        links.map { |parent,child| AssetLink.create!(:ancestor_id => parent, :descendant_id => child) }
+      end
     end
 
-    def perform
-      children.map { |child| AssetLink.create!(:ancestor_id => parent, :descendant_id => child) }
+    def self.create(*args)
+      Delayed::Job.enqueue(new(*args))
+    end
+  end
+
+  # Convenient mechanism for queueing the creation of AssetLink instances where there is
+  # singular parent with lots of children.
+  class Job < BuilderJob
+    def initialize(parent, children)
+      super(children.map { |child| [parent.id,child.id] })
     end
   end
 


### PR DESCRIPTION
AssetLink#import bypasses all of the validations and callbacks, and the
observer for broadcasting changes, so we need to build these
relationships in the background using delayed job.
