### PR TITLE
[ss537] - Add DynamicOption for run-time option generation

### DIFF
--- a/app/models/library_type.rb
+++ b/app/models/library_type.rb
@@ -6,6 +6,8 @@ class LibraryType < ActiveRecord::Base
 
   validates_presence_of :name
 
+  scope :alphabetical, ->() { order(:name) }
+
   has_many :library_types_request_types, :inverse_of=> :library_type
   has_many :request_types, :through => :library_types_request_types
 

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -83,13 +83,18 @@ library_type:
   unlocked: true
   validation:
     options:
-      type: :textLength
-      operator: :lessThanOrEqual
-      formula1: "255"
+      type: :list
+      formula1: "$A$1:$A$2"
       allowBlank: false
+      showDropDown: false
       showInputMessage: true
+      showErrorMessage: true
+      errorStyle: :stop
+      errorTitle: "Library type"
+      error: "You must enter a Library type from the list provided."
       promptTitle: "Library type"
       prompt: "Provide a library type from the approved list"
+    range_name: :library_type
   conditional_formattings:
     empty_cell:
 insert_size_from:

--- a/config/sample_manifest_excel/ranges.yml
+++ b/config/sample_manifest_excel/ranges.yml
@@ -1,5 +1,5 @@
 gender:
-  - Male 
+  - Male
   - Female
   - Mixed
   - Hermaphrodite
@@ -36,3 +36,7 @@ dna_storage_conditions:
   - +4C
   - '-20C'
   - '-80C'
+library_type: !ruby/object:SampleManifestExcel::DynamicOption
+  identifier: :name
+  klass: !ruby/class 'LibraryType'
+  scope: :alphabetical

--- a/lib/sample_manifest_excel/sample_manifest_excel.rb
+++ b/lib/sample_manifest_excel/sample_manifest_excel.rb
@@ -20,6 +20,7 @@ module SampleManifestExcel
   require_relative "sample_manifest_excel/range_list"
   require_relative "sample_manifest_excel/worksheet"
   require_relative "sample_manifest_excel/download"
+  require_relative "sample_manifest_excel/dynamic_option"
 
   module Helpers
     def load_file(folder, filename)

--- a/lib/sample_manifest_excel/sample_manifest_excel/dynamic_option.rb
+++ b/lib/sample_manifest_excel/sample_manifest_excel/dynamic_option.rb
@@ -1,0 +1,36 @@
+module SampleManifestExcel
+  # A dynamic option can be provided to a SampleManifestExcel::Range
+  # in place of the usual options array.
+  # It gets evaluated dynamically at manifest generation time,
+  # allowing for columns that take their accepted values
+  # from the database
+  class DynamicOption
+    include Enumerable
+
+    attr_reader :klass, :scope, :identifier
+    # Create a new dynamic otpion
+    #
+    # @param [Class] klass: The class on which the scope will be called
+    # @param [Symbol] scope: A scope called on the class
+    # CAUTION: Rails 3 returns an array for .all, not a scope.
+    # This is resolved in rails 4. Until then :all will NOT work as a scope argument.
+    # @param [Symbol] identifier: The attribute used to define the options range
+    # @return [DynamicOption] description of returned object
+    def initialize(klass:, scope:, identifier: :name)
+      @klass = klass
+      @scope = scope
+      @identifier = identifier
+    end
+
+    def to_a
+      klass.public_send(scope).pluck(identifier)
+    end
+
+    def empty?
+      klass.public_send(scope).none?
+    end
+
+    delegate :each, :length, to: :to_a
+
+  end
+end

--- a/lib/sample_manifest_excel/sample_manifest_excel/worksheet/base.rb
+++ b/lib/sample_manifest_excel/sample_manifest_excel/worksheet/base.rb
@@ -17,7 +17,9 @@ module SampleManifestExcel
       #Adds row to a worksheet with particular value, style and type for each cell
 
     	def add_row(values = [], style = nil, types = nil)
-  			axlsx_worksheet.add_row values, types: types || [:string]*values.length, style: style
+        # We call to_a here to allow us to pass through ANY enumerable. This extends the versitility
+        # of range options and allows us to have dynamically generated ranges.
+  			axlsx_worksheet.add_row values.to_a, types: types || [:string]*values.length, style: style
     	end
 
       #Adds n empty rows

--- a/test/lib/sample_manifest_excel/acceptance_test.rb
+++ b/test/lib/sample_manifest_excel/acceptance_test.rb
@@ -18,15 +18,15 @@ class AcceptanceTest < ActiveSupport::TestCase
     @sample_manifest = create :sample_manifest, rapid_generation: true
     sample_manifest.generate
 
-    @download = SampleManifestExcel::Download.new(sample_manifest, 
-        SampleManifestExcel.configuration.columns.test.dup, 
+    @download = SampleManifestExcel::Download.new(sample_manifest,
+        SampleManifestExcel.configuration.columns.test.dup,
         SampleManifestExcel.configuration.ranges.dup)
     download.save('test.xlsx')
   end
 
   test "should create a worksheet" do
     assert File.file?('test.xlsx')
-    p download.password
+    assert download.password
   end
 
   def teardown

--- a/test/lib/sample_manifest_excel/dynamic_options_test.rb
+++ b/test/lib/sample_manifest_excel/dynamic_options_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class DynamicOptionsTest < ActiveSupport::TestCase
+
+  setup do
+    @dynamic_options = SampleManifestExcel::DynamicOption.new(klass: LibraryType, scope: :alphabetical, identifier: :name)
+  end
+
+  test 'should convert to an array' do
+    assert_instance_of Array, @dynamic_options.to_a
+  end
+
+  test 'should resolve to an array of identifier, filtered by scope' do
+    assert_equal LibraryType.alphabetical.pluck(:name), @dynamic_options.to_a
+  end
+
+  test 'should be lazily converted' do
+    create :library_type, name: 'New library type'
+    assert_include @dynamic_options.to_a, 'New library type'
+  end
+end


### PR DESCRIPTION
[ss537] - Ranges with dynamic options do not cache list and last columns

[ss537] - Add library type dropdown to manifests