### PR TITLE
NPG requests are idepotent

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,18 @@
+directories:
+  "app/controllers":
+    IrresponsibleModule:
+      enabled: false
+    NestedIterators:
+      max_allowed_nesting: 2
+    UnusedPrivateMethod:
+      enabled: false
+    InstanceVariableAssumption:
+      enabled: false
+  "app/helpers":
+    IrresponsibleModule:
+      enabled: false
+    UtilityFunction:
+      enabled: false
+  "app/mailers":
+    InstanceVariableAssumption:
+      enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -382,7 +382,6 @@ Naming/HeredocDelimiterNaming:
 Naming/MemoizedInstanceVariableName:
   Exclude:
     - 'app/controllers/batches_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/helpers/workflows_helper.rb'
     - 'app/models/batch/pipeline_behaviour.rb'
     - 'app/models/fluidigm_file.rb'
@@ -1883,7 +1882,6 @@ Style/Documentation:
     - 'app/controllers/lab_searches_controller.rb'
     - 'app/controllers/labwhere_receptions_controller.rb'
     - 'app/controllers/machine_barcodes_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/controllers/orders_controller.rb'
     - 'app/controllers/pico_dilutions_controller.rb'
     - 'app/controllers/pico_set_results_controller.rb'
@@ -3184,7 +3182,6 @@ Style/FrozenStringLiteralComment:
     - 'app/controllers/lab_searches_controller.rb'
     - 'app/controllers/labwhere_receptions_controller.rb'
     - 'app/controllers/machine_barcodes_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/controllers/orders_controller.rb'
     - 'app/controllers/pico_dilutions_controller.rb'
     - 'app/controllers/pico_set_results_controller.rb'
@@ -4579,7 +4576,6 @@ Style/GuardClause:
     - 'app/controllers/admin/projects_controller.rb'
     - 'app/controllers/admin/studies_controller.rb'
     - 'app/controllers/assets_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/controllers/orders_controller.rb'
     - 'app/controllers/plates_controller.rb'
     - 'app/controllers/receptions_controller.rb'
@@ -4662,7 +4658,6 @@ Style/IfUnlessModifier:
     - 'app/controllers/batches/comments_controller.rb'
     - 'app/controllers/batches_controller.rb'
     - 'app/controllers/events_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/controllers/pico_set_results_controller.rb'
     - 'app/controllers/pipelines_controller.rb'
     - 'app/controllers/plate_templates_controller.rb'
@@ -5179,7 +5174,6 @@ Style/ParallelAssignment:
 Style/ParenthesesAroundCondition:
   Exclude:
     - 'app/api/core/io/base/json_formatting_behaviour.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/models/illumina_htp/pooled_plate_purpose.rb'
     - 'app/models/movie_length_task.rb'
@@ -5358,7 +5352,6 @@ Style/RedundantParentheses:
     - 'app/controllers/admin/studies_controller.rb'
     - 'app/controllers/assets_controller.rb'
     - 'app/controllers/batches_controller.rb'
-    - 'app/controllers/npg_actions/assets_controller.rb'
     - 'app/controllers/sdb/sample_manifests_controller.rb'
     - 'app/models/asset_barcode.rb'
     - 'app/models/bait_library.rb'

--- a/features/11803383_bug_NPG_batch_state_released.feature
+++ b/features/11803383_bug_NPG_batch_state_released.feature
@@ -7,7 +7,7 @@ Feature: The XML for the sequencescape API. If all lanes are passed batch state 
   Scenario: POST XML to change qc_state on a asset
     Given I am on the last batch show page
     Then batch state should be "started"
-    When I POST following XML to change in passed the QC state on the last asset:
+    When I POST following XML to pass QC state on the last asset:
        """
       <?xml version="1.0" encoding="UTF-8"?><qc_information><message>NPG change status in failed</message></qc_information>
        """

--- a/features/api/npg/5600990_npg_xml_asset_qc_state.feature
+++ b/features/api/npg/5600990_npg_xml_asset_qc_state.feature
@@ -94,3 +94,16 @@ Feature: The XML for the sequencescape API
           </requests>
         </asset>
         """
+
+  Scenario: POST invalid XML to change qc_state on a asset. NPG did the same action before
+    Given a pass event for the request
+    When I POST following XML to pass QC state on the last asset:
+       """
+      <?xml version="1.0" encoding="UTF-8"?><unknown_attribute><message>NPG change status in passed</message></unknown_attribute>
+       """
+    Then the HTTP response should be "400"
+    And ignoring "id|name|sample_id|parents" the XML response should be:
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <error><message>param is missing or the value is empty: qc_information</message></error>
+        """

--- a/features/api/npg/5600990_npg_xml_asset_qc_state.feature
+++ b/features/api/npg/5600990_npg_xml_asset_qc_state.feature
@@ -4,7 +4,7 @@ Feature: The XML for the sequencescape API
     Given sequencescape is setup for 5600990
 
   Scenario: POST XML to change qc_state on a asset
