### PR TITLE
Seq 937 allow n tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,9 +44,6 @@ group :default do
   # Locked for ruby version
   gem 'delayed_job_active_record'
 
-  gem 'ruby_walk', '>= 0.0.3',
-      github: 'sanger/ruby_walk'
-
   gem 'irods_reader', '>=0.0.2',
       github: 'sanger/irods_reader'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,12 +34,6 @@ GIT
     irods_reader (0.0.2)
 
 GIT
-  remote: git://github.com/sanger/ruby_walk.git
-  revision: 6e86c0413ab508933de899d7a3c6bc3b415e2acb
-  specs:
-    ruby_walk (0.0.3)
-
-GIT
   remote: git://github.com/sanger/sanger_barcode_format.git
   revision: 35846331c2b88d049a14b7cace08e18664494de1
   branch: development
@@ -557,7 +551,6 @@ DEPENDENCIES
   ruby-oci8
   ruby-prof
   ruby-units
-  ruby_walk (>= 0.0.3)!
   rubyzip
   sanger_barcode_format!
   sass-rails

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -164,22 +164,6 @@ class Aliquot < ApplicationRecord
     raise StandardError, 'The Behaviour of clone has changed in Rails 3. Please use dup instead!'
   end
 
-  # return all aliquots originated from the current one
-  # ie aliquots sharing the sample, tag information, descending the requess graph
-  def descendants(include_self = false)
-    (include_self ? self : requests).walk_objects(Aliquot => :receptacle,
-                                                  Receptacle => [:aliquots, :requests_as_source],
-                                                  Request => :target_asset) do |object|
-      case object
-      when Aliquot
-        # we cut the walk if the new aliquot doesn't "match" the current one
-        object if object.match?(self)
-      else # other objects
-        [] # are walked but not returned
-      end
-    end
-  end
-
   def matches?(object)
     # Note: This function is directional, and assumes that the downstream aliquot
     # is checking the upstream aliquot (or the AliquotRecord)

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -105,28 +105,30 @@ class Aliquot < ApplicationRecord
   # Validating the uniqueness of tags in rails was causing issues, as it was resulting the in the preform_transfer_of_contents
   # in transfer request to fail, without any visible sign that something had gone wrong. This essentially meant that tag clashes
   # would result in sample dropouts. (presumably because << triggers save not save!)
-  def untagged?
+  def no_tag1?
     tag_id == UNASSIGNED_TAG || tag.nil?
   end
+  alias untagged? no_tag1?
+
+  def tag1?
+    !no_tag1?
+  end
+  alias tagged? tag1?
 
   def no_tag2?
     tag2_id == UNASSIGNED_TAG || tag2.nil?
   end
 
-  def tagged?
-    !untagged?
-  end
-
-  def dual_tagged?
+  def tag2?
     !no_tag2?
   end
 
-  def tag_count
-    # Find the most highly tagged aliquot
-    return 2 if dual_tagged?
-    return 1 if tagged?
+  def tags?
+    !no_tags?
+  end
 
-    0
+  def no_tags?
+    no_tag1? && no_tag2?
   end
 
   def tags_combination
@@ -212,5 +214,15 @@ class Aliquot < ApplicationRecord
     [:sample_id, :tag_id, :tag2_id, :library_id, :bait_library_id, :insert_size_from, :insert_size_to, :library_type, :project_id, :study_id].all? do |attrib|
       send(attrib) == other.send(attrib)
     end
+  end
+
+  private
+
+  def tag_count
+    # Find the most highly tagged aliquot
+    return 2 if tag2?
+    return 1 if tag1?
+
+    0
   end
 end

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -166,7 +166,7 @@ class Aliquot < ApplicationRecord
 
   def matches?(object)
     # Note: This function is directional, and assumes that the downstream aliquot
-    # is checking the upstream aliquot (or the AliquotRecord)
+    # is checking the upstream aliquot
     case
     when sample_id != object.sample_id                                                   then false # The samples don't match
     when object.library_id.present?      && (library_id      != object.library_id)       then false # Our librarys don't match.

--- a/app/models/aliquot/remover.rb
+++ b/app/models/aliquot/remover.rb
@@ -3,38 +3,10 @@
 # Provides behaviour to walk downstream and remove aliquots from
 # any downstream assets in the event of a retrospective fail.
 module Aliquot::Remover
-  # We can't use the aliquot itself, as it will have been destroyed by
-  # the time we want to look at it. The aliquot record mimics
-  # an aliquot in the comparison functions
-  class AliquotRecord
-    attr_reader :tag_id, :sample_id, :library_id, :bait_library_id, :tag2_id
-
-    def initialize(aliquot)
-      @tag_id = aliquot.tag_id
-      @sample_id = aliquot.sample_id
-      @library_id = aliquot.library_id
-      @bait_library_id = aliquot.bait_library_id
-      @tag2_id = aliquot.tag2_id
-    end
-
-    def tag1?
-      !no_tag1?
-    end
-
-    def no_tag1?
-      tag_id.nil? || (tag_id == Aliquot::UNASSIGNED_TAG)
-    end
-
-    def no_tag2?
-      tag2_id.nil? || (tag2_id == Aliquot::UNASSIGNED_TAG)
-    end
-  end
-
   def remove_downstream_aliquots
     # On the target asset of the failed request.
     ActiveRecord::Base.transaction do
-      target_aliquots = aliquots.map { |aliquot| AliquotRecord.new(aliquot) }
-      on_downstream_aliquots(target_aliquots)
+      on_downstream_aliquots(aliquots)
     end
   end
 
@@ -58,9 +30,7 @@ module Aliquot::Remover
       raise "Duplicate aliquots detected in asset #{display_name}." if to_remove.count > 1
       next unless to_remove.count == 1
 
-      removed_aliquot = AliquotRecord.new(to_remove.first)
-      to_remove.first.destroy
-      removed_aliquot
+      to_remove.first.tap(&:destroy)
     end.compact
   end
 end

--- a/app/models/aliquot/remover.rb
+++ b/app/models/aliquot/remover.rb
@@ -17,11 +17,11 @@ module Aliquot::Remover
       @tag2_id = aliquot.tag2_id
     end
 
-    def tagged?
-      !untagged?
+    def tag1?
+      !no_tag1?
     end
 
-    def untagged?
+    def no_tag1?
       tag_id.nil? || (tag_id == Aliquot::UNASSIGNED_TAG)
     end
 

--- a/app/models/aliquot_indexer.rb
+++ b/app/models/aliquot_indexer.rb
@@ -1,3 +1,15 @@
+# frozen_string_literal: true
+
+#
+# The aliquot indexer is passed a Receptacle (usually a Lane) and
+# generates an index for all aliquots. This is a unique index that NPG
+# use to identify dplexed sequencing data. It replaces the previous role of
+# the map id of tag 1 (the i7) and allows a single identifier to be used to
+# represent both indices.
+# - Aliquots are sorted by the tag_2 map id, then the tag_1 map id.
+# - Tags associated with the PhiX tube are excluded. This includes the default
+#   phix tag index (configatron.phix_tag.tag_map_id) [888 at time of writing]
+#   as well as the actual index if they happen to differ.
 class AliquotIndexer
   attr_reader :lane, :aliquots
 
@@ -9,6 +21,7 @@ class AliquotIndexer
     end
   end
 
+  # Include in Receptacles to allow idempotent indexing by calling index_aliquots
   module Indexable
     def index_aliquots
       # Skip indexing if already present. Makes the call idempotent and also
@@ -18,6 +31,11 @@ class AliquotIndexer
     end
   end
 
+  #
+  # Generate an aliquot index for lane
+  # @param lane [Receptacle] The receptacle to index. Probably a lane.
+  #
+  # @return [Bool] Returns true if the index was successful
   def self.index(lane)
     new(lane).index
   end
@@ -27,24 +45,33 @@ class AliquotIndexer
     @index = 0
   end
 
+  # The actual index of the PhiX used in the lane.
+  # Note: PhiX isn't actually present as an aliquot within the lane, instead the PhiX
+  # tube is associated with the Lane as a parent asset.
+  # @return [Integer] map_id of the PhiX in the lane.
   def phix_map_id
     return nil unless lane.spiked_in_buffer.present?
 
     @phix_map_id ||= lane.spiked_in_buffer.primary_aliquot.tag.try(:map_id)
   end
 
+  # Returns all aliquots due to be indexed.
+  # @return [Array<Aliquot>] An sorted array of aliquots to index
   def aliquots
-    @aliquots ||= lane.aliquots.sorted_for_indexing.reject { |a| a.untagged? }
+    @aliquots ||= lane.aliquots.sorted_for_indexing
   end
 
+  def index
+    @lane.aliquot_indicies.build(aliquots.map { |a| { aliquot: a, aliquot_index: next_index } })
+    @lane.save
+  end
+
+  private
+
+  # The next index suitable for the aliquot (skips those associated with PhiX)
   def next_index
     @index += 1
     next_index if [phix_map_id, configatron.phix_tag.tag_map_id].include?(@index)
     @index
