### PR TITLE
Update Bunny/MarchHare publish api

### DIFF
--- a/app/observers/amqp_observer.rb
+++ b/app/observers/amqp_observer.rb
@@ -38,7 +38,7 @@ class AmqpObserver < ActiveRecord::Observer
       client = MarchHare.connect(uri: configatron.amqp.url)
       begin
         ch = client.create_channel
-        exchange = ch.topic('psd.sequencescape', passive: true, durable: true)
+        exchange = ch.topic('psd.sequencescape', durable: true)
         yield exchange
       ensure
         client.close
@@ -195,7 +195,7 @@ class AmqpObserver < ActiveRecord::Observer
     def publish_to(exchange, record)
       exchange.publish(
         MultiJson.dump(record),
-        key: record.routing_key || "#{Rails.env}.saved.#{record.class.name.underscore}.#{record.id}",
+        routing_key: record.routing_key || "#{Rails.env}.saved.#{record.class.name.underscore}.#{record.id}",
         persistent: configatron.amqp.persistent
       )
     end

--- a/test/unit/observers/amqp_observer_test.rb
+++ b/test/unit/observers/amqp_observer_test.rb
@@ -40,7 +40,7 @@ class AmqpObserverTest < ActiveSupport::TestCase
         object_class.stubs(:name).returns('ClassName')
 
         @exchange = mock('Exchange for sending')
-        @exchange.expects(:publish).with('JSON', key: 'test.saved.class_name.123456789', persistent: false)
+        @exchange.expects(:publish).with('JSON', routing_key: 'test.saved.class_name.123456789', persistent: false)
         @target.instance_variable_set(:@mock_exchange, @exchange)
 
         @target.send(:publish_to, @exchange, object)


### PR DESCRIPTION
The routing key is now passed in as routing_key: not key: