### PR TITLE
Fix manifest substitution issues

### DIFF
--- a/app/models/tag_substitution.rb
+++ b/app/models/tag_substitution.rb
@@ -12,7 +12,7 @@
 class TagSubstitution
   include ActiveModel::Model
 
-  attr_accessor :user, :ticket, :comment
+  attr_accessor :user, :ticket, :comment, :disable_clash_detection
   attr_reader :substitutions
   attr_writer :name
 
@@ -32,7 +32,7 @@ class TagSubstitution
 
   validates :substitutions, presence: true
   validate :substitutions_valid?, if: :substitutions
-  validate :no_duplicate_tag_pairs, if: :substitutions
+  validate :no_duplicate_tag_pairs, if: :substitutions, unless: :disable_clash_detection
 
   def substitutions_valid?
     @substitutions.reduce(true) do |valid, sub|

--- a/spec/sample_manifest_excel/upload/processor_spec.rb
+++ b/spec/sample_manifest_excel/upload/processor_spec.rb
@@ -193,6 +193,18 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model, sample_mani
             expect(processor.downstream_aliquots_updated?).to be_truthy
           end
 
+          it 'will update the aliquots downstream in dual index cases where the subtitured tags along look like a tag clash' do
+            # We already have distinct tag2s, so by setting these to the same, we aren't creating a tag clash.
+            download.worksheet.axlsx_worksheet.rows[10].cells[2].value = 'ATAGATAGATAG'
+            download.worksheet.axlsx_worksheet.rows[11].cells[2].value = 'ATAGATAGATAG'
+            download.save(new_test_file)
+            reupload = SampleManifestExcel::Upload::Base.new(filename: new_test_file, column_list: multiplex_library_with_tag_seq_cols, start_row: 9, override: true)
+            processor = SampleManifestExcel::Upload::Processor::MultiplexedLibraryTube.new(reupload)
+            processor.update_samples_and_aliquots(tag_group)
+            expect(processor.aliquots_updated?).to be_truthy
+            expect(processor.downstream_aliquots_updated?).to be_truthy
+          end
+
           it 'will not update the aliquots downstream if there is nothing to update' do
             download.save(new_test_file)
             reupload = SampleManifestExcel::Upload::Base.new(filename: new_test_file, column_list: multiplex_library_with_tag_seq_cols, start_row: 9, override: true)


### PR DESCRIPTION
Tag substitution would only screen clashes in the tags which had
been substituted. Which meant that in non-udi dual index pools
there was a risk of falsely detecting a clash if only the i7 tag
(or the i5) was substituted. Given we're already detecting clashes
within the manifest, AND, have fallback tag clash protections in the
database, we just disable this redundant round of clash detection.

This bug also revealed that we were improperly propagating errors
back out to the upload. (My fault) This ensures errors get properly
propagated.