### PR TITLE
Fix submission_pool for cancelled submissions

### DIFF
--- a/app/models/submission_pool.rb
+++ b/app/models/submission_pool.rb
@@ -35,7 +35,7 @@ class SubmissionPool < ApplicationRecord
   # It was agreed with Jamie that it was more important to detect clashes than it was to handle unlikely
   # possible future scenarios.
   def plates_in_submission
-    outer_request.submission_plate_count
+    outer_request&.submission_plate_count || 0 # If all requests have been cancelled, we can ignore the submission.
   end
 
   def used_tag2_layout_templates

--- a/spec/api/submission_pool_spec.rb
+++ b/spec/api/submission_pool_spec.rb
@@ -62,6 +62,33 @@ describe '/api/1/plate-uuid/submission_pools' do
       it_behaves_like 'an API/1 GET endpoint'
     end
 
+    context 'a submission with canceleld requests' do
+      let(:plate) { create :input_plate, well_count: 2 }
+
+      before do
+        plate.wells.each do |well|
+          create :library_creation_request, asset: well, submission: submission, request_type: request_type, state: 'cancelled'
+        end
+      end
+
+      let(:response_body) do
+        %({
+            "actions": {
+              "read": "http://www.example.com/api/1/#{uuid}/submission_pools/1",
+              "first": "http://www.example.com/api/1/#{uuid}/submission_pools/1",
+              "last": "http://www.example.com/api/1/#{uuid}/submission_pools/1"
+            },
+            "size":1,
+            "submission_pools":[{
+              "plates_in_submission":0,
+              "used_tag2_layout_templates":[],
+              "used_tag_layout_templates":[]
+           }]
+       })
+      end
+      it_behaves_like 'an API/1 GET endpoint'
+    end
+
     context 'a submission and a used tag template' do
       let(:plate) { create :input_plate, well_count: 2 }
 

--- a/test/unit/multiplexed_library_tube_test.rb
+++ b/test/unit/multiplexed_library_tube_test.rb
@@ -42,7 +42,8 @@ class MultiplexedLibraryTubeTest < ActiveSupport::TestCase
 
       context 'should allow overriding of attributes' do
         setup do
-          @stock = @multiplexed_library_tube.create_stock_asset!(name: 'Foo', barcode: '1111')
+          @custom_barcode = generate(:barcode_number).to_s
+          @stock = @multiplexed_library_tube.create_stock_asset!(name: 'Foo', barcode: @custom_barcode)
         end
 
         should 'use the specified name' do
@@ -50,7 +51,7 @@ class MultiplexedLibraryTubeTest < ActiveSupport::TestCase
         end
 
         should 'set the barcode' do
-          assert_equal '1111', @stock.barcode_number.to_s
+          assert_equal @custom_barcode, @stock.barcode_number.to_s
         end
       end
     end


### PR DESCRIPTION
Cancelled submissions have no active requests
so can't find an outer request to get the plate count
from. Fortunately fo us, no requests means no plates.