### PR TITLE
Performance tests don't dun with just rake:test

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,3 +1,15 @@
+Rake::Task['test'].clear
+
+task :test do
+  $LOAD_PATH << 'test'
+  if ENV.key?('TEST')
+    Rails::TestUnit::Runner.rake_run([ENV['TEST']])
+  else
+    test_folders = FileList['test/*'].exclude('test/performance', 'test/*.*')
+    Rails::TestUnit::Runner.rake_run(test_folders)
+  end
+end
+
 namespace :test do
   # lib/tasks/factory_girl.rake
   namespace :factory_girl do

--- a/spec/support/download_helper.rb
+++ b/spec/support/download_helper.rb
@@ -35,6 +35,7 @@ module DownloadHelpers
   end
 
   def self.create_directory
+    PATH.parent.mkdir unless PATH.parent.exist?
     PATH.mkdir
   end
 end


### PR DESCRIPTION
The performance tests are a bit flaky, and are meaningless when run
in the general test environment. Generally we need to consider
a different infrastructure for them, as rails_perf seems pretty
much abandoned.