### PR TITLE
Fix for case sensitive library type issue RT ticket 655435

### DIFF
--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -275,13 +275,23 @@ class BulkSubmission
     project = Project.find_by_id_or_name!(details['project id'], details['project name'])
     user    = User.find_by(login: details['user login']) or raise StandardError, "Cannot find user #{details['user login'].inspect}"
 
-    # The order attributes are initially
+    # Extract the request options from the row details
+    request_options = extract_request_options(details)
+
+    # Check the library type matches a value from the table
+    if request_options['library_type'].present?
+      lt = LibraryType.find_by(name: request_options['library_type']) or raise StandardError, "Cannot find library type #{request_options['library_type'].inspect}"
+      # find is case insensitive but we want the correct case sensitive name for requests or we get issues downstream in NPG
+      request_options['library_type'] = lt.name
+    end
+
+    # Set up the order attributes
     attributes = {
       study: study,
       project: project,
       user: user,
       comments: details['comments'],
-      request_options: extract_request_options(details),
+      request_options: request_options,
       pre_cap_group: details['pre-capture group']
     }
 

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -280,9 +280,10 @@ class BulkSubmission
 
     # Check the library type matches a value from the table
     if request_options['library_type'].present?
-      lt = LibraryType.find_by(name: request_options['library_type']) or raise StandardError, "Cannot find library type #{request_options['library_type'].inspect}"
       # find is case insensitive but we want the correct case sensitive name for requests or we get issues downstream in NPG
-      request_options['library_type'] = lt.name
+      lt = LibraryType.find_by(name: request_options['library_type'])&.name or
+        raise StandardError, "Cannot find library type #{request_options['library_type'].inspect}"
+      request_options['library_type'] = lt
     end
 
     # Set up the order attributes

--- a/app/models/request_type/validator.rb
+++ b/app/models/request_type/validator.rb
@@ -16,7 +16,7 @@ class RequestType::Validator < ApplicationRecord
     end
 
     def include?(option)
-      request_type.library_types.where(name: option).exists?
+      request_type.library_types.where(name: option).pluck(:name).include?(option)
     end
 
     def default

--- a/features/submission/csv/with_lowercase_library_type.csv
+++ b/features/submission/csv/with_lowercase_library_type.csv
@@ -1,0 +1,1 @@
+User Login,template name,study name,project name,submission name,asset names,asset group name,read length,fragment size from,fragment size to,pcr cycles,library type,commentsuser,library_type_test,abc123_study,Test project,sub,,assetgroup123,100,100,400,5,standard,hello there

--- a/features/submission/csv/with_unknown_library_type.csv
+++ b/features/submission/csv/with_unknown_library_type.csv
@@ -1,0 +1,1 @@
+User Login,template name,study name,project name,submission name,asset names,asset group name,read length,fragment size from,fragment size to,pcr cycles,library type,commentsuser,library_type_test,abc123_study,Test project,sub,,assetgroup123,100,100,400,5,unrecognised,hello there

--- a/spec/factories/request_type_factories.rb
+++ b/spec/factories/request_type_factories.rb
@@ -50,11 +50,15 @@ FactoryBot.define do
     end
 
     factory :library_creation_request_type do
+      transient do
+        library_type { build :library_type }
+      end
+
       target_asset_type { 'LibraryTube' }
       request_class { LibraryCreationRequest }
 
-      after(:build) do |request_type|
-        request_type.library_types_request_types << create(:library_types_request_type, request_type: request_type)
+      after(:build) do |request_type, evaluator|
+        request_type.library_types_request_types << create(:library_types_request_type, library_type: evaluator.library_type, request_type: request_type)
         request_type.request_type_validators << create(:library_request_type_validator, request_type: request_type)
       end
 

--- a/spec/models/request_type/validator/library_type_validator_spec.rb
+++ b/spec/models/request_type/validator/library_type_validator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RequestType::Validator::LibraryTypeValidator, type: :model do
+  let(:library_type) { create :library_type, name: 'MyLibraryType' }
+  let(:request_type) { create :library_creation_request_type, library_type: library_type }
+  let(:validator) { RequestType::Validator::LibraryTypeValidator.new(request_type.id) }
+
+  context 'when initialising' do
+    it 'keeps an association with the request type' do
+      expect(validator.request_type_id).to eq(request_type.id)
+    end
+  end
+
+  context 'when validating library type' do
+    context 'when exists and case matches' do
+      it 'returns true' do
+        expect(validator.include?('MyLibraryType')).to eq(true)
+      end
+    end
+
+    context 'when exists and case does not match' do
+      it 'returns false' do
+        expect(validator.include?('mylibrarytype')).to eq(false)
+      end
+    end
+
+    context 'when is not recognised' do
+      it 'returns false' do
+        expect(validator.include?('unknown')).to eq(false)
+      end
+    end
+  end
+
+  context 'when using default' do
+    let(:request_type) { create :request_type }
+    let(:library_type2) { create :library_type, name: 'MyDefaultLibraryType' }
+
+    context 'when a default library type is set' do
+      before do
+        request_type.library_types_request_types << create(:library_types_request_type, library_type: library_type, request_type: request_type, is_default: false)
+        request_type.library_types_request_types << create(:library_types_request_type, library_type: library_type2, request_type: request_type, is_default: true)
+      end
+
+      it 'returns the name' do
+        expect(validator.default).to eq('MyDefaultLibraryType')
+      end
+    end
+
+    context 'when a default library type is not set' do
+      before do
+        request_type.library_types_request_types << create(:library_types_request_type, library_type: library_type, request_type: request_type, is_default: false)
+        request_type.library_types_request_types << create(:library_types_request_type, library_type: library_type2, request_type: request_type, is_default: false)
+      end
+
+      it 'returns nil' do
+        expect(validator.default).to be_nil
+      end
+    end
+  end
+
+  context 'when using to_a' do
+    it 'returns expected array' do
+      expected_array = ['MyLibraryType']
+      expect(validator.to_a).to eq(expected_array)
+    end
+  end
+end


### PR DESCRIPTION
NPG reported library types being passed through with incorrect case e.g. chromium rather than Chromium.
Code to upload bulk submissions was not validating library type and was passing through whatever the spreadsheet column contained. Column in excel sheet has a dropdown so in most cases this is Ok, but in this case SSR had edited a saved csv and changed case on some rows.
This fix adds a check that library type matches to the name on the library types table (this is case insensitive) and if it does match uses the name from the table instead of what they've entered which might have incorrect case.