### PR TITLE
The qc study report was not displaying the pre-extracted plate, becau…

### DIFF
--- a/app/models/plate_purpose.rb
+++ b/app/models/plate_purpose.rb
@@ -27,6 +27,7 @@ class PlatePurpose < Purpose
   end
 
   include Relationship::Associations
+  include StudyReport::PlatePurposesFinder
 
  # We declare the scopes as lambdas as Rails 3.2 seems to fail to include the various subclasses otherwise
   scope :compatible_with_purpose, ->(purpose) {

--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -162,10 +162,8 @@ class Study < ActiveRecord::Base
   scope :alphabetical, ->() { order('name ASC') }
   scope :for_listing, ->()  { select('name, id') }
 
-  STOCK_PLATE_PURPOSES = ['Stock Plate','Stock RNA Plate', 'Pre-Extracted Plate']
-
   def each_well_for_qc_report_in_batches(exclude_existing,product_criteria)
-    base_scope = Well.on_plate_purpose(PlatePurpose.find_all_by_name(STOCK_PLATE_PURPOSES)).
+    base_scope = Well.on_plate_purpose(PlatePurpose.stock_and_act_as_stock_plate_purposes_for_qc_reports).
       for_study_through_aliquot(self).
       without_blank_samples.
       includes(:well_attribute, samples: :sample_metadata ).

--- a/app/models/study_report/plate_purposes_finder.rb
+++ b/app/models/study_report/plate_purposes_finder.rb
@@ -1,0 +1,15 @@
+module StudyReport::PlatePurposesFinder
+
+ STOCK_PLATE_PURPOSES_NAMES = ['Stock Plate','Stock RNA Plate']
+ ACT_AS_STOCK_PLATE_PURPOSES_NAMES = ['Pre-Extracted Plate']
+ ALIQUOT_PLATE_PURPOSES_NAMES = ['Aliquot 1','Aliquot 2','Aliquot 3','Aliquot 4','Aliquot 1']
+
+
+  def self.included(klass)
+    klass.instance_eval do
+      scope :stock_plate_purposes_for_qc_reports, -> { where(name: STOCK_PLATE_PURPOSES_NAMES) }
+      scope :aliquots_and_act_as_stock_plate_purposes_for_qc_reports, -> { where(name: ALIQUOT_PLATE_PURPOSES_NAMES.concat(ACT_AS_STOCK_PLATE_PURPOSES_NAMES))}
+      scope :stock_and_act_as_stock_plate_purposes_for_qc_reports, -> { where(name: STOCK_PLATE_PURPOSES_NAMES.concat(ACT_AS_STOCK_PLATE_PURPOSES_NAMES))}
+    end
+  end
+end

--- a/app/models/study_report/study_details.rb
+++ b/app/models/study_report/study_details.rb
@@ -12,7 +12,7 @@ module StudyReport::StudyDetails
     handle_wells(
       "INNER JOIN requests ON requests.asset_id=assets.id",
       "requests.initial_study_id",
-      PlatePurpose.where(name: Study::STOCK_PLATE_PURPOSES ).pluck(:id),
+      PlatePurpose.stock_plate_purposes_for_qc_reports.pluck(:id),
       &block
     )
 
@@ -20,7 +20,7 @@ module StudyReport::StudyDetails
     handle_wells(
       "INNER JOIN aliquots ON aliquots.receptacle_id=assets.id",
       "aliquots.study_id",
-      PlatePurpose.where(name:['Aliquot 1','Aliquot 2','Aliquot 3','Aliquot 4','Aliquot 1']).pluck(:id),
+      PlatePurpose.aliquots_and_act_as_stock_plate_purposes_for_qc_reports.pluck(:id),
       &block
     )
   end


### PR DESCRIPTION
…se it did not have a CreateAssetRequest

linking this asset to the Study. This was happening because this plate is not being created from a sample manifest,
but from another plate using the plate creator.
To display it in the qc report, we will search by study using the aliquot, instead of the request. We moved the
code that retrieves the specific plate purposes needed for qc report to a module belonging to study report that
will be included in the PlatePurpose class.