### PR TITLE
Rollback transaction if post checks fail

### DIFF
--- a/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
+++ b/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
@@ -31,8 +31,8 @@ class SampleManifestUploadWithTagSequencesController < ApplicationController
   end
 
   def prepare_manifest_pagination
-    pending_sample_manifests = SampleManifest.pending_manifests.paginate(page: params[:page])
-    completed_sample_manifests = SampleManifest.completed_manifests.paginate(page: params[:page])
+    pending_sample_manifests = SampleManifest.pending_manifests.includes(:study, :supplier, :user, :uploaded_document).paginate(page: params[:page])
+    completed_sample_manifests = SampleManifest.completed_manifests.includes(:study, :supplier, :user, :uploaded_document).paginate(page: params[:page])
     @display_manifests = pending_sample_manifests | completed_sample_manifests
     @sample_manifests = SampleManifest.paginate(page: params[:page])
   end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -58,6 +58,7 @@ class Asset < ApplicationRecord
   # TODO: Remove 'requests' and 'source_request' as they are abiguous
   # :requests should go before :events_on_requests, through: :requests
   has_many :requests
+  has_many :external_library_creation_requests
   has_many :events_on_requests, through: :requests, source: :events, validate: false
   has_one  :source_request,     ->() { includes(:request_metadata) }, class_name: 'Request', foreign_key: :target_asset_id
   has_many :requests_as_source, ->() { includes(:request_metadata) },  class_name: 'Request', foreign_key: :asset_id

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -7,11 +7,10 @@ class Document < ApplicationRecord
   module Associations
     # Adds accessors for named fields and attaches documents to them
 
-    def has_uploaded_document(field, options = {})
+    def has_uploaded_document(field, differentiator: field.to_s)
       # Options
       #  differentiator - this is a string used to separate multiple documents related to your model
       #     for example, you can have both a "generated" and an "uploaded" document in one Sample Manifest
-      differentiator = options.fetch(:differentiator, field.to_s)
 
       line = __LINE__ + 1
       class_eval(%Q{
@@ -23,7 +22,7 @@ class Document < ApplicationRecord
         end
 
         def #{field}=(file)
-          create_#{field}_document(:uploaded_data => file, :documentable_extended => '#{differentiator}') unless file.blank?
+          create_#{field}_document(uploaded_data: file, documentable_extended: '#{differentiator}') unless file.blank?
         end
       }, __FILE__, line)
     end
@@ -43,6 +42,8 @@ class Document < ApplicationRecord
   # Handle some of the metadata with this callback
   before_save :update_document_attributes
 
+  private
+
   # Save Size/content_type Metadata
   def update_document_attributes
     if uploaded_data.present?
@@ -50,5 +51,4 @@ class Document < ApplicationRecord
       self.size = uploaded_data.file.size
     end
   end
-  private :update_document_attributes
 end

--- a/app/models/external_library_creation_request.rb
+++ b/app/models/external_library_creation_request.rb
@@ -30,9 +30,10 @@ class ExternalLibraryCreationRequest < SystemRequest
     pending?
   end
 
+  private
+
   def perform_transfer_of_contents
     target_asset.aliquots << asset.aliquots.map(&:dup)
     target_asset.save!
   end
-  private :perform_transfer_of_contents
 end

--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -27,13 +27,11 @@ class LibraryTube < Tube
   end
 
   def specialized_from_manifest=(attributes)
-    if first_update?
-      # library_id is assigned on aliquot creation in `tube_sample_creation` method
-      # in sample_manifest `library` and `multiplexed library` behaviours
-      # library_id should be removed from here at some point (20/04/2017)
-      aliquots.first.update_attributes!(attributes.merge(library_id: id))
-      requests.each(&:manifest_processed!)
-    end
+    # library_id is assigned on aliquot creation in `tube_sample_creation` method
+    # in sample_manifest `library` and `multiplexed library` behaviours
+    # library_id should be removed from here at some point (20/04/2017)
+    aliquots.first.update_attributes!(attributes.merge(library_id: id)) if first_update?
+    requests.each(&:manifest_processed!)
   end
 
   def first_update?

