### PR TITLE
Prevent release og Active Record connection on api close

### DIFF
--- a/app/api/core/service.rb
+++ b/app/api/core/service.rb
@@ -255,9 +255,8 @@ module Core
       def discard_all_references
         request.send(:discard_all_references)
         super
-
-        # We can also view the current connection as a reference and release that too
-        ActiveRecord::Base.connection_pool.release_connection
+        # Note: Previously we released our connection here, which prevented rails from
+        # properly sweeping the query cache.
       end
       private :discard_all_references
     end


### PR DESCRIPTION
Rails connections are usually handled as part of the request
lifecycle, as part of the rack stack. This includes actions
such as cleaning the rails query cache. The premature release
of the connection to the pool here was resulting in the
query cache persisting over multiple requests to the API.