### PR TITLE
Flexible Submission builder returns multiplexed assets correctly

### DIFF
--- a/app/models/submission/flexible_request_graph.rb
+++ b/app/models/submission/flexible_request_graph.rb
@@ -38,7 +38,9 @@ module Submission::FlexibleRequestGraph
     # the multiplexing_assets
     def multiplexing_assets
       @multiplexed = true
+
       @multiplexing_assets ||= yield if block_given?
+      @multiplexing_assets
     end
 
     private

--- a/test/unit/flexible_submission_test.rb
+++ b/test/unit/flexible_submission_test.rb
@@ -55,8 +55,59 @@ class FlexibleSubmissionTest < ActiveSupport::TestCase
 
             should_change("Request.count", :by => (16+8)) { Request.count }
           end
+
         end
       end
+
+      context 'cross study/project submissions' do
+        setup do
+          @study_b   = Factory :study
+          @project_b = Factory :project
+
+          @xs_mpx_submission = FlexibleSubmission.build!(
+            :study            => @study,
+            :project          => @project,
+            :workflow         => @workflow,
+            :user             => @user,
+            :assets           => @assets.slice(0,8),
+            :request_types    => @request_type_ids,
+            :request_options  => @request_options
+          )
+          @order_b = FlexibleSubmission.prepare!(
+            :study            => @study_b,
+            :project          => @project_b,
+            :workflow         => @workflow,
+            :user             => @user,
+            :assets           => @assets.slice(8,8),
+            :request_types    => @request_type_ids,
+            :request_options  => @request_options,
+            :submission       => @xs_mpx_submission
+          )
+          @xs_mpx_submission.save!
+        end
+
+        should 'be a multiplexed submission' do
+          assert @xs_mpx_submission.multiplexed?
+        end
+
+        context "#process!" do
+
+          context 'multiple requests' do
+            setup do
+               @xs_mpx_submission.process!
+            end
+
+            should_change("Request.count", :by => (16+8)) { Request.count }
+
+            should 'not set study or project post multiplexing' do
+              assert_equal nil, @sequencing_request_type.requests.last.initial_study_id
+              assert_equal nil, @sequencing_request_type.requests.last.initial_project_id
+            end
+          end
+
+        end
+      end
+
 
     end
 


### PR DESCRIPTION
In the even no block was provided, not only would the assignment
not happen, but the statement would evaluate to nil and the
assets would not get returned.