### PR TITLE
[fixes #40533665] Call body on response, not request

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -205,8 +205,7 @@ class SamplesController < ApplicationController
        rc.headers["User-Agent"] = "Internet Explorer 5.0"
      end
      #rc.verbose = true
-     rc.get
-     body = rc.body.to_s
+     body = rc.get.body
 
      respond_to do |format|
        format.js {render :text =>body}


### PR DESCRIPTION
Fixes the taxon ID lookup which was generating exceptions. Looking into any other potential issues with accessioning.
