### PR TITLE
Reupload check performed at row level

### DIFF
--- a/app/models/library_tube.rb
+++ b/app/models/library_tube.rb
@@ -31,7 +31,7 @@ class LibraryTube < Tube
     # in sample_manifest `library` and `multiplexed library` behaviours
     # library_id should be removed from here at some point (20/04/2017)
     aliquots.first.update_attributes!(attributes.merge(library_id: id)) if first_update?
-    requests.each(&:manifest_processed!)
+    external_library_creation_requests.each(&:manifest_processed!)
   end
 
   def first_update?

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -34,7 +34,6 @@ module SampleManifestExcel
         @sample_manifest = derive_sample_manifest
         @override = override || false
         @processor = create_processor
-        @reuploaded = !@sample_manifest.pending? if sample_manifest.present?
       end
 
       def inspect
@@ -84,10 +83,6 @@ module SampleManifestExcel
         # causes exceptions
         sample_manifest.association(:uploaded_document).reset
         sample_manifest.fail!
-      end
-
-      def reuploaded?
-        @reuploaded
       end
 
       private

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/processor/multiplexed_library_tube.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/processor/multiplexed_library_tube.rb
@@ -27,7 +27,7 @@ module SampleManifestExcel
           upload.rows.each do |row|
             row.update_sample(tag_group, upload.override)
             row.transfer_aliquot # Requests are smart enough to only transfer once
-            substitutions << row.aliquot.substitution_hash if upload.reuploaded?
+            substitutions << row.aliquot.substitution_hash if row.reuploaded?
           end
           update_downstream_aliquots if substitutions.present?
         end
@@ -72,13 +72,10 @@ module SampleManifestExcel
         end
 
         def aliquots_updated?
-          if upload.reuploaded?
-            downstream_aliquots_updated? ||
-              no_substitutions? ||
-              log_error_and_return_false('Could not update tags in other assets.')
-          else
-            aliquots_transferred? || log_error_and_return_false('Could not transfer aliquots.')
-          end
+          downstream_aliquots_updated? ||
+            no_substitutions? ||
+            log_error_and_return_false('Could not update tags in other assets.')
+          aliquots_transferred? || log_error_and_return_false('Could not transfer aliquots.')
         end
       end
     end

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
@@ -101,9 +101,14 @@ module SampleManifestExcel
       # from the library tube to a multiplexed library tube and stated set to passed.
       def transfer_aliquot
         return unless valid?
-        sample.primary_receptacle.requests.each do |request|
+        sample.primary_receptacle.external_library_creation_requests.each do |request|
+          @reuploaded ||= request.passed?
           @aliquot_transferred = request.passed? || request.manifest_processed!
         end
+      end
+
+      def reuploaded?
+        @reuploaded || false
       end
 
       def sample_updated?

--- a/app/views/sdb/sample_manifests/show.html.erb
+++ b/app/views/sdb/sample_manifests/show.html.erb
@@ -3,17 +3,21 @@
 <% add :menu, "Download Blank Manifest" => export_sample_manifest_path(@sample_manifest) %>
 
 <%= page_title @sample_manifest.name, @sample_manifest.study.name %>
-<h3><%= link_to "Download Blank Manifest", export_sample_manifest_path(@sample_manifest) %></h3>
-
-<% if @sample_manifest.uploaded_document %>
-  <h3><%= link_to 'Download Completed Manifest', uploaded_spreadsheet_sample_manifest_path(@sample_manifest) %></h3>
-<% end %>
 
 <% if @sample_manifest.user %>
-  <p>Created by <%= link_to @sample_manifest.user.login, profile_path(@sample_manifest.user) %></p>
+  <p class="lead">Created by <%= link_to @sample_manifest.user.login, profile_path(@sample_manifest.user) %></p>
 <% end %>
 
