### PR TITLE
Create sample manifest wells in transaction

### DIFF
--- a/app/models/sample_manifest/plate_behaviour.rb
+++ b/app/models/sample_manifest/plate_behaviour.rb
@@ -135,11 +135,13 @@ module SampleManifest::PlateBehaviour
   end
 
   def generate_wells_asynchronously(well_data_with_ids, plate_id)
-    # Ensure the order of the wells are maintained
-    maps      = Hash[Map.find(well_data_with_ids.map(&:first)).map { |map| [ map.id, map ] }]
-    well_data = well_data_with_ids.map { |map_id,sample_id| [ maps[map_id], sample_id ] }
+    ActiveRecord::Base.transaction do
+      # Ensure the order of the wells are maintained
+      maps      = Hash[Map.find(well_data_with_ids.map(&:first)).map { |map| [ map.id, map ] }]
+      well_data = well_data_with_ids.map { |map_id,sample_id| [ maps[map_id], sample_id ] }
 
-    generate_wells(well_data, Plate.find(plate_id))
+      generate_wells(well_data, Plate.find(plate_id))
+    end
   end
   handle_asynchronously :generate_wells_asynchronously
 


### PR DESCRIPTION
This effectively wraps the delayed job in a transaction. As a result we:
1) Generate far fewer warehouse messages
2) Protect against problems halfway through the process
3) Improve speed ~70s => 20s
