### PR TITLE
Use non-breaking spaces directly

### DIFF
--- a/app/models/sequencing_request.rb
+++ b/app/models/sequencing_request.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #This file is part of SEQUENCESCAPE; it is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
 #Copyright (C) 2007-2011,2013,2014,2015,2016 Genome Research Ltd.
@@ -59,7 +60,7 @@ class SequencingRequest < CustomerRequest
   end
 
   def concentration
-    return "&nbsp" if lab_events_for_batch(batch).empty?
+    return " " if lab_events_for_batch(batch).empty?
     conc = lab_events_for_batch(batch).first.descriptor_value("Concentration")
     return "#{conc}μl" if conc.present?
     dna = lab_events_for_batch(batch).first.descriptor_value("DNA Volume")


### PR DESCRIPTION
This probably doesn't really belong here.