### PR TITLE
Sort events by id as well as created at

### DIFF
--- a/lib/eventful_record.rb
+++ b/lib/eventful_record.rb
@@ -15,10 +15,10 @@ module EventfulRecord
   end
 
   def has_many_lab_events(&block)
-    has_many(:lab_events, ->() { order('created_at') }, as: :eventful, dependent: :destroy, &block)
+    has_many(:lab_events, ->() { order(created_at: :asc, id: :asc) }, as: :eventful, dependent: :destroy, &block)
   end
 
   def has_one_event_with_family(event_family, &block)
-    has_one(:"#{event_family}_event", ->() { order('id DESC').where(family: event_family) }, class_name: 'Event', as: :eventful, &block)
+    has_one(:"#{event_family}_event", ->() { order(id: :desc).where(family: event_family) }, class_name: 'Event', as: :eventful, &block)
   end
 end


### PR DESCRIPTION
Apply a secondary sort to assist with events created in rapid
succession. Was causing intermittent test failures.