### PR TITLE
Remove jruby-openssl from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :default do
   gem "will_paginate-bootstrap"
   gem 'net-ldap'
   gem 'carrierwave'
-  gem 'jruby-openssl', :platforms => :jruby
 
   # Provides eg. error_messages_for previously in rails 2, now deprecated.
   gem 'dynamic_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,6 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     jrjackson (0.3.7)
-    jruby-openssl (0.9.16-java)
     json (1.8.3)
     json (1.8.3-java)
     launchy (2.4.3)
@@ -371,7 +370,6 @@ DEPENDENCIES
   jquery-tablesorter
   jquery-ui-rails
   jrjackson
-  jruby-openssl
   json
   launchy
   mime-types
@@ -409,3 +407,6 @@ DEPENDENCIES
   uuidtools
   will_paginate
   will_paginate-bootstrap
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
The gem is a default part of jruby. Including it in the gemfile
causes issues when the versions get out of sync.