### PR TITLE
Temporarily disable connection timeout rescue

### DIFF
--- a/app/observers/amqp_observer.rb
+++ b/app/observers/amqp_observer.rb
@@ -183,7 +183,7 @@ class AmqpObserver < ActiveRecord::Observer
       ensure
         client.stop
       end
-    rescue Qrack::ConnectionTimeout, StandardError => exception
+    rescue StandardError => exception
       Rails.logger.error { "Unable to broadcast: #{exception.message}\n#{exception.backtrace.join("\n")}" }
     end
     private :activate_exchange


### PR DESCRIPTION
Bunny disobeyed our version in the Gemfile, and updated itself.
The timeout exception class has changed.
Temporarily removing the rescue to allow time to fix things properly.