-  end
-
-  def index
-    @lane.aliquot_indicies.build(aliquots.each_with_index.map { |a, _i| { aliquot: a, aliquot_index: next_index } })
-    @lane.save
   end
 end

--- a/app/models/aliquot_indexer.rb
+++ b/app/models/aliquot_indexer.rb
@@ -3,7 +3,7 @@
 #
 # The aliquot indexer is passed a Receptacle (usually a Lane) and
 # generates an index for all aliquots. This is a unique index that NPG
-# use to identify dplexed sequencing data. It replaces the previous role of
+# use to identify deplexed sequencing data. It replaces the previous role of
 # the map id of tag 1 (the i7) and allows a single identifier to be used to
 # represent both indices.
 # - Aliquots are sorted by the tag_2 map id, then the tag_1 map id.

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -127,11 +127,11 @@ class Api::Messages::FlowcellIO < Api::Base
 
   module AliquotExtensions
     def aliquot_type
-      tag.present? ? 'library_indexed' : 'library'
+      tags? ? 'library_indexed' : 'library'
     end
 
     def control_aliquot_type
-      tag.present? ? 'library_indexed_spike' : 'library_control'
+      tags? ? 'library_indexed_spike' : 'library_control'
     end
   end
 

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -19,11 +19,7 @@ class Api::Messages::FlowcellIO < Api::Base
         end
 
         def lane_samples
-          some_untagged = target_asset.aliquots.any?(&:untagged?)
-          target_asset.aliquots.reject do |a|
-            (spiked_in_buffer.present? && spiked_in_buffer.primary_aliquot =~ a) or
-              some_untagged && a.tagged? # Reproduces behaviour of batch.xml. Needed due to odd legacy data
-          end
+          target_asset.aliquots
         end
 
         delegate :spiked_in_buffer, :external_release, to: :target_asset, allow_nil: true

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -451,11 +451,6 @@ class Asset < ApplicationRecord
     false
   end
 
-  # See Receptacle for handling of assets with contents
-  def tag_count
-    nil
-  end
-
   # We only support wells for the time being
   def latest_stock_metrics(_product, *_args)
     []

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -40,7 +40,7 @@ class Tag < ApplicationRecord
     raise StandardError, 'Cannot tag an empty asset'   if asset.aliquots.empty?
 
     asset.aliquots.group_by { |aliquot| aliquot.sample_id }.each do |_sample_id, aliquots|
-      new_aliquot = aliquots.first.untagged? ? aliquots.first : aliquots.first.dup
+      new_aliquot = aliquots.first.no_tag1? ? aliquots.first : aliquots.first.dup
       # dup automatically unsets receptacle, so we reallocate it here.
       new_aliquot.receptacle = asset
       new_aliquot.tag = self

--- a/app/sample_manifest_excel/sample_manifest_excel/tags/validator/formatting.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/tags/validator/formatting.rb
@@ -15,7 +15,7 @@ module SampleManifestExcel
         def check_formatting
           return if value.blank?
 
-          errors.add(:tag, 'must be a combination of A,C,G and T') unless value.match?(/\A[acgtACGT]+\z/)
+          errors.add(:tag, 'must be a combination of A,C,G,T or N') unless value.match?(/\A[acgtnACGTN]+\z/)
         end
       end
     end

--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -56,17 +56,12 @@ xml.batch do
               "request_id" => request.id,
               "qc_state" => request.target_asset.compatible_qc_state
             ) {
-              spiked_in_phiX = request.target_asset.spiked_in_buffer
-
               target_asset_aliquots.each do |aliquot|
-                next if spiked_in_phiX && spiked_in_phiX.primary_aliquot =~ aliquot
-
                 output_aliquot(xml, aliquot)
               end
             }
           else
-            # This is a lane that is not multiplexed.  It may have spiked in phiX in it, which is tagged, so we'll remove
-            # any aliquots that are tagged from the view.
+            # This is a lane that is not multiplexed.
             xml.library(
               "id" => request.target_asset.primary_aliquot.library_id, # TODO: remove
               "name" => request.asset.name, # TODO: remove
@@ -74,7 +69,7 @@ xml.batch do
               "qc_state" => request.target_asset.compatible_qc_state
             ) {
               target_asset_aliquots.each do |aliquot|
-                output_aliquot(xml, aliquot) unless aliquot.tag.present?
+                output_aliquot(xml, aliquot)
               end
             }
           end

