### PR TITLE
[fixes #85598438] Hyphenate long study titles on worksheets

### DIFF
--- a/public/stylesheets/print.css
+++ b/public/stylesheets/print.css
@@ -15,11 +15,15 @@ div.sample {
 }
 
 #header{
-	display: block;	
+	display: block;
 	font-size: 10pt;
 }
 #header h1{
-	
+	-moz-hyphens: auto;
+	-webkit-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
+	word-wrap: break-word;
 }
 
 #batchbarcode{


### PR DESCRIPTION
Study names tend to use underscores in place of spaces, which
result in long words. Here we tell the browser to hyphenate words
or fall back to word breaks if things get desperate.