### PR TITLE
Fix cherrypick for Illumina-C request type

### DIFF
--- a/db/migrate/20131008135410_illumina_c_cherrypick_requests_should_be_right_class.rb
+++ b/db/migrate/20131008135410_illumina_c_cherrypick_requests_should_be_right_class.rb
@@ -1,0 +1,13 @@
+class IlluminaCCherrypickRequestsShouldBeRightClass < ActiveRecord::Migration
+  def self.up
+    ActiveRecord::Base.transaction do
+      RequestType.find_by_key('illumina_c_cherrypick').update_attributes!(:request_class_name=>'CherrypickForPulldownRequest')
+    end
+  end
+
+  def self.down
+    ActiveRecord::Base.transaction do
+      RequestType.find_by_key('illumina_c_cherrypick').update_attributes!(:request_class_name=>'Request')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130916095432) do
+ActiveRecord::Schema.define(:version => 20131008135410) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false


### PR DESCRIPTION
Actually a bit redundant, as updated to be the same
as the chreeypick for Illumina-C. Clean up when I
refactor the submission templates.
