### PR TITLE
Use find_by! to raise error if id missing

### DIFF
--- a/app/controllers/qc_reports_controller.rb
+++ b/app/controllers/qc_reports_controller.rb
@@ -46,7 +46,7 @@ class QcReportsController < ApplicationController
   end
 
   def show
-    qc_report = QcReport.find_by(report_identifier: params[:id])
+    qc_report = QcReport.find_by!(report_identifier: params[:id])
     queue_count = qc_report.queued? ? Delayed::Job.count : 0
     @report_presenter = Presenters::QcReportPresenter.new(qc_report, queue_count)
 


### PR DESCRIPTION
Some of our power users modify the url to access reports directly, however if they typo, we get a method missing, as the find_by returns nil. ::find_by! will raise an ActiveRecord::RecordNotFound instead, which gets handled automatically, and converted to a 404. Not only is this more informative for the user, but it stops us getting spammed.