### PR TITLE
Handle  nil submission_attributes[:request_options]

### DIFF
--- a/app/models/product_catalogue/library_driven.rb
+++ b/app/models/product_catalogue/library_driven.rb
@@ -8,7 +8,9 @@ class ProductCatalogue::LibraryDriven
 
   def initialize(catalogue,submission_attributes)
     # library_type_name will be set to nil if it was not defined
-    library_type_name = submission_attributes.fetch(:request_options,{})[:library_type]
+    # We can't use fetch here, as in some cases submission_attributes[:request_options] is nil
+    # rather than just undefined.
+    library_type_name = (submission_attributes[:request_options] || {})[:library_type]
     @product = catalogue.product_with_default(library_type_name)
   end
 


### PR DESCRIPTION
During order creation submission_attributes[:request_options] can be nil,
rather than just undefined. This means we can't use fetch with a default
value.