### PR TITLE
[#42136521] Correctly handle changes to the volume files

### DIFF
--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -1,9 +1,7 @@
 class PlateVolume < ActiveRecord::Base
   extend DbFile::Uploader
-  
-  has_uploaded :uploaded, { :serialization_column => "uploaded_file_name" }
 
-  OFFSET = 1
+  has_uploaded :uploaded, { :serialization_column => "uploaded_file_name" }
 
   before_save :calculate_barcode_from_filename
   after_save :update_well_volumes
@@ -20,8 +18,8 @@ class PlateVolume < ActiveRecord::Base
     plate = Plate.include_wells_and_attributes.find_from_machine_barcode(barcode) or throw :no_source_plate
     location_to_well = plate.wells.map_from_locations
 
-    extract_well_volumes.each do |well_description, volume|
-      map  = Map.find_for_cell_location(well_description,plate.size)
+    extract_well_volumes do |well_description, volume|
+      map  = Map.find_for_cell_location(well_description,plate.size) or raise "Cannot find location for #{well_description.inspect} on plate size #{plate.size}"
       well = location_to_well[map] or raise "Could not find well #{map.description} on plate #{plate.id} (barcode: #{plate.barcode})"
       well.well_attribute.update_attributes!(:measured_volume => volume.to_f)
     end
@@ -29,15 +27,21 @@ class PlateVolume < ActiveRecord::Base
   private :update_well_volumes
 
   def extract_well_volumes
-    return if self.uploaded.blank?
-    csv = FasterCSV.parse(self.uploaded.file.read)
-    (OFFSET...csv.size).map { |row| [ csv[row][1], csv[row][2] ] }
+    return if self.uploaded.nil?
+    head, *tail = FasterCSV.parse(self.uploaded.file.read)
+    tail.each { |(barcode, location, volume)| yield(location, volume) }
   end
   private :extract_well_volumes
 
   # Is an update required given the timestamp specified
   def update_required?(modified_timestamp = Time.now)
     self.updated_at < modified_timestamp
+  end
+
+  def call(filename, file)
+    return unless update_required?(file.stat.mtime)
+    db_files.map(&:destroy!)
+    update_attributes!(:uploaded_file_name => filename, :updated_at => file.stat.mtime, :uploaded => file)
   end
 
   class << self
@@ -56,18 +60,16 @@ class PlateVolume < ActiveRecord::Base
 
     def handle_volume(filename, file)
       ActiveRecord::Base.transaction do
-        plate_volume, timestamp = self.find_by_uploaded_file_name(filename), file.stat.mtime
-        attributes = { :uploaded => file, :uploaded_file_name => filename, :updated_at => timestamp }
-        case
-        when plate_volume.nil?                        then self.create!(attributes)
-        when plate_volume.update_required?(timestamp) then plate_volume.update_attributes!(attributes)
-        else Rails.logger.debug "Skipping #{filename} as #{timestamp.to_s} is before #{plate_volume.updated_at.to_s}"
-        end
+        find_for_filename(filename).call(filename, file)
       end
     rescue => exception
       Rails.logger.warn("Error processing volume file #{filename}: #{exception.message}")
     end
     private :handle_volume
-  end
 
+    def find_for_filename(filename)
+      self.find_by_uploaded_file_name(filename) or
+      lambda { |filename, file| PlateVolume.create!(:uploaded_file_name => filename, :updated_at => file.stat.mtime, :uploaded => file) }
+    end
+  end
 end


### PR DESCRIPTION
Remove any DbFile references before updating the PlateVolume instance,
as this ensures that there will only ever be one associated.
