### PR TITLE
Run tests in two separate commands (#42)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ cache: bundler
 bundler_args: --without warehouse development deployment
 before_install:
   - export TZ=Europe/London
+script:
+ - "bundle exec rake test"
+ - "bundle exec cucumber -r features"
 before_script:
   - "bundle exec rake db:create RAILS_ENV=test"
   - "bundle exec rake db:test:load"


### PR DESCRIPTION
* Run tests in two separate commands

An as yet unidentified issue in travis appears to be disrupting the load paths
while loading cucumber-rails. Avoiding the use of rake when running cucumber
seems to relieve the problem. I'll keep looking into the issue, but this should
give us back our integration tests.

* Update .travis.yml