### PR TITLE
Identify requests directly via submission

### DIFF
--- a/app/models/health.rb
+++ b/app/models/health.rb
@@ -1,9 +1,10 @@
 
 class Health
-  attr_reader :status, :message
+  attr_reader :status, :message, :details
 
   def initialize
     @status, @message = :ok, []
+    @details = { vm_stas: RubyVM.stat }
     check
   end
 

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -136,6 +136,8 @@ class Plate < Asset
   # May not have been started yet
   has_many :waiting_submissions, -> { distinct }, through: :well_requests_as_source, source: :submission
   # The requests which were being processed to make the plate
+  # This should probably be switched to going through aliquots, but not 100% certain that it wont cause side effects
+  # Might just be safer to wait until we've moved off onto the new api
   has_many :in_progress_submissions, -> { distinct }, through: :transfer_requests_as_target, source: :submission
 
   def submission_ids

--- a/spec/api/submission_pool_spec.rb
+++ b/spec/api/submission_pool_spec.rb
@@ -122,13 +122,17 @@ describe '/api/1/plate-uuid/submission_pools' do
     end
 
     context 'a multi plate submission and a used template on children' do
-      let(:plate_b) { create :input_plate, well_count: 2 }
-      let(:plate) { create :plate, well_count: 2, parents: [plate_b] }
-
-      before do
-        plate_b.wells.each do |well|
+      let(:plate_b) do
+        plate = create :input_plate, well_count: 2
+        plate.wells.each do |well|
           create :library_creation_request, asset: well, submission: submission, request_type: request_type
         end
+        plate
+      end
+
+      let(:plate) { create :target_plate, well_count: 2, parent: plate_b, submission: submission }
+
+      before do
         create :tag2_layout_template_submission, submission: submission, tag2_layout_template: tag2_layout_template
       end
 


### PR DESCRIPTION
Popping via stock plate makes things brittle is additional stock plates
are introduced. This change reduces the risk of introducing tag
clashes, although does mean that we'll detect cross-plate submissions
on the basis of the initial requests in the submission only. This
is currently not a problem, as we don't have any submission templates
active which put cherrypicking upstream of library creation. And it
seems likely that the point will be rendered moot by the time that
changes.