### PR TITLE
Fix labwhere lookup of empty barcodes

### DIFF
--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -15,13 +15,15 @@ module LabWhereClient
     end
 
     def path_to(instance, target)
-      raise LabwhereException.new, "LabWhere service URL not set" if base_url.nil?
+      raise LabwhereException, "LabWhere service URL not set" if base_url.nil?
       [base_url, instance.endpoint, target].compact.join('/')
     end
 
     def parse_json(str)
-       return nil if str=='null'
-       JSON.parse(str)
+      return nil if str=='null'
+      JSON.parse(str)
+    rescue JSON::ParserError => e
+      raise LabwhereException.new(e), "LabWhere is returning unexpected content", e.backtrace
     end
 
     def get(instance, target)
@@ -96,6 +98,7 @@ module LabWhereClient
     attr_reader :location
 
     def self.find_by_barcode(barcode)
+      return nil if barcode.blank?
       attrs = LabWhere.instance.get(self, barcode)
       new(labwhere_result) unless attrs.nil?
     end


### PR DESCRIPTION
- Do not lookup empty barcodes
- Rescue JSON parse errors to catch odd Labwhere behaviour