--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -33,12 +33,12 @@ class SampleManifest::Uploader
 
   def run!
     return false unless valid?
-    upload.process(tag_group)
-    upload.broadcast_sample_manifest_updated_event(user)
-    if upload.processed?
+    if upload.process(tag_group)
       upload.complete
+      upload.broadcast_sample_manifest_updated_event(user)
       true
     else
+      extract_errors
       upload.fail
       false
     end
@@ -52,6 +52,10 @@ class SampleManifest::Uploader
 
   def check_upload
     return true if upload.valid?
+    extract_errors
+  end
+
+  def extract_errors
     upload.errors.each do |key, value|
       errors.add key, value
     end

--- a/app/models/tag_substitution.rb
+++ b/app/models/tag_substitution.rb
@@ -43,7 +43,7 @@ class TagSubstitution
   end
 
   def substitutions=(substitutions)
-    @substitutions = substitutions.map { |attrs| Substitution.new(attrs) }
+    @substitutions = substitutions.map { |attrs| Substitution.new(attrs.dup) }
   end
 
   def save

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -80,6 +80,9 @@ module SampleManifestExcel
       end
 
       def fail
+        # If we've failed, do not update the manifest file, trying to do so
+        # causes exceptions
+        sample_manifest.association(:uploaded_document).reset
         sample_manifest.fail!
       end
 

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -34,7 +34,7 @@ module SampleManifestExcel
         @sample_manifest = derive_sample_manifest
         @override = override || false
         @processor = create_processor
-        @reuploaded = @sample_manifest.completed? if sample_manifest.present?
+        @reuploaded = !@sample_manifest.pending? if sample_manifest.present?
       end
 
       def inspect
@@ -59,6 +59,10 @@ module SampleManifestExcel
           sample_manifest.last_errors = nil
           sample_manifest.start!
           processor.run(tag_group)
+          return true if processed?
+          # One of out post processing checks failed, something went wrong, so we
+          # roll everything back
+          raise ActiveRecord::Rollback
         end
       end
 

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/processor/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/processor/base.rb
@@ -45,7 +45,9 @@ module SampleManifestExcel
         ##
         # Override the sample manifest with the raw uploaded data.
         def update_sample_manifest
-          @sample_manifest_updated = upload.sample_manifest.update(uploaded: File.open(upload.filename))
+          File.open(upload.filename) do |file|
+            @sample_manifest_updated = upload.sample_manifest.update(uploaded: file)
+          end
         end
 
         def sample_manifest_updated?

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/processor/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/processor/base.rb
@@ -35,7 +35,7 @@ module SampleManifestExcel
         end
 
         def samples_updated?
-          upload.rows.all?(&:sample_updated?)
+          upload.rows.all?(&:sample_updated?) || log_error_and_return_false('could not update samples.')
         end
 
         def processed?
@@ -57,6 +57,12 @@ module SampleManifestExcel
         end
 
         private
+
+        # Log post processing checks and fail
+        def log_error_and_return_false(message)
+          upload.errors.add(:base, message)
+          false
+        end
 
         def check_upload_type
           return if upload.instance_of?(SampleManifestExcel::Upload::Base)

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/processor/multiplexed_library_tube.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/processor/multiplexed_library_tube.rb
@@ -26,20 +26,20 @@ module SampleManifestExcel
         def update_samples_and_aliquots(tag_group)
           upload.rows.each do |row|
             row.update_sample(tag_group, upload.override)
-            row.transfer_aliquot unless upload.reuploaded?
+            row.transfer_aliquot # Requests are smart enough to only transfer once
             substitutions << row.aliquot.substitution_hash if upload.reuploaded?
           end