-<%= render partial: "upload" %>
+<%= panel do %>
+  <%= link_to "Download Blank Manifest", export_sample_manifest_path(@sample_manifest), class: 'btn btn-lg btn-primary' %>
+  <% if @sample_manifest.uploaded_document %>
+    <%= link_to 'Download Completed Manifest', uploaded_spreadsheet_sample_manifest_path(@sample_manifest), class: 'btn btn-lg btn-secondary' %>
+  <% end %>
+<% end %>
+
+<%= panel do %>
+  <%= render partial: "upload" %>
+<% end %>
 
 <% if @sample_manifest.last_errors %>
   <h2>Errors</h2>
@@ -30,31 +34,30 @@
 
 <%= render partial: "pool", locals: { sample_manifest: @sample_manifest} %>
 
-<br>
+<%= panel do %>
+  <%= form_for(@sample_manifest, url: {action: "print_labels"}, method: :post) do |f| %>
 
-<%= form_for(@sample_manifest, url: {action: "print_labels"}, method: :post) do |f| %>
+    <div class="form-group">
+      <%= label_tag :barcode_printer, 'Barcode printer' %>
+      <%= render partial: "shared/printer_list" %>
+    </div>
 
-  <div class="form-group">
-    <%= label_tag :barcode_printer, 'Barcode printer' %>
-    <%= render partial: "shared/printer_list" %>
-  </div>
+    <div class="form-group">
+      <%= f.submit "Reprint all labels", class: 'btn btn-success' %>
+    </div>
 
-  <div class="form-group">
-    <%= f.submit "Reprint all labels" %>
-  </div>
-
-<% end %>
-
-<% if @sample_manifest.barcodes %>
-
-  <%= bs_column do %>
-    <h2>Barcodes</h2>
-    <ul>
-    <% @sample_manifest.barcodes.each do |barcode| %>
-      <li><%= barcode %></li>
+  <% end %>
+  <% if @sample_manifest.barcodes %>
+    <%= bs_column do %>
+      <h2>Barcodes</h2>
+      <ul>
+      <% @sample_manifest.barcodes.each do |barcode| %>
+        <li><%= barcode %></li>
+      <% end %>
+      </ul>
     <% end %>
-    </ul>
   <% end %>
 <% end %>
 
 <%= render partial: "samples", locals: { samples: @samples} %>
+

--- a/app/views/shared/_printer_list.html.erb
+++ b/app/views/shared/_printer_list.html.erb
@@ -1,6 +1,6 @@
 
 <div><label for="barcode_printer_list" style="display:none">Barcode Printer</label></div>
-<select name="printer" id="barcode_printer_list">
+<select name="printer" id="barcode_printer_list" class="select2">
    <% printer_list = BarcodePrinter.alphabetical.includes(:barcode_printer_type).all.group_by {|printer| "#{printer.barcode_printer_type.name} (#{printer.active? ? 'Active' : 'Inactive'})" } %>
    <% printer_list.each do |group, printers| %>
     <optgroup label="<%= group %>">

--- a/spec/factories/tube_factories.rb
+++ b/spec/factories/tube_factories.rb
@@ -122,10 +122,11 @@ FactoryBot.define do
   factory(:tagged_library_tube, class: LibraryTube, traits: [:tube_barcode]) do
     transient do
       tag_map_id 1
+      sample { create(:sample_with_sanger_sample_id) }
     end
 
     after(:create) do |library_tube, evaluator|
-      library_tube.aliquots << build(:tagged_aliquot, tag: create(:tag, map_id: evaluator.tag_map_id), receptacle: library_tube)
+      library_tube.aliquots << build(:tagged_aliquot, tag: create(:tag, map_id: evaluator.tag_map_id), receptacle: library_tube, sample: evaluator.sample)
     end
   end
 

--- a/spec/sample_manifest_excel/upload/row_spec.rb
+++ b/spec/sample_manifest_excel/upload/row_spec.rb
@@ -145,6 +145,45 @@ RSpec.describe SampleManifestExcel::Upload::Row, type: :model, sample_manifest_e
         row.transfer_aliquot
       end
       expect(rows.all?(&:aliquot_transferred?)).to be_truthy
