### PR TITLE
Add Builder to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,9 @@ group :default do
 
   gem 'axlsx'
   gem 'roo'
+
+  # Used in XML generation.
+  gem 'builder'
 end
 
 group :warehouse do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,7 @@ DEPENDENCIES
   acts-as-dag (~> 3.0.0)
   axlsx
   bootstrap-sass
+  builder
   bullet
   bunny (~> 0.7)
   cancan


### PR DESCRIPTION
Builder was previously required as part of Savon, and other gems.
It is still requied by cucumber, so its absense wasn't noticed.
However, we rely on it directly, so should declare it explicitly.