### PR TITLE
[fixes #58062774] Restrict study name length

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -106,6 +106,7 @@ class Study < ActiveRecord::Base
 
   validates_presence_of :name
   validates_uniqueness_of :name, :on => :create, :message => "already in use (#{self.name})"
+  validates_length_of :name, :maximum => 200
   validates_format_of :abbreviation, :with => /^[\w_-]+$/i, :allow_blank => false, :message => 'cannot contain spaces or be blank'
 
   validate :validate_ethically_approved

--- a/test/unit/study_test.rb
+++ b/test/unit/study_test.rb
@@ -322,6 +322,24 @@ class StudyTest < ActiveSupport::TestCase
       end
 
     end
+
+    context 'study name' do
+
+      setup do
+        @study = Factory :study
+      end
+
+      should 'accept names shorter than 200 characters' do
+        assert @study.update_attributes!(:name=>'Short name')
+      end
+
+      should 'reject names longer than 200 characters' do
+        assert_raise(ActiveRecord::RecordInvalid) do
+          @study.update_attributes!(:name=>'a'*201)
+        end
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
Limit study names to 200 characters. This is due to file names of >255 characters being generated at later stages of the pipeline otherwise, causing issues with accessioning.
