### PR TITLE
SEQ654 - Fix failure to assign billing product via linear submission

### DIFF
--- a/app/models/request_type.rb
+++ b/app/models/request_type.rb
@@ -94,8 +94,8 @@ class RequestType < ApplicationRecord
     new_request = klass.public_send(construct_method, attributes) do |request|
       request.request_type = self
       request.request_purpose ||= request_purpose
-      request.billing_product = find_product_for_request(request)
       yield(request) if block_given?
+      request.billing_product = find_product_for_request(request)
     end
     # Prevent us caching all our requests
     requests.reset

--- a/spec/models/request_type_spec.rb
+++ b/spec/models/request_type_spec.rb
@@ -70,6 +70,17 @@ describe RequestType do
         )
         expect(request.billing_product).to eq billing_product
       end
+
+      it 'should assign the right product to request when assigning attributes from a block' do
+        request = request_type.create! do |req|
+          req.request_metadata_attributes = {
+            read_length: 250,
+            fragment_size_required_to: 150,
+            fragment_size_required_from: 150
+          }
+        end
+        expect(request.billing_product).to eq billing_product
+      end
     end
   end
 end


### PR DESCRIPTION
release-10.0.0 included changes to the request constructor to remove
some meta-programming. These included a modification to the way in
which billing products were assigned in the request factory. These
modifications set-up the billing product in the create block, rather
than on a subsequent update after creation, avoiding the need to hit
the databaser twice. However, while the tests covered the situation
in which metadata was set via the hash passed in at initialization,
they did not cover any attempts to set metadata within the create
block. This process was used in submission building.

- Add tests for assigning billing products when metadata has been
 set via a block passed to create.
- Re-ordered asignment of billing product until after any custom
 blocks have returned.