### PR TITLE
Remove redundant code block

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -393,12 +393,6 @@ class Request < ActiveRecord::Base
   def remove_unused_assets
     ActiveRecord::Base.transaction do
       return if target_asset.nil?
-      target_asset.requests do |related_request|
-        target_asset.remove_unused_assets
-        releated_request.asset.ancestors.clear
-        releated_request.asset.destroy
-        releated_request.save!
-      end
       self.target_asset.ancestors.clear
       self.target_asset.destroy
       self.save!


### PR DESCRIPTION
This block never fires as it appears to be missing an each.
The first line of the block would raise a method_missing exception if it did execute.
related_request.asset = target_asset in all cases, so the block is completely redundant anyway

I can only assume it was supposed to walk down the request graph, but even then what I can only suppose was intended to be a recursive remove_unused_assets call would cover everything.

But the block has been entirely non-functional for three years, and redundant since the move to git. So I'm nuking it, as restoring the intended behaviour based on guesswork is just going to cause trouble; leaving the code here is just going to cause headaches.
