### PR TITLE
Find wells/tube through primary receptacle

### DIFF
--- a/app/sequencescape_excel/sequencescape_excel/specialised_field/sanger_plate_id.rb
+++ b/app/sequencescape_excel/sequencescape_excel/specialised_field/sanger_plate_id.rb
@@ -35,7 +35,8 @@ module SequencescapeExcel
       private
 
       def check_container
-        return if value == sample.wells.first.plate.human_barcode
+        primary_receptacle = sample.primary_receptacle
+        return if value == primary_receptacle.labware.human_barcode
 
         check_for_foreign_barcode
       end

--- a/app/sequencescape_excel/sequencescape_excel/specialised_field/sanger_tube_id.rb
+++ b/app/sequencescape_excel/sequencescape_excel/specialised_field/sanger_tube_id.rb
@@ -34,7 +34,8 @@ module SequencescapeExcel
       private
 
       def check_container
-        return if value == sample.assets.first.human_barcode
+        primary_receptacle = sample.primary_receptacle
+        return if value == primary_receptacle.labware.human_barcode
 
         check_for_foreign_barcode
       end


### PR DESCRIPTION
sample.assets.first and sample.wells.first return the oldest
well/tube associated with the sample. However, samples can
be transfered into plates which are older than they are.

Primary receptacle goes via the aliquot, so is more robust.
In future we should actually be able to access the containers more
directly via sample manifest assets. However we'll need to update some
historical records first.