### PR TITLE
If a manifest fails to process, flag as failed

### DIFF
--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -32,12 +32,14 @@ class SampleManifest::Uploader
   end
 
   def run!
-    if valid?
-      upload.process(tag_group)
-      upload.broadcast_sample_manifest_updated_event(user)
-      upload.complete if upload.processed?
-      # Delayed::Job.enqueue SampleManifestUploadProcessingJob.new(upload, tag_group)
+    return false unless valid?
+    upload.process(tag_group)
+    upload.broadcast_sample_manifest_updated_event(user)
+    if upload.processed?
+      upload.complete
+      true
     else
+      upload.fail
       false
     end
   end

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -75,6 +75,10 @@ module SampleManifestExcel
         sample_manifest.finished!
       end
 
+      def fail
+        sample_manifest.fail!
+      end
+
       def reuploaded?
         @reuploaded
       end


### PR DESCRIPTION
Currently failed manifests get stuck at processing, leading
users to believe that they will process if they wait long enough.
This change flags them as failed instead.

That said, this isn't a complete fix, as it doesn't help
indicate what has gone wrong, and realy failure should
be caught at the earlier validation anyway. It may be more
useful if we throw an exception here as well, as well as
logging eaxtly which bit of the completion check failed.