### PR TITLE
Paginate results and reduce memory consumption

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -92,7 +92,7 @@ module ApplicationHelper
   end
 
   def request_count_link(study, asset, state, request_type)
-    matching_requests   = asset.requests.select { |request| (request.request_type == request_type) and request.send(:"#{ state }?") }
+    matching_requests   = asset.requests.select { |request| (request.request_type_id == request_type.id) and request.state == state }
     html_options, count = { :title => "#{ asset.display_name } #{ state }" }, matching_requests.size
 
     # 0 requests => no link, just '0'

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -51,6 +51,8 @@ class Aliquot < ActiveRecord::Base
     scope :include_creation_batches, -> { includes(:creation_batches)}
     scope :include_source_batches, -> { includes(:source_batches)}
 
+    scope :for_study_and_request_type, ->(study,request_type) { joins(:aliquots,:requests).where(aliquots:{study_id:study}).where(requests:{request_type_id:request_type}) }
+
     # This is a lambda as otherwise the scope selects Aliquot::Receptacles
     scope :with_aliquots, -> { joins(:aliquots) }
 

--- a/app/views/studies/workflows/_summary_for_request_type.html.erb
+++ b/app/views/studies/workflows/_summary_for_request_type.html.erb
@@ -1,7 +1,7 @@
 <%#This file is part of SEQUENCESCAPE; it is distributed under the terms of GNU General Public License version 1 or later;
 #Please refer to the LICENSE and README files for information on licensing and authorship of this file.
 #Copyright (C) 2007-2011,2015 Genome Research Ltd.%>
-
+<%= pagination @assets_to_detail %>
 <table id="summary" width="100%" class="sortable">
   <thead>
     <tr>
@@ -26,3 +26,4 @@
   <% end %>
   </tbody>
 </table>
+<%= pagination @assets_to_detail %>


### PR DESCRIPTION
Large studies were causing high memory usage when viewing these summary
pages. The pagination helps to prevent this being a major issue
and some improvements in loading our assets should also help.

This controller needs a substantial re-visit. The code as is
could do with refactoring, but also the general contents of the
page are not very user-friendly. Not only that, but the statistics
have been misleading since cross study pooling.