### PR TITLE
Use rake task to clean up Carrierwave cache

### DIFF
--- a/app/models/qc_file.rb
+++ b/app/models/qc_file.rb
@@ -36,8 +36,11 @@ class QcFile < ActiveRecord::Base
       uploaded_data.cache!(uploaded_data.file)
       yield(uploaded_data)
     ensure
-      # Clear the cached file once done
-      uploaded_data.file.delete
+      # We can't actually delete the cache file here, as the send_file
+      # operation happens asynchronously. Instead we can use:
+      # PolymorphicUploader.clean_cached_files!
+      # This cleans the last 24h worth of files, so should be a daily
+      # cron
     end
   end
 

--- a/app/uploaders/polymorphic_uploader.rb
+++ b/app/uploaders/polymorphic_uploader.rb
@@ -13,15 +13,15 @@ module CarrierWave
       def retrieve!(identifier)
         CarrierWave::Storage::DirectDatabase::File.new(uploader, self, uploader.store_path(identifier))
       end
-      
+
       class File
         def initialize(uploader, base, path)
           @uploader = uploader
           @path = path
           @base = base
         end
-          
-        # Returns the current path of the file 
+
+        # Returns the current path of the file
         def path
           @path
         end
@@ -29,12 +29,12 @@ module CarrierWave
         def size
           current_data.size
         end
-        
+
         # Reads the contents of the file
         def read
           current_data
         end
-        
+
         # Remove the file
         def delete
           puts "Deleting file from database"
@@ -46,12 +46,12 @@ module CarrierWave
           raise NotImplementedError, "Files are stored in the database, so are not available directly through a URL"
         end
 
-        # Stores the file in the DbFiles model - split across many rows if size > 200KB 
+        # Stores the file in the DbFiles model - split across many rows if size > 200KB
         def store(file)
           each_slice(file) do |start, finish|
             @uploader.model.db_files.create!(:data => file.slice(start, finish))
           end
-          
+
           # Old code from attachment_fu: doesn't seem to be needed
           # #  self.class.update_all ['db_file_id = ?', self.db_file_id = db_file.id], ['id = ?', id]
         end
@@ -66,20 +66,20 @@ module CarrierWave
             @uploader.model.content_type=type unless type.nil?
           end
         end
-        
+
         private
           # Gets the current data from the database
           def current_data
             @uploader.model.db_files.map(&:data).join
           end
-          
+
           # Destroys the file. Called in the after_destroy callback
           def destroy_file
             @uploader.model.db_files.each do |db_file|
               db_file.delete
             end
           end
-          
+
           # Yields the partitions for the file with the max_part_size boundary
           def each_slice(data)
             max_part_size = 200.kilobytes
@@ -93,26 +93,31 @@ module CarrierWave
             end
           end
       end
-    end # Database 
+    end # Database
   end # Storage
 end # CarrierWave
 class PolymorphicUploader < CarrierWave::Uploader::Base
-  
+
   def initialize(*args, &block)
     super
   end
-  
+
   def exists?
     @column.blank?
   end
-  
+
   storage CarrierWave::Storage::DirectDatabase
-  
+
   # This is where files are stored on upload. We are using callbacks to empty it after upload
-  def cache_dir
+  def self.cache_dir
      "#{Rails.root}/tmp/uploads"
   end
-  
+
+  def cache_dir
+    self.class.cache_dir
+  end
+
+
   before :store, :remember_cache_id
   after :store, :delete_tmp_dir
 
@@ -127,8 +132,8 @@ class PolymorphicUploader < CarrierWave::Uploader::Base
       FileUtils.rm_rf(File.join(cache_dir, @cache_id_was))
     end
   end
-  
-  
+
+
 end
 
 

--- a/lib/tasks/carrierwave_cleanup.rake
+++ b/lib/tasks/carrierwave_cleanup.rake
@@ -1,0 +1,8 @@
+namespace :tmp do
+  namespace :carrierwave do
+    desc "Remove the past 24h of cached carrierwave files"
+    task :cleanup => :environment do
+      PolymorphicUploader.clean_cached_files!
+    end
+  end
+end


### PR DESCRIPTION
send_file works asynchronously, and as a result the file
can get cleaned up before it is even sent. Here we create
a rake task that uses the built in cleanup of carrierwave
that can be run as a daily cron.

NOTE: Remember to add daily cron to deployment