### PR TITLE
[hotfix] Use action_flash for error messages

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -29,7 +29,7 @@ class BulkSubmissionsController < ApplicationController
         render :action => "new"
       end
     rescue ActiveRecord::RecordInvalid => exception
-      flash[:error] = exception.message
+      action_flash[:error] = exception.message
       render :action => "new"
     end
   end


### PR DESCRIPTION
We're not redirecting here (Though we probably should) so don't need to set
a cookie. Which is good, and bulk submissions can have long messages
which overflow the limits on cookie size.