### PR TITLE
Adds the input html in the edit view instead of in the

### DIFF
--- a/app/views/shared/metadata/edit/_sample.html.erb
+++ b/app/views/shared/metadata/edit/_sample.html.erb
@@ -45,6 +45,7 @@
     <% metadata_fields.with_options(:grouping => 'ENA requirement') do |group| %>
       <%= group.select(:sample_sra_hold, Sample::SRA_HOLD_VALUES) %>
       <%= group.text_field(:sample_common_name, 'data-organism' => 'common_name') %>
+      <input class='btn btn-default validate_organism' type='button' value='Lookup'/>
       <%= group.text_field(:sample_taxon_id,    'data-organism' => 'taxon_id') %>
     <% end %>
 

--- a/config/locales/metadata/en.yml
+++ b/config/locales/metadata/en.yml
@@ -146,7 +146,7 @@ en:
         sample_common_name:
           label: Common Name
           help: Common name of sample that might be used in publication or other communications, or will be relevant and distinct within any study that refers to this sample.
-          edit_info: "<input class='validate_organism' type='button' value='Lookup'/> [ENA requirement, Array Express]"
+          edit_info: "[ENA requirement, Array Express]"
 
         sample_strain_att:
           label: Strain


### PR DESCRIPTION
localization config. If we want to use the localization for html we have to
modify the name of the variable where is stored to end with _html