### PR TITLE
[fixes #52368663] Remove 200000 offset and shift base

### DIFF
--- a/app/models/asset_barcode.rb
+++ b/app/models/asset_barcode.rb
@@ -1,13 +1,12 @@
 class AssetBarcode < ActiveRecord::Base
   # This class only a concurrency safe counter to generate asset barcode
   def self.new_barcode
-    offset = 200000
-    barcode = (AssetBarcode.create!).id + offset
+    barcode = (AssetBarcode.create!).id
 
-    while Asset.find_by_barcode(barcode.to_s) 
-      barcode = (AssetBarcode.create!).id + offset
+    while Asset.find_by_barcode(barcode.to_s)
+      barcode = (AssetBarcode.create!).id
     end
-    
+
     (barcode).to_s
   end
 end

--- a/db/migrate/20130626082027_increment_barcode_counter_by200000.rb
+++ b/db/migrate/20130626082027_increment_barcode_counter_by200000.rb
@@ -1,0 +1,11 @@
+class IncrementBarcodeCounterBy200000 < ActiveRecord::Migration
+  def self.up
+    last_barcode = AssetBarcode.last.id.to_i
+    execute %Q{
+      INSERT INTO `asset_barcodes` (`id`) VALUES (#{last_barcode+200000});
+    }
+  end
+
+  def self.down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130607150607) do
+ActiveRecord::Schema.define(:version => 20130626082027) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
The offset is just asking for trouble.

Note: this update REQUIRES sequencescape downtime to ensure the barcodes are correctly updated. Ensure that ALL Sequencescape processes are killed before running the migration.