+      expect(rows.all?(&:reuploaded?)).to be_falsey
+      mx_library_tube.samples.each_with_index do |sample, i|
+        expect(sample.aliquots.first.tag.oligo).to eq(tags[i][:i7])
+        expect(sample.aliquots.first.tag2.oligo).to eq(tags[i][:i5])
+        sample.primary_receptacle.requests.each do |request|
+          expect(request.state).to eq('passed')
+        end
+      end
+    end
+  end
+
+  context 'previously transferred aliquot on multiplex library tubes' do
+    attr_reader :rows
+
+    let!(:library_tubes) { create_list(:tagged_library_tube, 5) }
+    let!(:mx_library_tube) { create(:multiplexed_library_tube) }
+    let(:tags) { SampleManifestExcel::Tags::ExampleData.new.take(0, 4) }
+
+    before(:each) do
+      @rows = []
+      library_tubes.each_with_index do |tube, i|
+        rq = create(:external_multiplexed_library_tube_creation_request, asset: tube, target_asset: mx_library_tube)
+        rq.manifest_processed!
+        row_data = data.dup
+        row_data[0] = tube.samples.first.assets.first.human_barcode
+        row_data[1] = tube.samples.first.sanger_sample_id
+        row_data[2] = tags[i][:i7]
+        row_data[3] = tags[i][:i5]
+        rows << SampleManifestExcel::Upload::Row.new(number: i + 1, data: row_data, columns: columns)
+      end
+    end
+
+    it 'transfers stuff' do
+      rows.each do |row|
+        row.update_sample(tag_group, false)
+        row.transfer_aliquot
+      end
+      expect(rows.all?(&:aliquot_transferred?)).to be_truthy
+      expect(rows.all?(&:reuploaded?)).to be_truthy
       mx_library_tube.samples.each_with_index do |sample, i|
         expect(sample.aliquots.first.tag.oligo).to eq(tags[i][:i7])
         expect(sample.aliquots.first.tag2.oligo).to eq(tags[i][:i5])

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -84,27 +84,6 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
     expect(BroadcastEvent.last.subjects.count).to eq 8
   end
 
-  it 'should know if it is initial or reupload' do
-    download = build(:test_download_tubes, columns: SampleManifestExcel.configuration.columns.tube_library_with_tag_sequences.dup)
-    download.save(test_file)
-    upload = SampleManifestExcel::Upload::Base.new(filename: test_file, column_list: columns, start_row: 9)
-    expect(upload.reuploaded?).to be_falsey
-    upload.sample_manifest.start!
-    expect(upload.reuploaded?).to be_falsey
-    upload.sample_manifest.finished!
-    expect(upload.reuploaded?).to be_falsey
-
-    download.save(test_file)
-    download.worksheet.sample_manifest.start!
-    download.worksheet.sample_manifest.finished!
-    upload = SampleManifestExcel::Upload::Base.new(filename: test_file, column_list: columns, start_row: 9)
-    expect(upload.reuploaded?).to be_truthy
-    upload.sample_manifest.start!
-    expect(upload.reuploaded?).to be_truthy
-    upload.sample_manifest.finished!
-    expect(upload.reuploaded?).to be_truthy
-  end
-
   describe '#processor' do
     context '1dtube' do
       let!(:columns) { SampleManifestExcel.configuration.columns.tube_full.dup }


### PR DESCRIPTION
The reupload chaeck is used to work out if substitution
is required on row updates. Perviously it used manifest
state, but this only matched the state of the most recent
upload, thus failed was ambiguous.
- Failed first upload
- Failed reupload
This change looks directly at the state of the external library
creation request, which directly reports on whether the sample as
been moved downstream.

We don't currently support manifest reuploads for plain
libraries. These could use a similar row level mechanism, although
the actual check itself would need to be different. (Probably just
counting the number of aliquots with the same library_id, otherwise
we'd need to cover all the ways in which a sample can exist elsewhere)