### PR TITLE
[#74387912] Modifies fluidigm file to select correct plate type by using plate.size

### DIFF
--- a/app/views/plates/fluidigm_file.csv.erb
+++ b/app/views/plates/fluidigm_file.csv.erb
@@ -2,7 +2,7 @@ File Format,BioMark Sample Format V1.0,,,,,,,
 Sample Plate Name,<%= @parents.map(&:sanger_human_barcode).join('/')%>,,,,,,,
 Barcode ID,<%= @plate.fluidigm_barcode %>,,,,,,,
 Description,<%= @parents.map(&:sanger_human_barcode) %>,,,,,,,
-Plate Type,<%= @parents.count > 1 ? 'SBS384' : 'SBS96' %>,,,,,,,
+Plate Type,<%= @plate.size == 192 ? 'SBS384' : 'SBS96' %>,,,,,,,
 ,,,,,,,,
 Well Location,Sample Name,Sample Concentration,Sample Type,,,,,
 <% padded_wells_by_row(@plate) do |well,sample,conc,type| -%>


### PR DESCRIPTION
Sets plate.type into  fluidigm_file.csv to SBS384 when plate.size == 192; SBS96 otherwise.
