### PR TITLE
Hotfix limber library passing

### DIFF
--- a/app/models/illumina_htp/requests.rb
+++ b/app/models/illumina_htp/requests.rb
@@ -24,6 +24,29 @@ module IlluminaHtp::Requests
       errors.add(:asset, "#{asset.plate.purpose.name} is not a suitable plate purpose.")
       false
     end
+
+    def on_passed
+      super
+      apply_library_information!
+    end
+
+    #
+    # Applies the library information to aliquots of
+    # the target asset. Library id is used for downstream
+    # tracking, and primarily acts as a unique identifier.
+    # Note: Automatically saves the aliquots.
+    #
+    # @return [IlluminaHtp::Requests] Returns itself
+    #
+    def apply_library_information!
+      target_asset.aliquots.each do |aliquot|
+        aliquot.library      ||= target_asset
+        aliquot.library_type ||= library_type
+        aliquot.insert_size  ||= insert_size
+        aliquot.save!
+      end
+      self
+    end
   end
 
   class SharedLibraryPrep < StdLibraryRequest

--- a/app/models/illumina_htp/transferable_plate_purpose.rb
+++ b/app/models/illumina_htp/transferable_plate_purpose.rb
@@ -5,7 +5,6 @@
 # Copyright (C) 2013,2014,2015 Genome Research Ltd.
 
 class IlluminaHtp::TransferablePlatePurpose < IlluminaHtp::FinalPlatePurpose
-  include PlatePurpose::Library
   include PlatePurpose::RequestAttachment
   include PlatePurpose::WorksOnLibraryRequests
 

--- a/spec/models/std_library_request_spec.rb
+++ b/spec/models/std_library_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe IlluminaHtp::Requests::StdLibraryRequest, type: :model do
+  subject { create :library_request, target_asset: tagged_well, state: state }
+  let(:tagged_well) { create :tagged_well }
+
+  context '#pass' do
+    let(:state) { 'started' }
+
+    before(:each) do
+      expect(tagged_well.aliquots.first.library_id).to be_nil
+      subject.pass!
+    end
+
+    it 'sets library parameters on aliquots in the target asset' do
+      library = tagged_well
+      aliquot = tagged_well.aliquots.first
+      expect(aliquot.library_id).to eq(library.id)
+      expect(aliquot.insert_size).to eq(subject.insert_size)
+      expect(aliquot.library_type).to eq(subject.library_type)
+    end
+  end
+end


### PR DESCRIPTION
This is a temporary fix which may not apply to the upcoming ISC pipeline. I'm currently making enquiries as to the desired behaviour in future.