### PR TITLE
Update for shoulda-4

### DIFF
--- a/app/models/sample_registrar.rb
+++ b/app/models/sample_registrar.rb
@@ -110,7 +110,7 @@ class SampleRegistrar < ApplicationRecord
   end
 
   # SampleTubes are registered within an AssetGroup, unless the AssetGroup is unspecified.
-  attr_accessor :asset_group_helper
+  attr_writer :asset_group_helper
   attr_accessor :asset_group_name
 
   validates_each(:asset_group_name, if: :new_record?) do |record, _attr, value|
@@ -135,6 +135,10 @@ class SampleRegistrar < ApplicationRecord
   # So, once have created an instance we immediately destroy it.  Note that, because of the way ActiveRecord
   # works, this *must* be the LAST after_create callback in this file.
   after_create :delete
+
+  def asset_group_helper
+    @asset_group_helper ||= SampleRegistrar::AssetGroupHelper.new
+  end
 
   # Is this instance to be ignored?
   def ignore?

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Comment, type: :model do
   context 'A comment has relationships' do
     it 'should belong to commentable' do
-      should belong_to :commentable
+      should belong_to(:commentable).required
     end
 
     it 'should belong to a user' do

--- a/test/unit/flexible_submission_test.rb
+++ b/test/unit/flexible_submission_test.rb
@@ -8,7 +8,7 @@ class FlexibleSubmissionTest < ActiveSupport::TestCase
     end
 
     should belong_to :study
-    should belong_to :user
+    should belong_to(:user).required
 
     context 'build (Submission factory)' do
       setup do

--- a/test/unit/linear_submission_test.rb
+++ b/test/unit/linear_submission_test.rb
@@ -6,7 +6,7 @@ class LinearSubmissionTest < ActiveSupport::TestCase
 
   context 'LinearSubmission' do
     should belong_to :study
-    should belong_to :user
+    should belong_to(:user).required
   end
 
   context 'A LinearSubmission' do

--- a/test/unit/sample_registrar_test.rb
+++ b/test/unit/sample_registrar_test.rb
@@ -133,8 +133,8 @@ class SampleRegistrarTest < ActiveSupport::TestCase
       end
     end
 
-    should belong_to :user
-    should belong_to :study
+    should belong_to(:user).required
+    should belong_to(:study).required
     should belong_to(:sample).validate(true)
     should belong_to(:sample_tube).validate(true)
 


### PR DESCRIPTION
- association_tests have adjusted the way they handle 'required'
- Validations which are dependent on another association now
check that has been set, rather than throwing an exception. Changes in
shoulda were triggering these issues.