### PR TITLE
[#87191698] Add asset group move interface

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -512,4 +512,8 @@ class Asset < ActiveRecord::Base
     []
   end
 
+  def automatic_move?
+    false
+  end
+
 end

--- a/app/models/asset_group.rb
+++ b/app/models/asset_group.rb
@@ -45,6 +45,14 @@ class AssetGroup < ActiveRecord::Base
     return asset_group
   end
 
+  def automatic_move?
+    asset_types.one? && assets.first.automatic_move?
+  end
+
+  def asset_types
+    assets.map(&:sti_type).uniq
+  end
+
   def duplicate(project)
     # TODO: Implement me
   end

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -15,6 +15,10 @@ class Tube < Aliquot::Receptacle
     requests_as_target.where_is_a?(TransferRequest).all
   end
 
+  def automatic_move?
+    true
+  end
+
   named_scope :include_scanned_into_lab_event, :include => :scanned_into_lab_event
 
   named_scope :with_purpose, lambda { |*purposes|

--- a/app/views/studies/asset_groups/_reception_form.html.erb
+++ b/app/views/studies/asset_groups/_reception_form.html.erb
@@ -1,0 +1,11 @@
+
+<% form_for :receptions, :url => { :controller => receptions_path, :action => receive_barcode } do |f| %>
+<%= hidden_field :type, :id, :value=>type %><br />
+<ul class="plate_import">
+  <% barcodes.each_with_index do |barcode,i| %>
+  <li><%= hidden_field :barcode, i, :value=> barcode %></li>
+  <% end %>
+  <li><%= submit_tag "Move #{type}s to new location" %></li>
+</ul>
+<% end %>
+

--- a/app/views/studies/asset_groups/show.html.erb
+++ b/app/views/studies/asset_groups/show.html.erb
@@ -37,6 +37,10 @@
   <% end %>
 <hr />
 <% end %>
+<% if @asset_group.automatic_move? %>
+  <%= render :partial => "reception_form", :locals =>{ :barcodes => @asset_group.assets.map(&:ean13_barcode), :receive_barcode => "receive_barcode", :type=>@asset_group.asset_types.first} %>
+<hr />
+<% end %>
 <div class='section'>
   <% if current_user.is_admin? %>
     <%= link_to 'Edit', edit_study_asset_group_path(@study, @asset_group) %> |

--- a/test/unit/asset_group_test.rb
+++ b/test/unit/asset_group_test.rb
@@ -6,8 +6,11 @@ class AssetGroupTest < ActiveSupport::TestCase
       Study.destroy_all
       @asset1 = mock("Asset 1")
       @asset1.stubs(:id).returns(1)
+      @asset1.stubs(:sti_type).returns('Tube')
+      @asset1.stubs(:automatic_move?).returns(true)
       @asset2 = mock("Asset 2")
       @asset2.stubs(:id).returns(2)
+      @asset2.stubs(:sti_type).returns('Tube')
       @asset3 = mock("Asset 3")
       @asset3.stubs(:id).returns(3)
       @assets = []
@@ -20,12 +23,69 @@ class AssetGroupTest < ActiveSupport::TestCase
       assert_equal 2, @asset_group.assets.size
     end
 
+    should "report its asset types" do
+      assert_equal ['Tube'], @asset_group.asset_types
+    end
+
+    should "support automatic_move?" do
+      assert @asset_group.automatic_move?
+    end
+
     should "add to its assets" do
       assert_equal 2, @asset_group.assets.size
       @asset_group.assets << @asset3
       @asset_group.reload
       assert_equal 3, @asset_group.assets.size
     end
+  end
+
+  context "A mixed AssetGroup" do
+    setup do
+      Study.destroy_all
+      @asset1 = mock("Asset 1")
+      @asset1.stubs(:id).returns(1)
+      @asset1.stubs(:sti_type).returns('Tube')
+      @asset1.stubs(:automatic_move?)
+      @asset2 = mock("Asset 2")
+      @asset2.stubs(:id).returns(2)
+      @asset2.stubs(:sti_type).returns('Well')
+      @assets = []
+      @study = Factory :study
+      @asset_group = Factory :asset_group, :study_id => @study.id
+      @asset_group.stubs(:assets).returns([@asset1,@asset2])
+    end
+
+
+    should "report its asset types" do
+      assert_equal ['Tube','Well'], @asset_group.asset_types
+    end
+
+    should "not support automatic_move?" do
+      assert !@asset_group.automatic_move?
+    end
+
+  end
+
+  context "With immovable assets" do
+    setup do
+      Study.destroy_all
+      @asset1 = mock("Asset 1")
+      @asset1.stubs(:id).returns(1)
+      @asset1.stubs(:sti_type).returns('Tube')
+      @asset1.stubs(:automatic_move?).returns(false)
+      @asset2 = mock("Asset 2")
+      @asset2.stubs(:id).returns(2)
+      @asset2.stubs(:sti_type).returns('Tube')
+      @assets = []
+      @study = Factory :study
+      @asset_group = Factory :asset_group, :study_id => @study.id
+      @asset_group.stubs(:assets).returns([@asset1,@asset2])
+    end
+
+    should "not support automatic_move?" do
+      assert !@asset_group.automatic_move?
+    end
+
   end
 
   context "Validation" do


### PR DESCRIPTION
Asset groups have an embedded sample reception form for
tubes only. This might get removed/revisted once we have
means of registering libraries.