### PR TITLE
Completed batch transition error message

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -127,6 +127,12 @@ class WorkflowsController < ApplicationController
     @stage = params[:id].to_i
     @task = @workflow.tasks[@stage]
     @batch = Batch.find(params[:batch_id], :include => [:requests, :pipeline, :lab_events])
+
+    if [:completed?, :released?, :failed?, :discarded?].map {|s| @batch.send(s) }.any?
+      flash[:error] = "You cannot execute more tasks in a completed batch."
+      redirect_to :back
+    end
+
     ActiveRecord::Base.transaction do
       # If params[:next_stage] is nil then just render the current task
       # else actually execute the task.


### PR DESCRIPTION
Adds batch completed message to workflow in case we try to go to a state where we cannot go because there is no connection in the state machine.