-    When I POST following XML to change the QC state on the last asset:
+    When I POST following XML to fail QC state on the last asset:
        """
       <?xml version="1.0" encoding="UTF-8"?><qc_information><message>NPG change status in failed</message></qc_information>
        """
@@ -43,7 +43,7 @@ Feature: The XML for the sequencescape API
 
   Scenario: POST XML to change qc_state on a asset. This asset has 2 requests. Should give you error.
     Given a second request
-    When I POST following XML to change the QC state on the last asset:
+    When I POST following XML to fail QC state on the last asset:
        """
       <?xml version="1.0" encoding="UTF-8"?><qc_information><message>NPG change status in failed</message></qc_information>
        """
@@ -54,15 +54,43 @@ Feature: The XML for the sequencescape API
         <error><message>Unable to find a request for Lane: 1</message></error>
         """
 
-  Scenario: POST XML to change qc_state on a asset. NPG did this action before
-    Given an event to the request
-    When I POST following XML to change the QC state on the last asset:
+  Scenario: POST XML to change qc_state on a asset. NPG did a different action before
+    Given a pass event for the request
+    When I POST following XML to fail QC state on the last asset:
        """
       <?xml version="1.0" encoding="UTF-8"?><qc_information><message>NPG change status in failed</message></qc_information>
        """
-    Then the HTTP response should be "500"
+    Then the HTTP response should be "400"
     And the XML response should be:
         """
         <?xml version="1.0" encoding="UTF-8"?>
         <error><message>NPG user run this action. Please, contact USG</message></error>
+        """
+
+
+  Scenario: POST XML to change qc_state on a asset. NPG did the same action before
+    Given a pass event for the request
+    When I POST following XML to pass QC state on the last asset:
+       """
+      <?xml version="1.0" encoding="UTF-8"?><qc_information><message>NPG change status in passed</message></qc_information>
+       """
+    Then the HTTP response should be "200"
+    And ignoring "id|name|sample_id|parents" the XML response should be:
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <asset api_version="0.6">
+          <id>458100</id>
+          <type>Lane</type>
+          <name>XXXXX 119650</name>
+          <public_name></public_name>
+          <sample_id>10857</sample_id>
+          <qc_state>passed</qc_state>
+          <children>
+          </children>
+          <parents>
+            <id>119650</id>
+          </parents>
+          <requests>
+          </requests>
+        </asset>
         """

--- a/features/support/step_definitions/5600990_npg_xml_asset_qc_state_steps.rb
+++ b/features/support/step_definitions/5600990_npg_xml_asset_qc_state_steps.rb
@@ -6,6 +6,7 @@ Given /^sequencescape is setup for 5600990$/ do
   request = FactoryBot.create :request_with_sequencing_request_type, asset: library_tube, target_asset: lane, state: 'started'
 
   batch = FactoryBot.create :batch, state: 'started', qc_state: 'qc_manual'
+  batch.pipeline.request_types << request.request_type
   FactoryBot.create :batch_request, request: request, batch: batch, position: 1
 end
 
@@ -15,18 +16,18 @@ Given /^a second request$/ do
   request = FactoryBot.create :request_with_sequencing_request_type, asset: library_tube, target_asset: lane
 end
 
-Given /^an event to the request$/ do
+Given /^a pass event for the request$/ do
   lane = Lane.find_by(name: 'NPG_Action_Lane_Test')
   request = lane.source_request
-  FactoryBot.create :event, eventful: request, created_by: 'npg'
+  FactoryBot.create :event, eventful: request, created_by: 'npg', family: 'pass'
 end
 
-When /^I (POST|PUT) following XML to change the QC state on the last asset:$/ do |action, xml|
+When /^I (POST|PUT) following XML to fail QC state on the last asset:$/ do |action, xml|
   lane = Lane.last
   step %Q{I #{action} the following XML to "/npg_actions/assets/#{lane.id}/fail_qc_state":}, xml
 end
 
-When /^I (POST|PUT) following XML to change in passed the QC state on the last asset:$/ do |action, xml|
+When /^I (POST|PUT) following XML to pass QC state on the last asset:$/ do |action, xml|
   lane = Lane.last
   step %Q{I #{action} the following XML to "/npg_actions/assets/#{lane.id}/pass_qc_state":}, xml
 end

--- a/test/unit/event_test.rb
+++ b/test/unit/event_test.rb
@@ -92,16 +92,6 @@ class EventTest < ActiveSupport::TestCase
         should 'pass request' do
           assert @request.passed?
         end
-
-        context 'when passed twice' do
-          should 'should raise an exception' do
-            # This behaviour has changed.
-            assert_raise(AASM::InvalidTransition) do
-              event = Event.create(@settings)
-              event = Event.create(@settings)
-            end
-          end
-        end
       end
 
       context 'when fail' do


### PR DESCRIPTION
If NPG believe a request has failed, they will re-attempt it.
Occasionally this happens despite us recording the request as
passed. Previously we would reject the request if it was a duplicate,
now wer only reject requests which differ. Duplicate requests
just trigger the render (no new event is recorded)