### PR TITLE
avtivate_exchange and publish_to methods public

### DIFF
--- a/app/observers/amqp_observer.rb
+++ b/app/observers/amqp_observer.rb
@@ -199,7 +199,6 @@ class AmqpObserver < ActiveRecord::Observer
         persistent: configatron.amqp.persistent
       )
     end
-    private :publish_to
 
     # The buffer that should be written to is either the one created within the transaction, or it is a
     # wrapper around ourselves.
@@ -213,7 +212,6 @@ class AmqpObserver < ActiveRecord::Observer
     def activate_exchange(&block)
       exchange_interface.exchange(&block)
     end
-    private :activate_exchange
   end
   include Implementation
 end


### PR DESCRIPTION
In Rails 4, delegate has switched from using send, to public_send
This means that the proxy delegation no longer works as intended.
The methods have been made public.