### PR TITLE
Fix controller naming

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -10,6 +10,10 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.uncountable %w( health )
+end
+
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'


### PR DESCRIPTION
Health is an uncountable noun, being as it is somehow abstract
Your health, our health etc.