### PR TITLE
Fixed QcResultIO API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ doc/*
 .yardoc/*
 config/aker.yml
 test_file.xlsx
+node_modules
+sbin
+yarn.lock

--- a/app/models/api/messages/qc_result_io.rb
+++ b/app/models/api/messages/qc_result_io.rb
@@ -38,7 +38,7 @@ class Api::Messages::QcResultIO < Api::Base
   map_attribute_to_json_attribute(:cv)
   map_attribute_to_json_attribute(:key, 'qc_type')
   map_attribute_to_json_attribute(:created_at, 'date_created')
-  map_attribute_to_json_attribute(:updated_at, 'date_updated')
+  map_attribute_to_json_attribute(:updated_at, 'last_updated')
 
   with_association(:asset) do
     map_attribute_to_json_attribute(:labware_purpose)

--- a/spec/models/api/messages/qc_result_io_spec.rb
+++ b/spec/models/api/messages/qc_result_io_spec.rb
@@ -29,7 +29,7 @@ describe Api::Messages::QcResultIO do
     it 'generates a valid json' do
       actual = subject.as_json
       actual.delete('date_created')
-      actual.delete('date_updated')
+      actual.delete('last_updated')
       expected_json.fetch('aliquots').first['id_library_lims'] = sample_tube.external_identifier
       expect(actual).to eq(expected_json)
     end
@@ -41,7 +41,7 @@ describe Api::Messages::QcResultIO do
     it 'generates a valid json' do
       actual = subject.as_json
       actual.delete('date_created')
-      actual.delete('date_updated')
+      actual.delete('last_updated')
       expect(actual).to eq(expected_json)
     end
   end


### PR DESCRIPTION
- Changed `date_updated` to `last_updated` to be consistent with Unified Warehouse