### PR TITLE
[Bugfix] Update manifest filename generation

### DIFF
--- a/app/models/tasks/generate_manifest_handler.rb
+++ b/app/models/tasks/generate_manifest_handler.rb
@@ -2,8 +2,8 @@
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
 #Copyright (C) 2007-2011,2012 Genome Research Ltd.
 module Tasks::GenerateManifestHandler
-  def manifest_filename
-    ["#{study.name}", "#{batch.id}", "manifest.csv"].join("_").gsub(/\s/,"_").gsub(/[^A-Za-z0-9_\-\.]/,"")
+  def manifest_filename(name,number)
+    [name, number.to_s, "manifest.csv"].join("_").gsub(/\s/,"_").gsub(/[^A-Za-z0-9_\-\.]/,"")
   end
 
   def generate_manifest
@@ -12,7 +12,7 @@ module Tasks::GenerateManifestHandler
     csv_string = GenerateManifestsTask.generate_manifests(batch,study)
     send_data csv_string,
       :type => "text/csv",
-      :filename=> manifest_filename,
+      :filename=> manifest_filename(study.name,batch.id),
       :disposition => 'attachment'
   end
 

--- a/test/unit/tasks/generate_manifest_task_test.rb
+++ b/test/unit/tasks/generate_manifest_task_test.rb
@@ -4,11 +4,10 @@
 require "test_helper"
 
 class DummyTaskGroup
-  attr_reader :study, :batch
+  attr_reader :params
   include Tasks::GenerateManifestHandler
   def initialize(params)
-    @study = params[:study]
-    @batch = params[:batch]
+    @params = params
   end
 end
 
@@ -22,9 +21,9 @@ class GenerateManifestTaskTest < ActiveSupport::TestCase
           "Study name with any content:’'[](){}⟨⟩:,،、‒–—―…......!.‐-?‘’“”'';/⁄· &*@•^†",
           "‡°″¡¿#№÷×ºª%‰+−=‱¶′″‴§~_|‖‗¦©℗®℠™¤₳฿₵¢₡₢$₫₯₠€ƒ₣₲₴₭₺ℳ₥₦₧₱₰£៛₽₹₨₪৳₸₮₩¥⁂❧☞‽⸮◊※",
           "⁀and no more"].join('')
-          @task = DummyTaskGroup.new(:study => @study, :batch => @batch)
+          @task = DummyTaskGroup.new(:study_id => @study.id, :batch_id => @batch.id)
           name = 'Study_name_with_any_content.......-_and_no_more_1_manifest.csv'
-          assert_equal name, @task.manifest_filename
+          assert_equal name, @task.manifest_filename(@study.name,@batch.id)
         end
       end
     end


### PR DESCRIPTION
Manifest file generation was attempting to use local variables
study and batch. While these could probably be pushed out into
methods, the controller is far to overloaded with methods to
make safe for a quick fix. Until we can completely refactor
tasks, this will be the safest option.