### PR TITLE
Pin font-awesome to 5.0.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,11 @@ group :default do
   gem 'sass-rails'
   gem 'coffee-rails'
   gem 'select2-rails'
-  gem 'font-awesome-sass'
+  # Temporarily pin to earlier version
+  # Newer versions on font-awesome switch to sassc which will not
+  # compile on our older servers due to gcc version. We can update this
+  # as soon as we're migrated off the metal.
+  gem 'font-awesome-sass', '< 5.0.13'
 
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'therubyracer', platforms: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,8 +203,8 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
-    font-awesome-sass (5.3.1)
-      sassc (>= 1.11)
+    font-awesome-sass (5.0.9)
+      sass (>= 3.2)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     gherkin (4.1.3)
@@ -372,9 +372,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (1.12.1)
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.12.0)
@@ -473,7 +470,7 @@ DEPENDENCIES
   factory_bot_rails
   flay
   flog
-  font-awesome-sass
+  font-awesome-sass (< 5.0.13)
   formtastic
   gmetric (~> 0.1.3)
   irods_reader (>= 0.0.2)!


### PR DESCRIPTION
Newer versions was sass for sassc due to sass deprecations
and better performance. However sassc will not compile on our
older servers. Temporarily switching back until the movement
of pasd2a etc. is complete.