--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -48,7 +48,7 @@ xml.batch do
           if target_asset_aliquots.empty?
             # This is a batch that has yet to be started
             xml.comment!("This batch has yet to be started so no information about what's on this lane is available yet")
-          elsif target_asset_aliquots.all?(&:tagged?)
+          elsif target_asset_aliquots.any?(&:tags?)
             # Any lane where every aliquot is tagged is considered to be a pool
             xml.pool(
               "id" => request.asset.id, # TODO: remove

--- a/spec/models/aliquot_spec.rb
+++ b/spec/models/aliquot_spec.rb
@@ -62,11 +62,6 @@ RSpec.describe Aliquot, type: :model do
     it_behaves_like 'a tag matcher'
   end
 
-  describe '#=~' do
-    subject { aliquot1 =~ aliquot2 }
-    it_behaves_like 'a tag matcher'
-  end
-
   context 'mixing tests' do
     let(:asset) { create :empty_well }
 

--- a/test/unit/aliquot_indexer_test.rb
+++ b/test/unit/aliquot_indexer_test.rb
@@ -112,5 +112,60 @@ class AliquotIndexerTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context 'which are single indexed with i5 (tag2) tags' do
+      setup do
+        @pre_count = AliquotIndex.count
+        @lane = create :lane
+        @tags = [1, 8, 2, 4].map { |map_id| create :tag, map_id: map_id }
+        @aliquots = Array.new(4) { |i| create :aliquot, receptacle: @lane, tag_id: -1, tag2: @tags[i] }
+
+        @aliquot_index = [1, 4, 2, 3]
+      end
+
+      should 'Apply consecutive tags from 1' do
+        AliquotIndexer.index(@lane)
+
+        assert_equal 4, AliquotIndex.count - @pre_count, "#{AliquotIndex.count} indexes were created, 4 expected"
+
+        new_indexes = AliquotIndex.where(lane_id: @lane.id)
+        assert_equal 4, new_indexes.count, "#{new_indexes.count} indexes belonged to the lane, 4 expected"
+
+        new_indexes.each do |ai|
+          aliquot_number = @aliquots.index(ai.aliquot)
+          expected_index = @aliquot_index[aliquot_number]
+          actual_index   = ai.aliquot_index
+          assert_equal expected_index, ai.aliquot_index, "Aliquot #{aliquot_number} given index #{actual_index}, expected #{expected_index}"
+        end
+      end
+
+      context 'when phix is added' do
+        setup do
+          @phix = create :spiked_buffer do |sb|
+            sb.aliquots { |a| a.association(:aliquot, receptacle: sb, tag: @tags[2]) }
+          end
+          a = create :aliquot, receptacle: @phix, tag: @tags[2]
+          @phix.aliquots = [a]
+          @lane.parents << @phix
+          @aliquot_index = [1, 5, 3, 4]
+        end
+
+        should 'skip the phix map_id' do
+          AliquotIndexer.index(@lane)
+
+          assert_equal 4, AliquotIndex.count - @pre_count, "#{AliquotIndex.count} indexes were created, 4 expected"
+
+          new_indexes = AliquotIndex.where(lane_id: @lane.id)
+          assert_equal 4, new_indexes.count, "#{new_indexes.count} indexes belonged to the lane, 4 expected"
+
+          new_indexes.each do |ai|
+            aliquot_number = @aliquots.index(ai.aliquot)
+            expected_index = @aliquot_index[aliquot_number]
+            actual_index   = ai.aliquot_index
+            assert_equal expected_index, ai.aliquot_index, "Aliquot #{aliquot_number} given index #{actual_index}, expected #{expected_index}"
+          end
+        end
+      end
+    end
   end
 end

--- a/test/unit/plate_creator_test.rb
+++ b/test/unit/plate_creator_test.rb
@@ -40,7 +40,7 @@ class CreatorTest < ActiveSupport::TestCase
     assert_equal @creator_purpose, child.purpose
 
     parent.wells.each_with_index do |well, i|
-      matching_aliquots = (well.aliquots.first =~ child.wells[i].aliquots.first)
+      matching_aliquots = well.aliquots.first.matches?(child.wells[i].aliquots.first)
       assert matching_aliquots, "Aliquots do not match in #{well.map_description}: #{well.aliquots.first} !~= #{child.wells[i].aliquots.first}"
     end
   end


### PR DESCRIPTION
Draft pull request as am fixing further bugs:
- i5 only aliquots not flagged as 'library_index'

Also discovered a few other issues based on the use of the tagged? and untagged? methods. 