### PR TITLE
Hotfix failing spec

### DIFF
--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -77,20 +77,20 @@ class Well < Receptacle
   scope :include_stock_wells, -> { includes(stock_wells: :requests_as_source) }
   scope :include_stock_wells_for_modification, -> {
     preload(:stock_well_links,
-             stock_wells: {
-              requests_as_source: [
-                :target_asset,
-                :request_type,
-                :billing_product,
-                :request_metadata,
-                :billing_items,
-                :request_events,
-                {
-                  initial_project: :project_metadata,
-                  submission: :orders
-                }
-              ]
-            })
+            stock_wells: {
+             requests_as_source: [
+               :target_asset,
+               :request_type,
+               :billing_product,
+               :request_metadata,
+               :billing_items,
+               :request_events,
+               {
+                 initial_project: :project_metadata,
+                 submission: :orders
+               }
+             ]
+           })
   }
   scope :include_map, -> { includes(:map) }
 

--- a/spec/shared_contexts/limber_shared_context.rb
+++ b/spec/shared_contexts/limber_shared_context.rb
@@ -21,7 +21,7 @@ shared_context 'a limber target plate with submissions' do
     create :library_submission, assets: input_plate.wells, request_types: submission_request_types
   end
   # The target plate is the downstream plate we are going to be passing.
-  let(:target_plate) { create :target_plate, parent: input_plate, well_count: tested_wells }
+  let(:target_plate) { create :target_plate, parent: input_plate, well_count: tested_wells, submission: target_submission }
   # And now we have a few helpers to make the tests more readable
   let(:library_requests) { target_submission.requests.where(request_type_id: library_request_type.id) }
   let(:multiplex_requests) { target_submission.requests.where(request_type_id: multiplex_request_type.id) }

--- a/test/factories/plate_factories.rb
+++ b/test/factories/plate_factories.rb
@@ -37,12 +37,14 @@ FactoryGirl.define do
     factory :target_plate do
       transient do
         parent { build :input_plate }
+        submission { build :submission }
       end
 
       after(:build) do |plate, evaluator|
         well_hash = Hash[evaluator.parent.wells.map { |w| [w.map_description, w] }]
         plate.wells.each do |well|
           well.stock_well_links << build(:stock_well_link, target_well: well, source_well: well_hash[well.map_description])
+          create :transfer_request, asset: well_hash[well.map_description], target_asset: well, submission: evaluator.submission
         end
       end
     end


### PR DESCRIPTION
Transfer requests werent' being build, so wells weren't assigned
to specific submissions. The scope seemingly worked when we were
'including' the stock wells, presumably using the wrong request table.