### PR TITLE
[#85886858] Fallback to empty hash for creation_options in the event of ...

### DIFF
--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -78,7 +78,7 @@ class Tube < Aliquot::Receptacle
 
   class StandardMx < Tube::Purpose
     def created_with_request_options(tube)
-      tube.parent.created_with_request_options
+      tube.parent.try(:created_with_request_options)||{}
     end
 
     # Transitioning an MX library tube to a state involves updating the state of the transfer requests.  If the

--- a/features/7711055_new_request_links_broken.feature
+++ b/features/7711055_new_request_links_broken.feature
@@ -4,6 +4,7 @@ Feature: Creating new requests from an asset
     Given a sample tube called "Sample tube for testing new request" exists
       And a properly created library tube called "Library tube for testing new request" exists
       And a properly created multiplexed library tube called "Multiplexed library tube for testing new request" exists
+      And an improperly created multiplexed library tube called "Faulty Multiplexed library tube for testing new request" exists
       And I have an "active" study called "Study testing new request"
       And I have an "approved" project called "Project testing new request"
 
@@ -48,9 +49,10 @@ Feature: Creating new requests from an asset
 
     @multiplexed_library_tube
     Scenarios:
-      | asset type               | link to follow                | page                                     |
-      | Multiplexed library tube | Request additional sequencing | show page                                |
-      | Multiplexed library tube | Request additional sequencing | "Next-gen sequencing" workflow show page |
+      | asset type                      | link to follow                | page                                     |
+      | Multiplexed library tube        | Request additional sequencing | show page                                |
+      | Faulty Multiplexed library tube | Request additional sequencing | show page                                |
+      | Multiplexed library tube        | Request additional sequencing | "Next-gen sequencing" workflow show page |
 
   @manager
   Scenario Outline: Request more sequencing as the manager of a study for the asset

--- a/features/step_definitions/various_object_construction_steps.rb
+++ b/features/step_definitions/various_object_construction_steps.rb
@@ -10,6 +10,10 @@ Given /^(?:a|the) properly created ((?:multiplexed )?library tube) (?:named|call
   Factory(:"full_#{type.gsub(/[^a-z0-9]+/, '_')}", :name => name)
 end
 
+Given /^(?:an|the) improperly created ((?:multiplexed )?library tube) (?:named|called) "([^\"]+)" exists$/ do |type, name|
+  Factory(:"broken_#{type.gsub(/[^a-z0-9]+/, '_')}", :name => name)
+end
+
 Given /^an (item) named "([^\"]+)" exists$/ do |type,name|
   Factory(type.gsub(/[^a-z0-9]+/, '_').to_sym, :name => name)
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -589,6 +589,10 @@ Factory.define :full_multiplexed_library_tube, :parent => :multiplexed_library_t
   end
 end
 
+Factory.define :broken_multiplexed_library_tube, :parent => :multiplexed_library_tube do |multiplexed_library_tube|
+
+end
+
 Factory.define :multiplexed_library_creation_request, :parent => :request do |request|
   request_type = RequestType.find_by_name('Multiplexed library creation') or raise "Cannot find 'Multiplexed library creation' request type"
 


### PR DESCRIPTION
...missing parent

I'm not certain about this fix, as it is a bit of a patch on bad data.
I'm going to be fixing the actual problem underlying out current issues,
which is the wrong purpose being assigned to MX library tubes from certain pipelines.

This fix does make things more pleasant for the users, but could result in more
serious underlying issues getting overlooked.
