### PR TITLE
Allow renaming of studies

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -111,8 +111,7 @@ class Study < ApplicationRecord
   has_many :suppliers, ->() { distinct }, through: :sample_manifests
 
   # Validations
-  validates_presence_of :name
-  validates :name, on: :create, uniqueness: { case_sensitive: false }
+  validates :name, uniqueness: { case_sensitive: false }, presence: true
   validates_length_of :name, maximum: 200
   validates_format_of :abbreviation, with: /\A[\w_-]+\z/i, allow_blank: false, message: 'cannot contain spaces or be blank'
   validate :validate_ethically_approved

--- a/app/views/admin/studies/_edit.html.erb
+++ b/app/views/admin/studies/_edit.html.erb
@@ -6,32 +6,20 @@
       Study <%= study.id %> &middot; Created on <%= study.created_at.to_formatted_s(:long) %> &middot; <%= study.state.capitalize %>
     </div>
 
-    <div class='row'>
-      <div class='col-md-6'>
-        <%= panel(:info,title:'Study state') do %>
-          <%= form_group do %>
-            <%= form.label :state, "State", class: 'col-md-4' %>
-            <div class='col-md-8'>
-              <%= form.select :state, Study.aasm.states_for_select, {}, {class: 'custom-select'} %>
-            </div>
-          <% end %>
+    <div class='columnize'>
+      <%= panel(:info,title:'Study state') do %>
+        <%= form_group do %>
+          <%= form.label :state, "State", class: 'col-md-4' %>
+          <div class='col-md-8'>
+            <%= form.select :state, Study.aasm.states_for_select, {}, {class: 'custom-select'} %>
+          </div>
         <% end %>
-      </div>
+      <% end %>
 
-      <div class='col-md-6'>
-        <%= panel(:info,title:'Contacts') do %>
-            <%= link_to "View Study Contacts", collaborators_study_path(study) %>
-        <% end %>
-      </div>
+      <%= panel(:info,title:'Contacts') do %>
+          <%= link_to "View Study Contacts", collaborators_study_path(study) %>
+      <% end %>
     </div>
-
-    <%= panel(:info,title:'Study information') do %>
-        <%= fields_for(study) do |form| %>
-          <%= form.fields_for(:study_metadata, builder: Metadata::FormBuilder) do |metadata_fields| %>
-            <%= metadata_fields.select_by_association(:reference_genome, {}, { class: 'select2' }) %>
-          <% end %>
-        <% end %>
-    <% end %>
 
     <%= render partial: "studies/managed_study", locals: {read_only: false, form: form, study: study} %>
 

--- a/app/views/admin/studies/_filtered_studies.html.erb
+++ b/app/views/admin/studies/_filtered_studies.html.erb
@@ -3,7 +3,7 @@
   <div id='study_list'>
     <%= form_tag(edit_admin_studies_path, remote: true, id: "study_form", class: 'remote-form observed', data: {update: "#study_editor", throbber: '#update_loader' }) do %>
       <p>Found <%= pluralize @studies.size, "study" %></p>
-      <%= select_tag :id, options_from_collection_for_select(@studies, :id, :name), prompt: 'Select a study...'  %>
+      <%= select_tag :id, options_from_collection_for_select(@studies, :id, :name), prompt: 'Select a study...', class: 'select2' %>
     <% end %>
 
     <div id='study_editor'>

--- a/app/views/shared/metadata/edit/_study.html.erb
+++ b/app/views/shared/metadata/edit/_study.html.erb
@@ -8,6 +8,8 @@
     <%= metadata_fields.text_field(:number_of_gigabases_per_sample) %>
     <%= metadata_fields.text_field(:prelim_id) %>
 
+    <%= metadata_fields.select_by_association(:reference_genome, {}, { class: 'select2' }) %>
+
     <% metadata_fields.with_options(grouping: 'ENA requirement') do |group| %>
       <%= group.text_field(:study_study_title) %>
       <%= group.select_by_association(:study_type)%>

--- a/app/views/studies/_managed_study.html.erb
+++ b/app/views/studies/_managed_study.html.erb
@@ -1,23 +1,29 @@
 
 <%= panel(:info,title:'Properties') do %>
-<%= render(partial: 'shared/metadata/edit/study', locals: { study: study, form: form }) %>
 
