### PR TITLE
Hotfix -Set empty supplier sample name flag

### DIFF
--- a/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/row.rb
@@ -83,6 +83,7 @@ module SampleManifestExcel
           aliquot.save!
           metadata.save!
           sample.updated_by_manifest = true
+          sample.empty_supplier_sample_name = false
           @sample_updated = sample.save
         end
       end


### PR DESCRIPTION
While we hope to be rid of this shortly, and it doesn't affect newly
generated manifests, older manifests still have the flag set
incorrectly on upload. This prevents samples from appearing
in reports, and some lab processes.