### PR TITLE
Exclude wells in other submissions

### DIFF
--- a/app/models/work_completion.rb
+++ b/app/models/work_completion.rb
@@ -80,6 +80,6 @@ class WorkCompletion < ActiveRecord::Base
   end
 
   def target_wells
-    @target_wells ||= target.wells.include_stock_wells.include_requests_as_target
+    @target_wells ||= target.wells.include_stock_wells.include_requests_as_target.where(requests: { submission_id: submissions })
   end
 end

--- a/spec/models/work_completion_spec.rb
+++ b/spec/models/work_completion_spec.rb
@@ -68,5 +68,19 @@ describe WorkCompletion do
         expect(library_requests.first).to be_failed
       end
     end
+
+    context 'when no submission is included' do
+      before(:each) do
+        WorkCompletion.create!(
+          user: create(:user),
+          target: target_plate,
+          submissions: []
+        )
+      end
+
+      it "doesn't pass the request" do
+        expect(library_requests.first).to be_started
+      end
+    end
   end
 end


### PR DESCRIPTION
Wells in other submissions were still included in the each
and would fail when trying to find an appropriate outer request.
This was causing issues if all wells in a submission were failed
as they would no longer be listed as pools in active limber.
It would also cause issues if we ever did end up passing
partial plates.