### PR TITLE
Fix x10 submission processing

### DIFF
--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -251,6 +251,7 @@ class BulkSubmission < ActiveRecord::Base
       attributes[:request_options][:bait_library_name]            ||= details['bait library']           unless details['bait library'].blank?
       attributes[:request_options]['pre_capture_plex_level']        = details['pre-capture plex level'] unless details['pre-capture plex level'].blank?
       attributes[:request_options]['gigabases_expected']            = details['gigabases expected']     unless details['gigabases expected'].blank?
+      attributes[:request_options][:multiplier]                     = {}
 
       # Deal with the asset group: either it's one we should be loading, or one we should be creating.
       begin
@@ -287,13 +288,14 @@ class BulkSubmission < ActiveRecord::Base
       end
 
       # Create the order.  Ensure that the number of lanes is correctly set.
-      template          = find_template(details['template name'])
-      request_types     = RequestType.all(:conditions => { :id => template.submission_parameters[:request_type_ids_list].flatten })
-      lane_request_type = request_types.detect(&:targets_lanes?)
+      sub_template      = find_template(details['template name'])
       number_of_lanes   = details.fetch('number of lanes', 1).to_i
-      attributes[:request_options][:multiplier] = { lane_request_type.id => number_of_lanes } if lane_request_type.present?
 
-      return template.new_order(attributes)
+      sub_template.new_order(attributes).tap do |new_order|
+        new_order.request_type_multiplier do |multiplexed_request_type_id|
+          new_order.request_options[:multiplier][multiplexed_request_type_id] = number_of_lanes
+        end
+      end
     rescue => exception
       errors.add :spreadsheet, "There was a problem on row(s) #{details['rows']}: #{exception.message}"
       nil

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -1,6 +1,6 @@
 #This file is part of SEQUENCESCAPE is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
-#Copyright (C) 2011,2012,2013,2014 Genome Research Ltd.
+#Copyright (C) 2011,2012,2013,2014,2015 Genome Research Ltd.
 class ActiveRecord::Base
   class << self
     def find_by_id_or_name(id, name)

--- a/app/models/flexible_submission.rb
+++ b/app/models/flexible_submission.rb
@@ -17,9 +17,11 @@ class FlexibleSubmission < Order
   end
 
   def request_type_multiplier(&block)
-    RequestType.find(:all,:conditions=>{:id=>request_types,:for_multiplexing=>true}).each do |mx_request|
+    return nil if request_types.blank?
+    mxr = RequestType.find(:all,:conditions=>{:id=>request_types,:for_multiplexing=>true}).each do |mx_request|
       yield(request_types[request_types.index(mx_request.id)+1].to_s.to_sym)
-    end unless request_types.blank?
+    end
+    yield(request_types.first.to_s.to_sym) if mxr.empty?
     nil
   end
 

--- a/app/models/submission/submission_creator.rb
+++ b/app/models/submission/submission_creator.rb
@@ -210,7 +210,7 @@ class Submission::SubmissionCreator < Submission::PresenterSkeleton
   private :find_assets_from_text
 
   def find_wells_in_array(plate,well_array)
-    return plate.wells.with_aliquots if well_array.empty?
+    return plate.wells.with_aliquots.find(:all,:select=>'DISTINCT assets.*') if well_array.empty?
     well_array.map do |map_description|
       case map_description
       when /^[a-z,A-Z][0-9]+$/ # A well
@@ -221,9 +221,9 @@ class Submission::SubmissionCreator < Submission::PresenterSkeleton
           well
         end
       when /^[a-z,A-Z]$/ # A row
-        plate.wells.with_aliquots.in_plate_row(map_description,plate.size)
+        plate.wells.with_aliquots.in_plate_row(map_description,plate.size).find(:all,:select=>'DISTINCT assets.*')
       when /^[0-9]+$/ # A column
