### PR TITLE
Hotfix - Stock metric found for all stock wells

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -528,7 +528,7 @@ class Asset < ActiveRecord::Base
   end
 
   # We only support wells for the time being
-  def latest_stock_metric(product,*args)
+  def latest_stock_metrics(product,*args)
     nil
   end
 

--- a/app/models/submission/flexible_request_graph.rb
+++ b/app/models/submission/flexible_request_graph.rb
@@ -25,7 +25,7 @@ module Submission::FlexibleRequestGraph
 
     def initialize(order,source_assets, multiplexing_assets)
       @order = order
-      @source_assets_qc_metrics = source_assets.map {|asset| Doublet.new(asset,[asset.latest_stock_metric(product)]) }
+      @source_assets_qc_metrics = source_assets.map {|asset| Doublet.new(asset,asset.latest_stock_metrics(product)) }
       @multiplexing_assets = multiplexing_assets
       @preplexed = multiplexing_assets.present?
       @built = false

--- a/app/models/submission/linear_request_graph.rb
+++ b/app/models/submission/linear_request_graph.rb
@@ -13,7 +13,7 @@ module Submission::LinearRequestGraph
     ActiveRecord::Base.transaction do
       create_request_chain!(
         build_request_type_multiplier_pairs,
-        assets.map { |asset| [ asset, [asset.latest_stock_metric(product)], create_item_for!(asset) ] },
+        assets.map { |asset| [ asset, asset.latest_stock_metrics(product), create_item_for!(asset) ] },
         multiplexing_assets,
         &block
       )

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -283,12 +283,13 @@ class Well < Aliquot::Receptacle
     plate.stock_plate?
   end
 
-  def latest_stock_metric(product)
-    raise StandardError, 'Too many stock wells to report metrics' if stock_wells.count > 1
+  def latest_stock_metrics(product)
     # If we don't have any stock wells, use ourself. If it is a stock well, we'll find our
     # qc metric. If its not a stock well, then a metric won't be present anyway
-    stock_well = stock_wells.first || self
-    stock_well.qc_metrics.for_product(product).most_recent_first.first
+    metric_wells = stock_wells.empty? ? [self] : stock_wells
+    metric_wells.map do |stock_well|
+      stock_well.qc_metrics.for_product(product).most_recent_first.first
+    end.compact.uniq
   end
 
   def source_plate

--- a/test/unit/well_test.rb
+++ b/test/unit/well_test.rb
@@ -318,7 +318,7 @@ class WellTest < ActiveSupport::TestCase
       end
 
       should 'report appropriate metrics' do
-        assert_equal @expected_metric, @well.latest_stock_metric(@our_product_criteria.product)
+        assert_equal [@expected_metric], @well.latest_stock_metrics(@our_product_criteria.product)
       end
     end
   end


### PR DESCRIPTION
The attempt to look up stock metrics was raising an exception
for re-sequencing requests from pools, as these had too many
stock wells. However, this is entirely legitimate behaviour,
the raising of an exception was over cautious.

Instead we map over each of the stock wells and find the latest report.
This is consistent with the behaviour on building of the original
submission.