### PR TITLE
Forces the return of a list for gender markers, even when it is unknown

### DIFF
--- a/app/models/study_report/study_details.rb
+++ b/app/models/study_report/study_details.rb
@@ -84,7 +84,7 @@ module StudyReport::StudyDetails
           asset_progress_data[:measured_volume],
           asset_progress_data[:quantity],
           asset_progress_data[:sequenom_count],
-          (asset_progress_data[:sequenom_gender]||[]).join(''),
+          [(asset_progress_data[:sequenom_gender])].flatten.compact.join(''),
           asset_progress_data[:pico],
           asset_progress_data[:gel],
           asset_progress_data[:qc_status],


### PR DESCRIPTION
or we should update the sequenom_genders in well_attrributes for old studies. I'll leave this pull request for discussing it.