### PR TITLE
Re-eanble eager loading of prefixes and metadata

### DIFF
--- a/app/controllers/pico_dilutions_controller.rb
+++ b/app/controllers/pico_dilutions_controller.rb
@@ -8,7 +8,7 @@ class PicoDilutionsController < ApplicationController
   before_action :login_required, except: [:index]
 
   def index
-    pico_dilutions = DilutionPlate.with_pico_children.page(params[:page]).order(id: :desc).per_page(500)
+    pico_dilutions = DilutionPlate.with_pico_children.for_pico_view.page(params[:page]).order(id: :desc).per_page(500)
     pico_dilutions_hash = PicoDilutionPlate.index_to_hash(pico_dilutions)
 
     respond_to do |format|

--- a/app/models/dilution_plate.rb
+++ b/app/models/dilution_plate.rb
@@ -19,7 +19,7 @@ class DilutionPlate < Plate
   }
 
   scope :for_pico_view, -> {
-    includes(:barcode_prefix, :plate_metadata, :studies)
+    preload(:barcode_prefix, :plate_metadata)
   }
 
   def to_pico_hash


### PR DESCRIPTION
Previous eager loading of studies had a number of issues
1) THe introduction of .pluck bypassed any gains
2) The loading had issues, and was returning an empty association
3) When loading via eager_load memory usage spiked drastically.

Eager loading was disabled in production while the issue was
investigated. These improvement result in a ~%30 reduction in
response time, and result in only studies causing n+1 query
issues. This was tested against the training database.