### PR TITLE
Update dev environment to use jruby-1.7.4

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,3 +1,3 @@
 SUFFIX=''
 [ -f database_suffix ] && SUFFIX="-$( cat database_suffix )"
-rvm use jruby-1.6.8@sequencescape${SUFFIX} --create
+rvm use jruby-1.7.4@sequencescape${SUFFIX} --create

--- a/config/environments/cucumber.rb
+++ b/config/environments/cucumber.rb
@@ -25,3 +25,10 @@ config.action_controller.allow_forgery_protection    = false
 config.action_mailer.delivery_method = :test
 
 config.active_record.observers = [ :batch_cache_sweeper, :request_observer ]
+
+if defined?(ENV_JAVA)
+  ENV_JAVA['http.proxyHost'] = nil
+  ENV_JAVA['http.proxyPort'] = nil
+  ENV_JAVA['https.proxyHost'] = nil
+  ENV_JAVA['https.proxyPort'] = nil
+end


### PR DESCRIPTION
We override the proxy options, as jruby-1.7.4 helpfully imports
the java proxy settings, but fails to pay attention to the proxy
exceptions. This is fixed in later versions of jruby, but sadly
rubygem issues prevent use from going higher than 1.7.4.

pick Add text for HiSeq 2500 metadata
