### PR TITLE
Disable sample caching

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -55,7 +55,7 @@ class SamplesController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.xml { cache_xml_response(@sample) }
+      format.xml { render :layout => false }
       format.json { render :json => @sample.to_json }
     end
   end


### PR DESCRIPTION
We're currently hitting file limits in the samples cache. We
could make changes to stick files in subdirectories, but
as this interface is due to be deprecated, its probably
worth just disabling it for now.