### PR TITLE
Reduce risk of race condition on asset link formation

### DIFF
--- a/app/jobs/asset_link/builder_job.rb
+++ b/app/jobs/asset_link/builder_job.rb
@@ -1,10 +1,10 @@
 # Enables the bulk creation of the asset links defined by the pairs passed as edges.
 require_dependency 'asset_link'
 AssetLink::BuilderJob = Struct.new(:links) do
-  # For memory resons we need to limit transaction size to 10 links at a time
+  # For memory reasons we need to limit transaction size to 10 links at a time
   TRANSACTION_COUNT = 10
   def perform
-    links.each_slice(TRANSACTION_COUNT) do |link_group|
+    links.uniq.each_slice(TRANSACTION_COUNT) do |link_group|
       ActiveRecord::Base.transaction do
         link_group.each do |parent, child|
           # Create edge can accept either a model (which it converts to an endpoint) or


### PR DESCRIPTION
We recently experienced a number of issues where duplicate asset links
had been created. In particular this occured in the following situation

  /-- p2 --\
p1----------p3

Where plate p1 had been picked onto plate p3 directly, and
via plate p2. The p1->p3 and p2->p3 picks happened in the same
batch. In the previous code this generated two delatyed jobs per
pick. If both jobs got picked up at the same time, the p1 to p3
link would get created twice due to a race condition.

This change does not completely eliminate a race condition,
but ensures that each batch generates a single job.