### PR TITLE
Sibling tube handles diverse submissions

### DIFF
--- a/app/models/illumina_htp/initial_stock_tube_purpose.rb
+++ b/app/models/illumina_htp/initial_stock_tube_purpose.rb
@@ -23,16 +23,17 @@ class IlluminaHtp::InitialStockTubePurpose < IlluminaHtp::StockTubePurpose
   # We only pick up open requests, just in case a whole tube has failed / been cancelled.
   def sibling_tubes(tube)
     return [] if tube.submission.nil?
-    submission_id     = tube.submission.id
-    outr_request_type = tube.transfer_requests_as_target.first.outer_request.request_type_id
+    submission_id = tube.submission.id
 
     siblings = Tube.select('assets.*, tfr.state AS quick_state').distinct.joins([
       'LEFT JOIN transfer_requests AS tfr ON tfr.target_asset_id = assets.id',
-      'RIGHT OUTER JOIN requests AS outr ON outr.asset_id = tfr.asset_id AND outr.asset_id IS NOT NULL'
+      'RIGHT OUTER JOIN requests AS outr ON outr.asset_id = tfr.asset_id AND outr.asset_id IS NOT NULL',
+      'LEFT JOIN request_types AS rt ON rt.id = outr.request_type_id'
     ])
                    .where(
-                     outr: { submission_id: submission_id, request_type_id: outr_request_type, state: Request::Statemachine::OPENED_STATE },
-                     tfr:  { submission_id: submission_id, state: TransferRequest::ACTIVE_STATES }
+                     outr: { submission_id: submission_id, state: Request::Statemachine::OPENED_STATE },
+                     tfr:  { submission_id: submission_id, state: TransferRequest::ACTIVE_STATES },
+                     rt:   { for_multiplexing: true }
                    )
                    .includes(:uuid_object, :barcodes)
 

--- a/spec/factories/request_factories.rb
+++ b/spec/factories/request_factories.rb
@@ -91,6 +91,7 @@ FactoryBot.define do
   factory(:multiplex_request, class: Request::Multiplexing) do
     asset nil
     association(:target_asset, factory: :multiplexed_library_tube)
+    association(:request_type, factory: :multiplex_request_type)
     request_purpose :standard
   end
 

--- a/spec/models/illumina_htp/initial_stock_tube_purpose_spec.rb
+++ b/spec/models/illumina_htp/initial_stock_tube_purpose_spec.rb
@@ -19,24 +19,37 @@ describe IlluminaHtp::InitialStockTubePurpose do
     let(:sibling_tube_hash) { { name: sibling_tube.name, uuid: sibling_tube.uuid, ean13_barcode: sibling_tube.ean13_barcode, state: sibling_state } }
     let(:target_tube) { create :multiplexed_library_tube }
     let(:sibling_state) { 'pending' }
+    let(:library_request) { create :multiplex_request, asset: parent_well, target_asset: target_tube, submission: current_submission }
 
     before do
       create :transfer_request, asset: parent_well, target_asset: tube, submission: current_submission
       create :transfer_request, asset: parents_sibling_well, target_asset: sibling_tube, submission: sibling_submission, state: sibling_state
-      lr = create :library_request, asset: parent_well, target_asset: target_tube, submission: current_submission
-      create :library_request, asset: parents_sibling_well, target_asset: target_tube, submission: sibling_submission, request_type: lr.request_type
+      library_request
+      create :multiplex_request, asset: parents_sibling_well, target_asset: target_tube, submission: sibling_submission, request_type: sibling_request_type
     end
 
     context 'with siblings' do
+      let(:sibling_request_type) { library_request.request_type }
       let(:sibling_submission) { current_submission }
       let(:parents_sibling_well) { create :well }
       it 'works', :aggregate_failures do
         is_expected.to be_a Array
         is_expected.to include(sibling_tube_hash)
       end
+
+      context 'which are a different request type' do
+        let(:sibling_submission) { current_submission }
+        let(:sibling_request_type) { create :multiplex_request_type }
+        let(:sibling_state) { 'started' }
+        it 'works', :aggregate_failures do
+          is_expected.to be_a Array
+          is_expected.to include(sibling_tube_hash)
+        end
+      end
     end
 
     context 'with wells which are also siblings' do
+      let(:sibling_request_type) { library_request.request_type }
       let(:sibling_submission) { current_submission }
       let(:sibling_tube) { create(:well) }
       let(:parents_sibling_well) { create :well }
@@ -48,6 +61,7 @@ describe IlluminaHtp::InitialStockTubePurpose do
     end
 
     context 'with unrelated requests out the same well' do
+      let(:sibling_request_type) { library_request.request_type }
       let(:sibling_submission) { create :submission }
       let(:parents_sibling_well) { parent_well }
       it 'works', :aggregate_failures do
@@ -58,6 +72,7 @@ describe IlluminaHtp::InitialStockTubePurpose do
 
     context 'with related requests out the same well' do
       context 'which are cancelled' do
+        let(:sibling_request_type) { library_request.request_type }
         let(:sibling_submission) { current_submission }
         let(:parents_sibling_well) { parent_well }
         let(:sibling_state) { 'cancelled' }


### PR DESCRIPTION
Submissions may now pool distinct request types.
This identifies pools based on the multiplexed request