-          update_downstream_aliquots if upload.reuploaded? && substitutions.present?
+          update_downstream_aliquots if substitutions.present?
         end
 
         # if manifest is reuploaded, only aliquots, that are in 'fake' library tubes will be updated
         # actual aliquots in multiplexed library tube and other aliquots downstream are updated by this method
         # library updates all aliquots in one go, doing it row by row is inefficient and may trigger tag clash
         def update_downstream_aliquots
-          @downstream_aliquots_updated = if substitutions.compact.blank?
+          @downstream_aliquots_updated = if no_substitutions?
                                            false
                                          else
-                                           TagSubstitution.new(substitutions: substitutions.compact).save
+                                           TagSubstitution.new(substitutions: substitutions.compact, comment: 'Manifest updated').save
                                          end
         end
 
@@ -67,11 +67,17 @@ module SampleManifestExcel
           @processed ||= samples_updated? && aliquots_updated? && sample_manifest_updated?
         end
 
+        def no_substitutions?
+          substitutions.compact.all?(&:blank?)
+        end
+
         def aliquots_updated?
           if upload.reuploaded?
-            downstream_aliquots_updated? || substitutions.compact.blank?
+            downstream_aliquots_updated? ||
+              no_substitutions? ||
+              log_error_and_return_false('Could not update tags in other assets.')
           else
-            aliquots_transferred?
+            aliquots_transferred? || log_error_and_return_false('Could not transfer aliquots.')
           end
         end
       end

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
@@ -102,8 +102,7 @@ module SampleManifestExcel
       def transfer_aliquot
         return unless valid?
         sample.primary_receptacle.requests.each do |request|
-          request.manifest_processed!
-          @aliquot_transferred = true
+          @aliquot_transferred = request.passed? || request.manifest_processed!
         end
       end
 

--- a/app/views/sample_manifest_upload_with_tag_sequences/_upload.html.erb
+++ b/app/views/sample_manifest_upload_with_tag_sequences/_upload.html.erb
@@ -4,18 +4,17 @@
 # authorship of this file.
 # Copyright (C) 2018 Genome Research Ltd.%>
 
-<h2>Upload a sample manifest</h2>
-<p>This sample manifest upload screen handles tubes with tag sequences, and plates or tubes with foreign barcodes.</p>
+<p class="lead">This sample manifest upload screen handles tubes with tag sequences, and plates or tubes with foreign barcodes.</p>
 
-<div class='alert alert-warning'>
+<%= alert(:warning) do %>
   <strong>Warning!</strong> This upload page should cope with both old and new plate and tube sample manifests, including tube manifests with tag groups and indexes or with tag sequences, and plate or tube manifests with foreign barcodes. It does not handle some of the obsolete columns from the older manifests which will need to be removed before upload.</br>Alternatively, you can still <a href="<%= sample_manifests_path %>">use the old sample manifest upload page here</a>.
-</div>
+<% end %>
 
 <%= form_tag(sample_manifest_upload_with_tag_sequences_path, multipart: true) do -%>
   <fieldset>
     <div class="form-group">
       <%= label_tag :upload, 'File to upload', style: "display: none;" %></br>
-      <%= file_field_tag :upload %>
+      <%= file_field_tag :upload, required: true %>
     </div>
     <div class="form-group">
       <%= check_box_tag :override %>&nbsp;<%= label_tag :override, 'Override previously uploaded samples' %>

--- a/app/views/sample_manifest_upload_with_tag_sequences/new.html.erb
+++ b/app/views/sample_manifest_upload_with_tag_sequences/new.html.erb
@@ -3,6 +3,14 @@
 
 <%= page_title "Sample Manifests", "New and upload" %>
 
+<% if @uploader %>
+  <%= alert(:danger) do %>
+    <% @uploader.errors.full_messages.each do |message| %>
+      <p><%= message %></p>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= render partial: "upload" %>
 
 <%= pagination @sample_manifests %>


### PR DESCRIPTION
Post checks were outside the transaction, and would
identify a manifest in an invalid sate, however this
makes subsequent attempt to fix the manifest fail.
This makes the errors more informative, and moves the
check inside process, such that the transaction is aborted.