### PR TITLE
ss480 only users with data_access_coordinator role can check the chec…

### DIFF
--- a/app/controllers/admin/studies_controller.rb
+++ b/app/controllers/admin/studies_controller.rb
@@ -69,6 +69,7 @@ class Admin::StudiesController < ApplicationController
     params[:study].delete(:uploaded_data)
 
     ActiveRecord::Base.transaction do
+      params[:study].delete(:ethically_approved) unless current_user.data_access_coordinator?
       @study.update_attributes!(params[:study])
       flash[:notice] = "Your study has been updated"
       redirect_to :controller => "admin/studies", :action => "update", :id => @study.id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,10 @@ class User < ActiveRecord::Base
     self.has_role? 'owner', item
   end
 
+  def data_access_coordinator?
+    self.has_role? 'data_access_coordinator'
+  end
+
   def manager_or_administrator?
     self.is_administrator? || self.is_manager?
   end

--- a/app/views/shared/_ethical_approval_upload.html.erb
+++ b/app/views/shared/_ethical_approval_upload.html.erb
@@ -6,7 +6,7 @@
 <table width="100%" cellspacing="0" cellpadding="0">
   <tr>
     <td width="40%" class="item"><%= form.label :ethically_approved, "HMDMC approved" %></td>
-    <td width="60%"><%= form.check_box :ethically_approved %></td>
+    <td width="60%"><%= form.check_box :ethically_approved, disabled: !current_user.data_access_coordinator? %></td>
   </tr>
 </table>
 <%= fields_for(@study) do |f| %>

--- a/features/administration/study_administration.feature
+++ b/features/administration/study_administration.feature
@@ -30,14 +30,27 @@ Feature: Study administration
     Given I am visiting study "Study B" homepage
     When I follow "Manage"
     Then I should see "Manage Study Study B"
-    And the checkbox labeled "HMDMC approved" should not be checked
+    And the field labeled "HMDMC approved" should be disabled
     And the field labeled "HMDMC approval number" should contain ""
+    When I fill in "HMDMC approval number" with "XX/XXX"
+    And I press "Update"
+    Then I should see "Your study has been updated"
+    And the field labeled "HMDMC approval number" should contain "XX/XXX"
+    When I press "Update"
+    Then I should see "Your study has been updated"
+
+  @javascript
+  Scenario: Data access coordinator edits study properties
+    Given I am an "data_access_coordinator and administrator" user logged in as "xyz1"
+    Given I am visiting study "Study B" homepage
+    When I follow "Manage"
+    Then I should see "Manage Study Study B"
+    And the field labeled "HMDMC approved" should not be disabled
+    And the checkbox labeled "HMDMC approved" should not be checked
     When I check "HMDMC approved"
-    And I fill in "HMDMC approval number" with "XX/XXX"
     And I press "Update"
     Then I should see "Your study has been updated"
     And the checkbox labeled "HMDMC approved" should be checked
-    And the field labeled "HMDMC approval number" should contain "XX/XXX"
     When I press "Update"
     Then I should see "Your study has been updated"
 

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -31,7 +31,10 @@ Given /^I am an? "([^\"]*)" user logged in as "([^\"]*)"$/ do |type_of_user, log
     :workflow_id => wk.id
   )
 
-  @current_user.roles << FactoryGirl.create(:role, :name => type_of_user)
+  role_names = type_of_user.split("and").collect(&:strip)
+
+  role_names.each { |name| @current_user.roles << FactoryGirl.create(:role, name: name)}
+
   # :create syntax for restful_authentication w/ aasm. Tweak as needed.
   # @current_user.activate!
 

--- a/features/step_definitions/web_form_steps.rb
+++ b/features/step_definitions/web_form_steps.rb
@@ -21,6 +21,14 @@ Then /^the checkbox labeled "([^"]+)" should be checked$/ do |label|
   step %Q{the "#{ label }" checkbox should be checked}
 end
 
+Then /^the field labeled "([^\"]*)" should be disabled$/ do |label|
+  find_field(label, disabled: true)
+end
+
+Then /^the field labeled "([^\"]*)" should not be disabled$/ do |label|
+  find_field(label)
+end
+
 Then /^option "([^"]*)" in the menu labeled "([^"]*)" should be selected$/ do |arg1, arg2|
   pending # express the regexp above with the code you wish you had
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -489,6 +489,13 @@ FactoryGirl.define do
     workflow          {|workflow| workflow.association(:submission_workflow)}
   end
 
+  factory  :data_access_coordinator, :class => "User"  do
+    login                 "abc123"
+    email                 {|a| "#{a.login}@example.com".downcase }
+    roles                 {|role| [role.association(:data_access_coordinator_role)]}
+    workflow              {|workflow| workflow.association(:submission_workflow)}
+  end
+
   factory  :role  do
     sequence(:name)   { |i| "Role #{ i }" }
     authorizable       nil
@@ -504,6 +511,10 @@ FactoryGirl.define do
 
   factory  :manager_role, :class => 'Role'  do
     name            "manager"
+  end
+
+  factory  :data_access_coordinator_role, :class => 'Role'  do
+    name            "data_access_coordinator"
   end
 
   factory  :owner_role, :class => 'Role'  do

--- a/test/functional/admin_studies_controller_test.rb
+++ b/test/functional/admin_studies_controller_test.rb
@@ -41,6 +41,18 @@ class Admin::StudiesControllerTest < ActionController::TestCase
         should redirect_to("admin studies path") { "/admin/studies/#{@study.id}" }
       end
 
+      should "change 'ethically_approved' only if user has data_access_coordinator role" do
+        put :managed_update, :id => @study.id, study: { name: @study.name, ethically_approved: "1"}
+        @study.reload
+        refute @study.ethically_approved
+
+        @user.roles << (create :data_access_coordinator_role)
+        put :managed_update, :id => @study.id, study: { name: @study.name, ethically_approved: "1"}
+        @study.reload
+        assert @study.ethically_approved
+
+      end
+
     end
 
   end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -213,5 +213,16 @@ if false
       end
     end
 
+    context "is a data_access_coordinator" do
+      setup do
+        @user = create :data_access_coordinator
+      end
+
+      should "be able to access data_access_coordinator functions" do
+        assert @user.data_access_coordinator?
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
…kbox and change 'ethically_approved' attribute, for all other users the checkbox is disabled (but visible)