### PR TITLE
Work completions support multiple stock wells

### DIFF
--- a/app/models/work_completion.rb
+++ b/app/models/work_completion.rb
@@ -31,7 +31,7 @@ class WorkCompletion < ActiveRecord::Base
 
   def connect_requests
     target_wells.each do |target_well|
-      next unless target_well.stock_wells.present? && target_well.passed?
+      next if target_well.stock_wells.empty?
       # Upstream requests our on our stock wells.
       upstream = detect_upstream_requests(target_well)
 

--- a/app/models/work_completion.rb
+++ b/app/models/work_completion.rb
@@ -31,33 +31,46 @@ class WorkCompletion < ActiveRecord::Base
 
   def connect_requests
     target_wells.each do |target_well|
-      target_well.stock_wells.each do |source_well|
-        # We may have multiple requests out of each well, however we're only concerned
-        # about those associated with the active submission.
-        # We've already eager loaded requests out of the stock wells, so filter in Ruby.
-        upstream = source_well.requests.detect do |r|
-          r.library_creation? && submission_ids.include?(r.submission_id)
-        end || raise("Could not find matching upstream requests for #{target_well.map_description}")
+      next unless target_well.stock_wells.present? && target_well.passed?
+      # Upstream requests our on our stock wells.
+      upstream = detect_upstream_requests(target_well)
 
-        # We need to find the downstream requests BEFORE connecting the upstream
-        # This is because submission.next_requests tries to take a shortcut through
-        # the target_asset if it is defined.
-        downstream = upstream.submission.next_requests(upstream)
-        downstream.each { |ds| ds.update_attributes!(asset: target_well) }
+      # We need to find the downstream requests BEFORE connecting the upstream
+      # This is because submission.next_requests tries to take a shortcut through
+      # the target_asset if it is defined.
+      downstream = upstream.submission.next_requests(upstream)
+      downstream.each { |ds| ds.update_attributes!(asset: target_well) }
 
-        # In some cases, such as the Illumina-C pipelines, requests might be
-        # connected upfront. We don't want to touch these.
-        upstream.target_asset ||= target_well
-        # We don't try and pass failed requests.
-        # I'm not 100% convinced this decision belongs here, and instead
-        # we may want to let the client specify wells to pass, and perform
-        # validation to ensure this is correct. However this increases
-        # the complexity of both the code and the interface, with only
-        # marginal system simplification.
-        upstream.pass if upstream.may_pass?
-        upstream.save!
+      # In some cases, such as the Illumina-C pipelines, requests might be
+      # connected upfront. We don't want to touch these.
+      upstream.target_asset ||= target_well
+      # We don't try and pass failed requests.
+      # I'm not 100% convinced this decision belongs here, and instead
+      # we may want to let the client specify wells to pass, and perform
+      # validation to ensure this is correct. However this increases
+      # the complexity of both the code and the interface, with only
+      # marginal system simplification.
+      upstream.pass if upstream.may_pass?
+      upstream.save!
+    end
+  end
+
+  def detect_upstream_requests(target_well)
+    target_well.stock_wells.each do |source_well|
+      # We may have multiple requests out of each well, however we're only concerned
+      # about those associated with the active submission.
+      # We've already eager loaded requests out of the stock wells, so filter in Ruby.
+      source_well.requests.each do |r|
+        return r if suitable_request?(r)
       end
     end
+    # We've looked at all the requests, on all the stock wells and still haven't found
+    # what we're looking for.
+    raise("Could not find matching upstream requests for #{target_well.map_description}")
+  end
+
+  def suitable_request?(request)
+    request.library_creation? && submission_ids.include?(request.submission_id)
   end
 
   def update_stock_wells


### PR DESCRIPTION
In the event of a repool, wells may end up with multiple
stock wells. The previous code tried to find outer requests
on all available stock wells, which would fail.

The new code will select the first appropriate request,
and only fail if no suitable requests are available.