-<% if logged_in? && current_user.privileged? %>
-   <%= render partial: "shared/ethical_approval_upload", locals: { study: study, form: form } -%>
-   <%= render partial: "shared/data_release_enforce",     locals: { study: study, form: form } -%>
-<% end %>
+  <%= form_collection(
+    form.label(:name, 'Study name', class: 'required'),
+    form.text_field(:name, class: 'form-control', required: true),
+    'Rename the study'
+  ) %>
+  <%= render(partial: 'shared/metadata/edit/study', locals: { study: study, form: form }) %>
 
-<table width="100%" cellspacing="0" cellpadding="0">
-  <tr>
-    <td width="40%" >&nbsp;</td>
-    <td width="60%">
-      <br />
-      <% unless study.id.nil? %>
-        <%= submit_tag :study, value: "Update" %> or <%= link_to "cancel", study_path(study) %>
-      <% else %>
-        <%= submit_tag :study, value: "Create" %> or <%= link_to "cancel", studies_path %>
-      <% end %>
-    </td>
-  </tr>
-</table>
+  <% if logged_in? && current_user.privileged? %>
+     <%= render partial: "shared/ethical_approval_upload", locals: { study: study, form: form } -%>
+     <%= render partial: "shared/data_release_enforce",     locals: { study: study, form: form } -%>
+  <% end %>
+
+  <table width="100%" cellspacing="0" cellpadding="0">
+    <tr>
+      <td width="40%" >&nbsp;</td>
+      <td width="60%">
+        <br />
+        <% unless study.id.nil? %>
+          <%= submit_tag :study, value: "Update" %> or <%= link_to "cancel", study_path(study) %>
+        <% else %>
+          <%= submit_tag :study, value: "Create" %> or <%= link_to "cancel", studies_path %>
+        <% end %>
+      </td>
+    </tr>
+  </table>
 <% end %>

--- a/app/views/studies/_study.html.erb
+++ b/app/views/studies/_study.html.erb
@@ -27,12 +27,6 @@
   </div>
 <% end %>
 
-<%= fields_for(study) do |form| %>
-  <%= form.fields_for(:study_metadata, builder: Metadata::FormBuilder) do |metadata_fields| %>
-    <%= metadata_fields.select_by_association(:reference_genome, {}, {class: 'custom-select select2'}) %>
-  <% end %>
-<% end %>
-
 <h3>Properties</h3>
 <%= render partial: 'shared/metadata/edit/study', locals: { study: study } %>
 

--- a/spec/features/studies/manage_study_spec.rb
+++ b/spec/features/studies/manage_study_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Manage a study' do
+  let(:user) { create :admin }
+  let!(:study) { create :study, name: 'Original name' }
+
+  scenario 'Rename a study', js: true do
+    login_user(user)
+    visit study_path(study)
+    click_link 'Manage'
+    expect(page).to have_content('Original name')
+    fill_in 'Study name', with: 'Updated name'
+    click_on 'Update'
+    expect(page).to have_content('Updated name')
+    expect(page).not_to have_content('Original name')
+  end
+end


### PR DESCRIPTION
- Add a study name field to the manage study page
- Validate uniqueness of study name on update and create

Note: This renders 22 Studies in the Sequencescape database invalid
as the have non-unique names. THis will need to be addressed
before this story can go live. SSRs have been emailed the following
(Study names and ids removed)

Hello all,

I’m currently adding the ability to rename studies via the ‘manage’ page in Sequencescape. As part of this I have discovered a number of studies which share identical names:

<snipped>List of ids and names of duplicate studies

I suspect many of these have been created in error, and will definitely be very difficult to work with in Sequencescape. Once we’ve added the ability to rename studies, you will also observe further issues, as Sequencescape will see the studies as invalid.

For each set of studies we have the following options:

1) Attempt to merge them together. In this case, please let us know which study we should merge things into.
	- We’ll keep the old study around, but add ‘(Legacy)’ to the end, a comment on the study will record what happened.
2) Differentiate them by renaming one or both studies. (Eg. Adding a year)
3) Abandon the plans to let you rename studies.

Leaving them unchanged , without taking option 3, is unfortunately not an option. If the studies are invalid it will end up having an impact on everything associated with them, as validation issues tend to cascade and affect anything associated with them, even sometimes indirectly. (eg. Submissions, samples, requests, plates, study reports, possibly even lanes associated with the study)