### PR TITLE
Avoid mutating includes with concat

### DIFF
--- a/app/resources/api/v2/base_resource.rb
+++ b/app/resources/api/v2/base_resource.rb
@@ -33,11 +33,11 @@ module Api
       # Eager load specified models by default. Useful when attributes are
       # dependent on an associated model.
       def self.default_includes(*inclusions)
-        @default_includes = inclusions
+        @default_includes = inclusions.freeze
       end
 
       def self.inclusions
-        @default_includes || []
+        @default_includes || [].freeze
       end
 
       # Extends the default behaviour to add our default inclusions if provided
@@ -67,7 +67,7 @@ module Api
               model_includes.delete(key)
               # MODIFICATION BEGINS
               included_relationships = resolve_relationship_names_to_relations(relationship.resource_klass, value, options)
-              model_includes[relationship.relation_name(options)] = relationship.resource_klass.inclusions.concat(included_relationships)
+              model_includes[relationship.relation_name(options)] = relationship.resource_klass.inclusions + included_relationships
               # MODIFICATION ENDS
             end
             return model_includes

--- a/config/environments/profile.rb
+++ b/config/environments/profile.rb
@@ -7,23 +7,16 @@ Rails.application.configure do
   config.eager_load = true
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
 
   config.cache_template_loading = true
 
-  # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist? #rubocop:disable all
-    config.action_controller.perform_caching = true
+  config.action_controller.perform_caching = true
+  ActionController::Base.cache_store = :file_store, 'tmp/cache'
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
-    }
-  else
-    config.action_controller.perform_caching = false
+  config.action_controller.allow_forgery_protection = false
 
-    config.cache_store = :null_store
-  end
+  config.assets.digest = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
@@ -36,27 +29,10 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
-
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  if ENV['WITH_BULLET'] == 'true'
-    config.after_initialize do
-      require 'bullet'
-      Bullet.enable = true
-      Bullet.alert = ENV['NOISY_BULLET'] == 'true'
-      Bullet.bullet_logger = true
-    end
-  end
 end


### PR DESCRIPTION
The default includes were having any custom includes concatenated
onto them repeatedly. This was causing significant performance
degredation. This commit used + instead, and freezes the default
includes to prefent similar errors occuring again in future.

Profile environment updated to more closely mimic production.