### PR TITLE
Remove compat line

### DIFF
--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,3 +1,2 @@
-compat.version=1.9
 objectspace.enabled=false
 compile.invokedynamic=true


### PR DESCRIPTION
I didn't think jruby-9000 used this, and instead just supported
ruby 2.2. However it hasn't actually complained about the line
since it snuck back in. Removing it now to avoid confusion.