### PR TITLE
Ss475 extend ss searches

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -53,6 +53,8 @@ class Submission < ActiveRecord::Base
 
   scope :latest_first, -> { order('id DESC') }
 
+  scope :for_search_query, ->(query,with_includes) { where(name:query) }
+
   before_destroy :building?, :empty_of_orders?
 
   def empty_of_orders?

--- a/app/views/searches/show/_submission.html.erb
+++ b/app/views/searches/show/_submission.html.erb
@@ -1,0 +1,1 @@
+<li>Submission: <%= link_to submission.name, submission_path(submission) -%></li>

--- a/db/migrate/20160722100506_add_index_to_accession_number.rb
+++ b/db/migrate/20160722100506_add_index_to_accession_number.rb
@@ -1,0 +1,5 @@
+class AddIndexToAccessionNumber < ActiveRecord::Migration
+  def change
+    add_index :sample_metadata, :sample_ebi_accession_number
+  end
+end

--- a/db/migrate/20160722130737_index_submission_name.rb
+++ b/db/migrate/20160722130737_index_submission_name.rb
@@ -1,0 +1,5 @@
+class IndexSubmissionName < ActiveRecord::Migration
+  def change
+    add_index :submissions, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160519124121) do
+ActiveRecord::Schema.define(:version => 20160722100506) do
 
   create_table "aliquot_indices", :force => true do |t|
     t.integer  "aliquot_id",    :null => false
@@ -1369,6 +1369,7 @@ ActiveRecord::Schema.define(:version => 20160519124121) do
     t.string   "donor_id"
   end
 
+  add_index "sample_metadata", ["sample_ebi_accession_number"], :name => "index_sample_metadata_on_sample_ebi_accession_number"
   add_index "sample_metadata", ["sample_id"], :name => "index_sample_metadata_on_sample_id"
   add_index "sample_metadata", ["supplier_name"], :name => "index_sample_metadata_on_supplier_name"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160722100506) do
+ActiveRecord::Schema.define(:version => 20160722130737) do
 
   create_table "aliquot_indices", :force => true do |t|
     t.integer  "aliquot_id",    :null => false
@@ -1633,6 +1633,7 @@ ActiveRecord::Schema.define(:version => 20160722100506) do
     t.integer  "priority",                   :limit => 1,  :default => 0, :null => false
   end
 
+  add_index "submissions", ["name"], :name => "index_submissions_on_name"
   add_index "submissions", ["state"], :name => "index_submissions_on_state"
   add_index "submissions", ["study_id_to_delete"], :name => "index_submissions_on_project_id"
 

--- a/lib/informatics.rb
+++ b/lib/informatics.rb
@@ -21,7 +21,7 @@ module Informatics
     end
 
     def global_searchable_classes
-       [ Project, Study, Sample, Asset, AssetGroup, Request, Supplier ]
+       [ Project, Study, Sample, Asset, AssetGroup, Request, Supplier, Submission ]
     end
 
     def search_options

--- a/lib/informatics/lib/informatics/globals.rb
+++ b/lib/informatics/lib/informatics/globals.rb
@@ -21,7 +21,7 @@ module Informatics
     end
 
     def global_searchable_classes
-       [ Project, Study, Sample, Asset, AssetGroup, Request, Supplier ]
+       [ Project, Study, Sample, Asset, AssetGroup, Request, Supplier, Submission ]
     end
 
     def search_options

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -30,6 +30,9 @@ class SearchesControllerTest < ActionController::TestCase
         @asset_group_to_find      =FactoryGirl.create :asset_group, :name => "FindMeAssetGroup", :study => @study
         @asset_group_to_not_find  =FactoryGirl.create :asset_group, :name => "IgnoreAssetGroup"
 
+        @sample_with_supplier_name = FactoryGirl.create :sample, sample_metadata_attributes: { supplier_name: "FindMe" }
+        @sample_with_accession_number = FactoryGirl.create :sample, sample_metadata_attributes: { sample_ebi_accession_number: "FindMe" }
+
       end
       context "#index" do
 
@@ -59,6 +62,14 @@ class SearchesControllerTest < ActionController::TestCase
 
             should "contain a link to the sample that was found" do
               assert_link_to sample_path(@sample)
+            end
+
+            should "contain a link to the sample that was found by supplier name" do
+              assert_link_to sample_path(@sample_with_supplier_name)
+            end
+
+            should "contain a link to the sample that was found by sample_ebi_accession_number" do
+              assert_link_to sample_path(@sample_with_accession_number)
             end
 
             should 'contain a link to the asset that was found' do

--- a/test/functional/searches_controller_test.rb
+++ b/test/functional/searches_controller_test.rb
@@ -30,6 +30,9 @@ class SearchesControllerTest < ActionController::TestCase
         @asset_group_to_find      =FactoryGirl.create :asset_group, :name => "FindMeAssetGroup", :study => @study
         @asset_group_to_not_find  =FactoryGirl.create :asset_group, :name => "IgnoreAssetGroup"
 
+        @submission = FactoryGirl.create :submission, name: 'FindMe'
+        @ignore_submission = FactoryGirl.create :submission, name: 'IgnoreMeSub'
+
         @sample_with_supplier_name = FactoryGirl.create :sample, sample_metadata_attributes: { supplier_name: "FindMe" }
         @sample_with_accession_number = FactoryGirl.create :sample, sample_metadata_attributes: { sample_ebi_accession_number: "FindMe" }
 
@@ -58,6 +61,15 @@ class SearchesControllerTest < ActionController::TestCase
 
             should "not contain a link to the study that was not found" do
               deny_link_to study_path(@study2)
+            end
+
+
+            should "contain a link to the submission that was found" do
+              assert_link_to submission_path(@submission)
+            end
+
+            should "not contain a link to the submission that was not found" do
+              deny_link_to submission_path(@ignore_submission)
             end
 
             should "contain a link to the sample that was found" do


### PR DESCRIPTION
Sorry for the seemingly over complicated query on the sample side of things. Unfortunately the simple version performs terribly (8s longer), and we've already had complaints about search speed.

Once we've made the move to 5.7 we can have a look at the full text indexing. This should improve on the LIKE '%query%' searches, which are unable to used indices. (Either that or use a proper search solution, like solr)

