### PR TITLE
Revert "Use request.id ASC as fallback sort for batch.requests"

### DIFF
--- a/app/api/model_extensions/batch.rb
+++ b/app/api/model_extensions/batch.rb
@@ -6,7 +6,7 @@ module ModelExtensions::Batch
     base.class_eval do
       # These were in Batch but it makes more sense to keep them here for the moment
       has_many :batch_requests, :include => :request, :inverse_of => :batch
-      has_many :requests, :through => :batch_requests, :inverse_of => :batch, :order => 'batch_requests.position ASC, request.id ASC' do
+      has_many :requests, :through => :batch_requests, :inverse_of => :batch, :order => 'batch_requests.position ASC' do
         # we redefine count to use the fast one.
         # the normal request.count is slow because of the eager load of requests in batch_request
         def count


### PR DESCRIPTION
Reverts sanger/sequencescape#1035