### PR TITLE
[fixes #51393927] Use the inbox count for inbox count

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -29,8 +29,7 @@ class Request < ActiveRecord::Base
       {
         :joins => [ 'LEFT JOIN pipelines_request_types prt ON prt.request_type_id=requests.request_type_id' ],
         :conditions => [ 'prt.pipeline_id=?', pipeline.id],
-        :readonly => false,
-        :include => [:asset,:submission,:request_type]
+        :readonly => false
       }
     }
 

--- a/app/views/pipelines/_default_inbox.html.erb
+++ b/app/views/pipelines/_default_inbox.html.erb
@@ -1,8 +1,7 @@
 <h2>Input requests</h2>
 <%= render :partial => "batch_statuses" %>
 <%= render :partial => 'pipeline_limit' %>
-
-<% unless @requests.empty? -%>
+<% unless @requests_waiting == 0  -%>
 	<%= render :partial => 'pipeline_paginate' %>
   <% form_tag({:controller => :batches, :action => :create, :id => @pipeline.id}, :id => "requests_to_batch_form") do -%>
     <% if @pipeline.item_limit -%>

--- a/app/views/pipelines/_pac_bio_sequencing_inbox.html.erb
+++ b/app/views/pipelines/_pac_bio_sequencing_inbox.html.erb
@@ -2,7 +2,7 @@
 <%= render :partial => "batch_statuses" %>
 <%= render :partial => 'pipeline_limit' %>
 
-<% if @grouped_requests.empty? -%>
+<% if @requests_waiting == 0 -%>
   There are no outstanding requests for this pipeline.
 <% else -%>
 	<%= render :partial => 'pipeline_paginate' %>
@@ -10,8 +10,8 @@
     <% if @pipeline.item_limit -%>
       <input type="hidden" id="batch_item_limit" value="<%= @pipeline.item_limit %>" />
     <% end -%>
-    
-    
+
+
     <table width="100%" bgcolor="#edf5ff" cellpadding="2" cellspacing="0" class="sortable" id='request_inbox'>
       <thead>
         <tr>
@@ -24,7 +24,7 @@
           <% @information_types.each do |information_type| %>
             <% next if information_type.hide_in_inbox %>
             <th class='label' style='text-align: left' width='5%'><%= link_to "#{information_type.label}", "javascript:void(0);" %></th>
-          <% end %>    
+          <% end %>
           <th class='label' width='5%'><%= link_to "Study", "javascript:void(0);" %></th>
         </tr>
       </thead>
@@ -49,7 +49,7 @@
                 <td class='request' width='5%'><%= h(request.request_metadata[information_type.key]) %></td>
               <% end %>
               <td class='request' width='5%'><%= request.submission.name %></td>
-            </tr>        
+            </tr>
 
           <tr class="nested" id="<%= request_item.item_id %>_0" style="display:none">
              <td>&nbsp;</td>
@@ -66,8 +66,8 @@
               <% progr = indice + 1 %>
             <tr class="nested" id="<%= request_item.item_id %>_<%= progr.to_s %>" style="display:none">
               <td class="request" width='2%'>&nbsp;</td>
-              <td>                  
-    	        <%= label(:request, request.id, "Select Request #{indice}", :style => 'display:none') %>                                     
+              <td>
+    	        <%= label(:request, request.id, "Select Request #{indice}", :style => 'display:none') %>
     		    <%= check_box :request, request.id, :value => request.id %>
     		  </td>
               <td class='request' width='5%'><%= link_to request.id, "#{configatron.studies_url}/requests/#{request.id}" %></td>
@@ -85,8 +85,8 @@
       </tbody>
     </table>
 
-    
-    
+
+
 	  <%= render :partial => 'inbox_submission_button' %>
   <% end -%>
 

--- a/app/views/pipelines/_request_group_by_submission_inbox.html.erb
+++ b/app/views/pipelines/_request_group_by_submission_inbox.html.erb
@@ -2,7 +2,7 @@
 <%= render :partial => "batch_statuses" %>
 <%= render :partial => 'pipeline_limit' %>
 
-<% if @grouped_requests.empty? -%>
+<% if @requests_waiting == 0 -%>
   There are no outstanding requests for this pipeline.
 <% else -%>
 	<%= render :partial => 'pipeline_paginate' %>


### PR DESCRIPTION
Calling .empty? on the inbox scope generates an SQL
request which attempts to join across half the database.
This takes ages. Fortunately the inbox scope already
provides a special count action, which we can use instead.

This makes inboxes much faster.
