### PR TITLE
Rails-5.1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 group :default do
-  gem 'rails', '~> 5.1.2'
+  gem 'rails', '~> 5.1.6'
 
   # State machine
   gem 'aasm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       net-http-persistent (>= 2.7)
       net-http-pipeline
     gherkin (4.1.3)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     gmetric (0.1.3)
     hashdiff (0.3.7)
@@ -536,7 +536,7 @@ DEPENDENCIES
   rack-acceptable
   rack-cors
   rack-mini-profiler
-  rails (~> 5.1.2)
+  rails (~> 5.1.6)
   rails-controller-testing
   rails-perftest
   rest-client
@@ -573,4 +573,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.6
+   1.17.2


### PR DESCRIPTION
Rails 5.2 requires an audit and update of our after_ and before_ callbacks, but 5.1 versions should be fine.