### PR TITLE
PlateCreator fix

### DIFF
--- a/db/migrate/20150528133638_fix_add_parent_purpose_to_plate_creators.rb
+++ b/db/migrate/20150528133638_fix_add_parent_purpose_to_plate_creators.rb
@@ -1,0 +1,36 @@
+class FixAddParentPurposeToPlateCreators < ActiveRecord::Migration
+  def self.build_purpose_config_record(plate_purpose_name, parent_purpose_name)
+    {
+      :plate_purpose => Purpose.find_by_name!(plate_purpose_name),
+      :parent_purpose => Purpose.find_by_name!(parent_purpose_name)
+    }
+  end
+
+  def self.purposes_config
+    [
+      build_purpose_config_record("Working dilution", "Stock plate"),
+      build_purpose_config_record("Pico dilution", "Working dilution"),
+      build_purpose_config_record("Pico Assay Plates", "Pico dilution")
+    ]
+  end
+
+  def self.up
+    ActiveRecord::Base.transaction do
+      self.purposes_config.each do |p|
+        Plate::Creator.find_by_name(p[:plate_purpose].name).plate_creator_purposes.each do |relation|
+          relation.update_attributes!(:parent_purpose_id =>  p[:parent_purpose].id)
+        end
+      end
+    end
+  end
+
+  def self.down
+    ActiveRecord::Base.transaction do
+      self.purposes_config.each do |p|
+        Plate::Creator.find_by_name(p[:plate_purpose].name).plate_creator_purposes.each do |relation|
+          relation.update_attributes!(:parent_purpose_id =>  nil)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20150528133638_fix_add_parent_purpose_to_plate_creators.rb
+++ b/db/migrate/20150528133638_fix_add_parent_purpose_to_plate_creators.rb
@@ -16,6 +16,7 @@ class FixAddParentPurposeToPlateCreators < ActiveRecord::Migration
 
   def self.up
     ActiveRecord::Base.transaction do
+      change_column(:plate_creator_purposes, :parent_purpose_id, :integer)
       self.purposes_config.each do |p|
         Plate::Creator.find_by_name(p[:plate_purpose].name).plate_creator_purposes.each do |relation|
           relation.update_attributes!(:parent_purpose_id =>  p[:parent_purpose].id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -778,7 +778,7 @@ ActiveRecord::Schema.define(:version => 20150528133638) do
     t.integer  "plate_purpose_id",  :null => false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "parent_purpose_id"
+    t.integer  "parent_purpose_id"
   end
 
   create_table "plate_creators", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150519105535) do
+ActiveRecord::Schema.define(:version => 20150528133638) do
 
   create_table "aliquots", :force => true do |t|
     t.integer  "receptacle_id",    :null => false

--- a/db/seeds/0019_plate_creators.rb
+++ b/db/seeds/0019_plate_creators.rb
@@ -32,28 +32,9 @@ ActiveRecord::Base.transaction do
     ]
   end
 
-  def validate_purposes_config(purposes_config)
-    purposes_config.all? { |p| !p[:plate_purpose].nil? && !p[:parent_purpose].nil? }
-  end
-
   purposes_config.each do |p|
-    relations = Plate::Creator::PurposeRelationship.find(:all, :conditions => {
-      :plate_purpose_id => p[:plate_purpose].id
-    })
-    if (relations.length == 0)
-      Plate::Creator.find(:all, :conditions => {
-        :plate_purpose_id => p[:plate_purpose].id
-      } ).each do |c|
-        Plate::Creator::PurposeRelationship.create!({
-          :plate_creator_id => c.id,
-          :plate_purpose_id => p[:plate_purpose].id,
-          :parent_purpose_id => p[:parent_purpose].id
-        })
-      end
-    else
-      relations.each do |r|
-        r.update_attributes!(:parent_purpose_id =>  p[:parent_purpose].id)
-      end
+    Plate::Creator.find_by_name(p[:plate_purpose].name).plate_creator_purposes.each do |relation|
+      relation.update_attributes!(:parent_purpose_id =>  p[:parent_purpose].id)
     end
   end
 


### PR DESCRIPTION
Migration for adding plate purposes was being incorrect while modifying PlateCreators where its plate_creator_purposes list didnt contain PlateCreator::plate_purpose. IMHO this PlateCreator::plate_purpose should be removed.