### PR TITLE
Change database column type for samples extraction to long text

### DIFF
--- a/db/migrate/20170710100939_change_extraction_column_to_long_text.rb
+++ b/db/migrate/20170710100939_change_extraction_column_to_long_text.rb
@@ -1,0 +1,5 @@
+class ChangeExtractionColumnToLongText < ActiveRecord::Migration
+  def change
+    change_column :extraction_attributes, :attributes_update, :text, :limit => 4294967295
+  end
+end

--- a/db/migrate/20170710100939_change_extraction_column_to_long_text.rb
+++ b/db/migrate/20170710100939_change_extraction_column_to_long_text.rb
@@ -1,5 +1,5 @@
 class ChangeExtractionColumnToLongText < ActiveRecord::Migration
   def change
-    change_column :extraction_attributes, :attributes_update, :text, :limit => 4294967295
+    change_column :extraction_attributes, :attributes_update, :text, limit: 4294967295
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531082054) do
+ActiveRecord::Schema.define(version: 20170710100939) do
 
   create_table "aliquot_indices", force: :cascade do |t|
     t.integer  "aliquot_id",    limit: 4, null: false
@@ -527,9 +527,9 @@ ActiveRecord::Schema.define(version: 20170531082054) do
   create_table "extraction_attributes", force: :cascade do |t|
     t.integer  "target_id",         limit: 4
     t.string   "created_by",        limit: 255
-    t.text     "attributes_update", limit: 65535
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.text     "attributes_update", limit: 4294967295
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
   end
 
   create_table "faculty_sponsors", force: :cascade do |t|


### PR DESCRIPTION
The size of the updates is exceeding the size allowed by the column.