### PR TITLE
Use request.id ASC as fallback sort for batch.requests

### DIFF
--- a/app/api/model_extensions/batch.rb
+++ b/app/api/model_extensions/batch.rb
@@ -6,7 +6,7 @@ module ModelExtensions::Batch
     base.class_eval do
       # These were in Batch but it makes more sense to keep them here for the moment
       has_many :batch_requests, :include => :request, :inverse_of => :batch
-      has_many :requests, :through => :batch_requests, :inverse_of => :batch, :order => 'batch_requests.position ASC' do
+      has_many :requests, :through => :batch_requests, :inverse_of => :batch, :order => 'batch_requests.position ASC, request.id ASC' do
         # we redefine count to use the fast one.
         # the normal request.count is slow because of the eager load of requests in batch_request
         def count


### PR DESCRIPTION
While strictly speaking we never specified a batch sort
order before, in practice MySQL would almost always
return the requests in id order, and some code assumed this
would be the case. When we specified position however
MySQL tended to flip the order requests were returned in
when position was NULL. This causes issues with fluidigm
where plate order is assumed.