### PR TITLE
Split test running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ rvm:
   - jruby-9.0.5.0
 sudo: false
 cache: bundler
-bundler_args: --without warehouse development deployment
-before_install:
-  - export TZ=Europe/London
-script:
- - "bundle exec rake test"
- - "bundle exec cucumber -r features"
+bundler_args: --without warehouse deployment
+env:
+  - "TZ=Europe/London SUITE='rake test'"
+  - "JRUBY_OPTS='' CUCUMBER_FORMAT=progress TZ=Europe/London SUITE='cucumber'"
 before_script:
-  - "bundle exec rake db:create RAILS_ENV=test"
-  - "bundle exec rake db:test:load"
-  - export CUCUMBER_FORMAT=progress
+  - "RAILS_ENV=test bundle exec rake db:setup"
+script:
+  - "bundle exec $SUITE"

--- a/features/samples/sample_registration.feature
+++ b/features/samples/sample_registration.feature
@@ -100,7 +100,7 @@ Feature: Registering samples
     And I press "Upload spreadsheet"
     Then I should be on the spreadsheet sample registration page for study "Testing registering samples"
     And the following samples should be in the sample registration fields:
-      |Sample name           |Cohort|Country of origin|Geographical region|Gender|Volume (µl)| Ethnicity | DNA source | Donor Id |
+      |»Sample name Help     |Cohort|Country of origin|Geographical region|[ Array Express ] Gender|Volume (µl)| Ethnicity | DNA source | [ EGA (As subject id) ] Donor Id |
       |cn_dev_96_inc_blank_01|ro    |uk               |europe             |Male  |100        | Caucasian | Blood      | 12345    |
       |cn_dev_96_inc_blank_02|ro    |uk               |europe             |Female|100        | Caucasian | Blood      | 12345    |
       |cn_dev_96_inc_blank_03|ro    |uk               |europe             |Male  |100        | Caucasian | Blood      | 12345    |

--- a/features/step_definitions/samples_steps.rb
+++ b/features/step_definitions/samples_steps.rb
@@ -27,18 +27,18 @@ Then /^I should see an error "([^\"]*)"$/ do |msg|
   assert_contain msg
 end
 
-# TODO[xxx]: This is incredibly slow!
 Then /^the following samples should be in the sample registration fields:$/ do |table|
-  table.hashes.each_with_index do |details,index|
-    with_scope("table#samples_to_register tr.sample_row:nth-child(#{index+1})") do
-      details.each do |label, value|
-        field       = find_field("#{ label } for sample #{ index }")
-        field_value = (field.tag_name == 'textarea') ? field.text : field.value
-        assert_match(/#{value}/, field_value, "Field #{ label.inspect } for sample #{ index } was unexpected")
-      end
-    end
+  number = table.rows.count
+  approved_heads = table.headers
+  heads = find('table#samples_to_register').find_all('thead th').map { |th| th.text }
+  rows = find('table#samples_to_register').find_all("tbody tr:nth-child(-n+#{number})")
+  hashes = rows.map do |tr|
+    hash = Hash[heads.zip(tr.find_all('td').map { |td| td.first('input').try(:value) || td.first('select').try(:value) })]
+    hash.slice(*approved_heads)
   end
+  assert_equal table.hashes, hashes
 end
+
 
 Given /^the sample "([^\"]+)" has the Taxon ID "([^\"]+)"$/ do |name,id|
   sample = Sample.find_by_name(name) or raise StandardError, "Cannot find sample with name #{ name.inspect }"


### PR DESCRIPTION
While travis runs the separate script commands consecutively, different ENV options are run in parallel. This reduces the time it takes the test suite to run.

In addition, the features/step_definitions/samples_steps.rb changes address the speed issues mentioned in the comment. 