### PR TITLE
Asset creators allow naming

### DIFF
--- a/app/api/io/specific_tube_creation.rb
+++ b/app/api/io/specific_tube_creation.rb
@@ -9,9 +9,10 @@ class ::Io::SpecificTubeCreation < ::Core::Io::Base
   set_json_root(:specific_tube_creation)
   set_eager_loading { |model| model.include_parent }
 
-  define_attribute_and_json_mapping("
-                   user <=> user
-                 parent <=> parent
+  define_attribute_and_json_mapping('
+     user <=> user
+     parent <=> parent
      set_child_purposes <=  child_purposes
-  ")
+     names <= names
+  ')
 end

--- a/app/api/io/specific_tube_creation.rb
+++ b/app/api/io/specific_tube_creation.rb
@@ -13,6 +13,6 @@ class ::Io::SpecificTubeCreation < ::Core::Io::Base
      user <=> user
      parent <=> parent
      set_child_purposes <=  child_purposes
-     names <= names
+     tube_attributes <= tube_attributes
   ')
 end

--- a/app/models/asset_creation.rb
+++ b/app/models/asset_creation.rb
@@ -32,10 +32,6 @@ class AssetCreation < ActiveRecord::Base
     AssetLink.create_edge!(asset, child)
   end
 
-  def can_create_ancestor_plate?(asset, child)
-    (asset.kind_of? Well) && (!child.nil?) && (!child.ancestors.include?(asset))
-  end
-
   def connect_parent_and_children
     children.each { |child| create_ancestor_asset!(parent, child) }
   end

--- a/app/models/specific_tube_creation.rb
+++ b/app/models/specific_tube_creation.rb
@@ -16,6 +16,8 @@ class SpecificTubeCreation < TubeCreation
 
   validates_presence_of :child_purposes
 
+  attr_writer :names
+
   def set_child_purposes=(uuids)
     self.child_purposes = uuids.map { |uuid| Uuid.find_by(external_id: uuid).resource }
   end
@@ -26,11 +28,17 @@ class SpecificTubeCreation < TubeCreation
   private :no_pooling_expected?
 
   def create_children!
-    self.children = child_purposes.map { |child_purpose| child_purpose.create! }
+    self.children = child_purposes.each_with_index.map do |child_purpose, index|
+      child_purpose.create!(name: names[index])
+    end
   end
   private :create_children!
 
   def multiple_purposes
-   true
+    true
+  end
+
+  def names
+    @names || []
   end
 end

--- a/app/models/specific_tube_creation.rb
+++ b/app/models/specific_tube_creation.rb
@@ -16,7 +16,7 @@ class SpecificTubeCreation < TubeCreation
 
   validates_presence_of :child_purposes
 
-  attr_writer :names
+  attr_writer :tube_attributes
 
   def set_child_purposes=(uuids)
     self.child_purposes = uuids.map { |uuid| Uuid.find_by(external_id: uuid).resource }
@@ -29,7 +29,7 @@ class SpecificTubeCreation < TubeCreation
 
   def create_children!
     self.children = child_purposes.each_with_index.map do |child_purpose, index|
-      child_purpose.create!(name: names[index])
+      child_purpose.create!(tube_attributes[index])
     end
   end
   private :create_children!
@@ -38,7 +38,7 @@ class SpecificTubeCreation < TubeCreation
     true
   end
 
-  def names
-    @names || []
+  def tube_attributes
+    @tube_attributes || Array.new(child_purposes.length,{})
   end
 end

--- a/app/models/tube_creation.rb
+++ b/app/models/tube_creation.rb
@@ -32,16 +32,9 @@ class TubeCreation < AssetCreation
   private :target_for_ownership
 
   def create_children!
-    self.children = (1..parent.pools.size).map { |_| child_purpose.create! }
+    self.children = Array.new(parent.pools.size) { child_purpose.create! }
   end
   private :create_children!
-
-  def create_ancestor_plate!
-    children.each do |child|
-      create_ancestor_asset!(parent.plate, child) if can_create_ancestor_plate?(parent.plate, child)
-    end
-  end
-  before_save :create_ancestor_plate!
 
   def record_creation_of_children
     #    children.each { |child| parent.events.create_tube!(child_purpose, child, user) }

--- a/spec/models/specific_tube_creations_spec.rb
+++ b/spec/models/specific_tube_creations_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe SpecificTubeCreation, type: :model do
+  subject(:specific_tube_creation) { described_class.new(creation_parameters) }
+
+  shared_examples 'a specific tube creator' do
+    let(:child_purpose) { create(:tube_purpose) }
+    let(:user) { create :user }
+    let(:parent) { create :plate }
+
+    describe '#save' do
+      before do
+        expect(subject.save).to (be true), ->() { "Failed to save: #{subject.errors.full_messages}"}
+      end
+
+      let(:first_child) { subject.children.first }
+
+      it 'creates one child' do
+        expect(subject.children.count).to eq purpose_count
+      end
+
+      it 'creates a tube' do
+        expect(first_child).to be_a Tube
+      end
+
+      it 'sets the purpose' do
+        expect(first_child.purpose).to eq child_purpose
+      end
+
+      it 'sets expected names' do
+        subject.children.each_with_index do |child, i|
+          expect(child.name).to eq names[i]
+        end
+      end
+
+      it 'sets plates as parents' do
+        subject.children.each do |child|
+          expect(child.parents).to include(parent)
+        end
+      end
+    end
+  end
+
+  context 'with no custom names' do
+    let(:names) { [nil]*purpose_count }
+    let(:creation_parameters) { { user: user, child_purposes: [child_purpose]*purpose_count, parent: parent } }
+
+    context 'with one child purpose' do
+      it_behaves_like 'a specific tube creator'
+      let(:purpose_count) { 1 }
+    end
+
+    context 'with two child purpose' do
+      it_behaves_like 'a specific tube creator'
+      let(:purpose_count) { 2 }
+    end
+  end
+
+  context 'with custom names' do
+    let(:names) { ['example_1', 'example_2'] }
+    let(:purpose_count) { 2 }
+    let(:creation_parameters) { { user: user, child_purposes: [child_purpose]*purpose_count, parent: parent, names: names } }
+    it_behaves_like 'a specific tube creator'
+  end
+end

--- a/spec/models/specific_tube_creations_spec.rb
+++ b/spec/models/specific_tube_creations_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe SpecificTubeCreation, type: :model do
   context 'with custom names' do
     let(:names) { ['example_1', 'example_2'] }
     let(:purpose_count) { 2 }
-    let(:creation_parameters) { { user: user, child_purposes: [child_purpose]*purpose_count, parent: parent, names: names } }
+    let(:tube_attributes) { names.map { |name| { name: name } } }
+    let(:creation_parameters) { { user: user, child_purposes: [child_purpose]*purpose_count, parent: parent, tube_attributes: tube_attributes } }
     it_behaves_like 'a specific tube creator'
   end
 end


### PR DESCRIPTION
Just on specific tube creators for the time being.
Accept nested attributes, rather than just name.