-        plate.wells.with_aliquots.in_plate_column(map_description,plate.size)
+        plate.wells.with_aliquots.in_plate_column(map_description,plate.size).find(:all,:select=>'DISTINCT assets.*')
       else
         raise InvalidInputException, "#{map_description} is not a valid well location"
       end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -593,7 +593,6 @@ Factory.define(:library_creation_request_for_testing_sequencing_requests, :class
   end
 end
 
-
 Factory.define :library_creation_request, :parent => :request do |request|
   request_type = RequestType.find_by_name('Library creation') or raise "Cannot find 'Library creation' request type"
 

--- a/test/factories/pulldown_factories.rb
+++ b/test/factories/pulldown_factories.rb
@@ -85,6 +85,18 @@ Factory.define(:partial_plate, :class => Plate) do |plate|
   end
 end
 
+Factory.define(:two_column_plate, :class => Plate) do |plate|
+  plate.size 96
+
+  plate.after_build do |plate|
+    plate.plate_purpose = PlatePurpose.stock_plate_purpose
+  end
+
+  plate.after_create do |plate|
+    plate.wells.import(Map.where_plate_size(plate.size).where_plate_shape(plate.asset_shape).in_column_major_order.slice(0,16).map { |map| Factory(:well, :map => map) })
+  end
+end
+
 Factory.define(:full_plate_with_samples, :parent => :full_plate) do |plate|
   plate.after_create do |plate|
     plate.wells.each { |well| well.aliquots.create!(:sample => Factory(:sample)) }

--- a/test/functional/submissions_controller_test.rb
+++ b/test/functional/submissions_controller_test.rb
@@ -1,6 +1,6 @@
 #This file is part of SEQUENCESCAPE is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
-#Copyright (C) 2012,2013 Genome Research Ltd.
+#Copyright (C) 2012,2013,2015 Genome Research Ltd.
 require "test_helper"
 require 'submissions_controller'
 

--- a/test/functional/submissions_controller_test.rb
+++ b/test/functional/submissions_controller_test.rb
@@ -96,6 +96,19 @@ class SubmissionsControllerTest < ActionController::TestCase
 
     end
 
+    context "by plate barcode with pools" do
+
+      setup do
+        @plate.wells.first.aliquots.create!(:sample=> Factory(:sample), :tag_id=>Tag.first.id)
+        post :create, plate_submission('DN123456P')
+      end
+
+      should "create the appropriate orders" do
+        assert_equal 27, Order.first.assets.count
+      end
+
+    end
+
     context "should allow submission by plate barcode and wells" do
 
       setup do

--- a/test/unit/flexible_submission_test.rb
+++ b/test/unit/flexible_submission_test.rb
@@ -6,7 +6,7 @@ require "test_helper"
 class FlexibleSubmissionTest < ActiveSupport::TestCase
   context "FlexibleSubmission" do
     setup do
-      @assets       = Factory(:full_stock_plate).wells
+      @assets       = Factory(:two_column_plate).wells
       @workflow     = Factory :submission_workflow
       @pooling      = Factory :pooling_method
     end
@@ -53,7 +53,7 @@ class FlexibleSubmissionTest < ActiveSupport::TestCase
                @mpx_submission.process!
             end
 
-            should_change("Request.count", :by => (96+8)) { Request.count }
+            should_change("Request.count", :by => (16+8)) { Request.count }
           end
         end
       end
@@ -99,7 +99,7 @@ class FlexibleSubmissionTest < ActiveSupport::TestCase
                @mpx_submission.process!
             end
 
-            should_change("Request.count", :by => (96+8)) { Request.count }
+            should_change("Request.count", :by => (16+8)) { Request.count }
 
             should "set target assets according to the request_type.pool_by" do
               rows = (0...8).map
@@ -153,9 +153,9 @@ class FlexibleSubmissionTest < ActiveSupport::TestCase
             @mx_submission_with_multiplication_factor.process!
           end
 
-          should "create 96 library requests and 40 sequencing requests" do
+          should "create 16 library requests and 40 sequencing requests" do
             lib_requests = Request.find_all_by_submission_id_and_request_type_id(@mx_submission_with_multiplication_factor, @mx_request_type.id)
-            assert_equal 96, lib_requests.count
+            assert_equal 16, lib_requests.count
             seq_requests = Request.find_all_by_submission_id_and_request_type_id(@mx_submission_with_multiplication_factor, @pe_request_type.id)
             assert_equal 16, seq_requests.count
           end


### PR DESCRIPTION
Fixes three independent bugs:
1) Submission of multiplexed asses would create one request per sample
2) FlexibleSubmissions would ignore lane numbers when non-plexed
NOTE: The solution here isn't ideal, as it doesn't support single plexed library creation.
3) Bulk submissions were multiplying the last request only.

Really we should look at unifying the two submission processes a little more.