### PR TITLE
Fix broken submission cancellation

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -257,7 +257,7 @@ Sequencescape::Application.routes.draw do
     end
     member do
       post :change_priority
-      get :cancel
+      post :cancel
     end
   end
 


### PR DESCRIPTION
The submission cancellation button sends a POST not a GET
However the routes were set to GET
This updates the routes (As we really don't want to be cancelling stuff on a get)
