### PR TITLE
[fixes #44878753] Prevent empty arrays returning all assets

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -393,7 +393,7 @@ class Asset < ActiveRecord::Base
       else
         { :query => '(barcode=? AND barcode_prefix_id=?)', :conditions => [ barcode_number, barcode_prefix.id ] }
       end
-    end.inject({ :query => [], :conditions => [] }) do |building, current|
+    end.inject({ :query => ['FALSE'], :conditions => [nil] }) do |building, current|
       building.tap do
         building[:query]      << current[:query]
         building[:conditions] << current[:conditions]


### PR DESCRIPTION
Fixes a critical bug with the search interface
