### PR TITLE
[fixes #89507708] Sample registrar now sets study on aliquot

### DIFF
--- a/app/models/sample_registrar.rb
+++ b/app/models/sample_registrar.rb
@@ -1,6 +1,6 @@
 #This file is part of SEQUENCESCAPE is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
-#Copyright (C) 2007-2011,2011,2012,2013,2014 Genome Research Ltd.
+#Copyright (C) 2007-2011,2011,2012,2013,2014,2015 Genome Research Ltd.
 require 'rexml/text'
 # An instance of this class is responsible for the registration of a sample and its sample tube.
 # You can think of this as a binding between those two, within the context of a user, study and
@@ -95,7 +95,7 @@ class SampleRegistrar < ActiveRecord::Base
     record.sample_tube.name = record.sample.name
   end
   after_create do |record|
-    record.sample_tube.aliquots.create!(:sample => record.sample)
+    record.sample_tube.aliquots.create!(:sample => record.sample, :study=>record.study)
   end
 
   # SampleTubes are registered within an AssetGroup, unless the AssetGroup is unspecified.

--- a/test/unit/sample_registrar_test.rb
+++ b/test/unit/sample_registrar_test.rb
@@ -1,6 +1,6 @@
 #This file is part of SEQUENCESCAPE is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
-#Copyright (C) 2007-2011,2011,2014 Genome Research Ltd.
+#Copyright (C) 2007-2011,2011,2014,2015 Genome Research Ltd.
 require "test_helper"
 
 class SampleRegistrarTest < ActiveSupport::TestCase
@@ -41,6 +41,10 @@ class SampleRegistrarTest < ActiveSupport::TestCase
       should 'put the sample into the study' do
         @study.reload
         assert_contains(@study.samples, Sample.last)
+      end
+
+      should 'put the aliquots into the study' do
+        assert_equal @study, SampleTube.last.aliquots.first.study
       end
 
       should 'make the user the owner of the sample' do


### PR DESCRIPTION
We have a large number of aliquots missing study, most of these come via the sample registrar. Ideally we want to be able to enforce the presence of study on aliquot.