### PR TITLE
Add circle ci support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,212 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+defaults: &defaults
+  docker:
+    # specify the version you desire here
+    - image: circleci/ruby:2.4.6-node-browsers
+      environment:
+          BUNDLE_JOBS: 4
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+          BUNDLE_WITHOUT: 'warehouse deployment'
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_ROOT_PASSWORD: ''
+          MYSQL_DATABASE: circleci
+          DATABASE_URL: 'mysql2://root@127.0.0.1:3306/'
+          TZ: Europe/London
+    - image: circleci/mysql:5.7.24
+      environment:
+        BUNDLE_JOBS: 4
+        BUNDLE_RETRY: 3
+        BUNDLE_PATH: vendor/bundle
+        BUNDLE_WITHOUT: 'warehouse deployment'
+        MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        MYSQL_ROOT_PASSWORD: ''
+        MYSQL_DATABASE: circleci
+        DATABASE_URL: 'mysql2://root@127.0.0.1:3306/'
+
+    # Specify service dependencies here if necessary
+    # CircleCI maintains a library of pre-built images
+    # documented at https://circleci.com/docs/2.0/circleci-images/
+    # - image: circleci/postgres:9.4
+
+  working_directory: ~/repo
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle --without warehouse deployment
+      - run:
+          name: remove mysql2 temporary
+          command: |
+            bundle exec gem uninstall mysql2
+
+      - run:
+          name: reinstall mysql2 temporary
+          command: |
+            bundle install --jobs=3 --retry=3 --path vendor/bundle
+      - run:
+         name:  Download cc-test-reporter
+         command: |
+           mkdir -p tmp/
+           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
+           chmod +x ./tmp/cc-test-reporter
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - tmp/cc-test-reporter
+            - vendor/bundle
+
+  run-specs:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/repo
+      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle --without warehouse deployment
+      - run: cp ./.circleci/database.yml ./config/database.yml
+      - run:
+          name: Wait for DB
+          # preinstalled in circleci/* docker image
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+      - run: echo $DATABASE_URL
+      - run: RAILS_ENV=test bundle exec bin/setup
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rspec \
+              --format documentation \
+              --format RspecJunitFormatter \
+              --out /tmp/test-results/rspec.xml
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+  run-tests:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/repo
+      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle --without warehouse deployment
+      - run: cp ./.circleci/database.yml ./config/database.yml
+      - run:
+          name: Wait for DB
+          # preinstalled in circleci/* docker image
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+      - run: RAILS_ENV=test bundle exec bin/setup
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rake test
+      # collect reports
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+  run-cukes:
+    <<: *defaults
+    environment:
+      RAILS_ENV: cucumber
+      CUCUMBER_FORMAT: DebugFormatter
+    parallelism: 3
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/repo
+      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle --without warehouse deployment
+      - run: cp ./.circleci/database.yml ./config/database.yml
+      - run:
+          name: Wait for DB
+          # preinstalled in circleci/* docker image
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 120s
+      - run: RAILS_ENV=cucumber bundle exec bin/setup
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rake knapsack:cucumber
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+  run-rubocop:
+    <<: *defaults
+    environment:
+      RAILS_ENV: cucumber
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/repo
+      - run: bundle install --jobs=4 --retry=3 --path vendor/bundle --without warehouse deployment
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            bundle exec rubocop
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+
+workflows:
+  version: 2
+
+  commit:
+    jobs:
+      - build
+      - run-specs:
+          requires:
+            - build
+      - run-tests:
+          requires:
+            - build
+      - run-cukes:
+          requires:
+            - build
+      - run-rubocop:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,6 @@ defaults: &defaults
         MYSQL_ROOT_PASSWORD: ''
         MYSQL_DATABASE: circleci
         DATABASE_URL: 'mysql2://root@127.0.0.1:3306/'
-
-    # Specify service dependencies here if necessary
-    # CircleCI maintains a library of pre-built images
-    # documented at https://circleci.com/docs/2.0/circleci-images/
-    # - image: circleci/postgres:9.4
-
   working_directory: ~/repo
 jobs:
   build:
@@ -102,6 +96,9 @@ jobs:
               --format documentation \
               --format RspecJunitFormatter \
               --out /tmp/test-results/rspec.xml
+      - run:
+          name: Build coverage
+          command: ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.specs.json coverage/.resultset.json
 
       # collect reports
       - store_test_results:
@@ -109,6 +106,10 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - tmp/codeclimate.specs.json
   run-tests:
     <<: *defaults
     parallelism: 1
@@ -131,12 +132,19 @@ jobs:
             mkdir /tmp/test-results
             bundle exec rake test
       # collect reports
+      - run:
+          name: Build coverage
+          command: ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.tests.json coverage/.resultset.json
 
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - tmp/codeclimate.tests.json
   run-cukes:
     <<: *defaults
     environment:
@@ -161,13 +169,19 @@ jobs:
           command: |
             mkdir /tmp/test-results
             bundle exec rake knapsack:cucumber
-
+      - run:
+          name: Build coverage
+          command: ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/codeclimate.cukes.json coverage/.resultset.json
       # collect reports
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - tmp/codeclimate.cukes.json
   run-rubocop:
     <<: *defaults
     environment:
@@ -191,6 +205,17 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+  upload-coverage:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Upload coverage results to Code Climate
+          command: |
+            ls ./tmp
+            ./tmp/cc-test-reporter sum-coverage tmp/codeclimate.*.json -p 3 -o tmp/codeclimate.total.json
+            ./tmp/cc-test-reporter upload-coverage -i tmp/codeclimate.total.json
 
 workflows:
   version: 2
@@ -210,3 +235,8 @@ workflows:
       - run-rubocop:
           requires:
             - build
+      - upload-coverage:
+          requires:
+            - run-specs
+            - run-tests
+            - run-cukes

--- a/.circleci/database.yml
+++ b/.circleci/database.yml
@@ -1,0 +1,89 @@
+# SQLite version 3.x
+#   gem install sqlite3-ruby (not necessary on OS X Leopard)
+
+# To enable developers to have their own development setup per repository clone we allow them to stick
+# the suffix they want attached to any database names in the suffix file in the root of the project.
+<% suffix = "_#{File.read(File.join(Rails.root, 'database_suffix'))}".strip rescue nil %>
+
+mysql: &MYSQL
+  adapter: mysql2
+  host: 127.0.0.1
+  port: 3306
+  username: <%= ENV.fetch('DBUSERNAME','root') %>
+  password: <%= ENV['DBPASSWORD'] %>
+  encoding: utf8
+  properties:
+    characterSetResults: utf8
+  pool: 5
+  timeout: 5000
+  reaping_frequency: 600
+  variables:
+    sql_mode: TRADITIONAL
+    # This improbably large value mimics the global option for production
+    # Without this things fall back to 1024 (At least with my setup) which
+    # is too small for larger pools.
+    group_concat_max_len: 67108864
+
+development:
+  <<: *MYSQL
+  database: sequencescape_development<%= suffix %>
+
+  # indentation is deliberate!
+  development_warehouse: &warehouse
+    <<: *MYSQL
+    database: warehouse_development<%= suffix %>
+
+development_local:
+  adapter: sqlite3
+  database: db/development.sqlite3
+  pool: 5
+  timeout: 5000
+
+development_local_snp:
+  adapter: sqlite3
+  database: db/snp_development.sqlite3
+  pool: 5
+  timeout: 5000
+
+development_local_cas:
+  adapter: sqlite3
+  database: db/cas_development.sqlite3
+  pool: 5
+  timeout: 5000
+
+##  Oracle legacy
+development_snp:
+  adapter: nulldb
+  database: snp
+  username: username
+  password: password
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+
+test: &test
+  <<: *MYSQL
+  database: sequencescape_test<%= ENV['TEST_ENV_NUMBER'] %><%= suffix %>
+  pool: 10
+  timeout: 5000
+
+cucumber:
+  <<: *test
+  database: sequencescape_test<%= ENV['TEST_ENV_NUMBER'] %><%= suffix %>_cuke
+
+# In production environments adapter should be 'oracle_enhanced',
+# Username, password and database are values that go to sqlplus login <username>/<password>@<database>
+
+agresso_test_db:
+  adapter: nulldb
+  database: database
+  username: username
+  password: password
+
+# These other connections are exported during deploy, from:
+# ssh://git/repos/git/psd/config/private.git/
+### Staging
+### Next release
+### Training
+### Production

--- a/Gemfile
+++ b/Gemfile
@@ -160,6 +160,7 @@ group :test do
   # with rails versions.
   gem 'minitest', '5.10.3'
   gem 'minitest-profiler'
+  gem 'rspec_junit_formatter'
 end
 
 group :test, :cucumber do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     amq-protocol (2.3.0)
     arel (8.0.0)
@@ -134,8 +134,8 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chronic (0.10.2)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -198,7 +198,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.25)
+    ffi (1.10.0)
     flay (2.12.0)
       erubis (~> 2.7.0)
       path_expander (~> 1.0)
@@ -280,7 +280,7 @@ GEM
     net-ldap (0.16.1)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -298,7 +298,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-acceptable (0.1.0)
       rack (>= 1.1.0)
     rack-cors (1.0.3)
@@ -367,6 +367,14 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rspec_junit_formatter (0.4.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.6)
     rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -401,9 +409,9 @@ GEM
       tilt (>= 1.1, < 3)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    selenium-webdriver (3.12.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2)
+    selenium-webdriver (3.142.2)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.11.0)
     shoulda-context (1.2.2)
     shoulda-matchers (4.0.1)
@@ -473,7 +481,7 @@ GEM
     will_paginate (3.1.7)
     will_paginate-bootstrap (1.0.2)
       will_paginate (>= 3.0.3)
-    xpath (3.1.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.18)
 
@@ -544,6 +552,7 @@ DEPENDENCIES
   roo
   rspec-json_expectations
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-performance
   rubocop-rspec

--- a/app/models/broadcast_event.rb
+++ b/app/models/broadcast_event.rb
@@ -75,3 +75,5 @@ class BroadcastEvent < ApplicationRecord
     @event_type
   end
 end
+
+require_dependency 'broadcast_event/qc_assay'

--- a/app/models/broadcast_event/qc_assay.rb
+++ b/app/models/broadcast_event/qc_assay.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_dependency 'qc_assay'
+
 # Serializes lab events for the event warehouse
 class BroadcastEvent::QcAssay < BroadcastEvent
-  seed_class QcAssay
+  seed_class ::QcAssay
 
   def self.generate_events(qc_assay)
     # A qc_assay is made up of multiple qc_results, which usually have the same assay_type, don't HAVE to.

--- a/bin/setup
+++ b/bin/setup
@@ -19,12 +19,14 @@ chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system('bin/yarn')
 
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Copying example files =="
+  [
+    'config/aker.yml',
+  ].each do |base|
+    cp "#{base}.example", base unless File.exist?(base)
+  end
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'

--- a/lib/label_printer/label_printer/pmb_client.rb
+++ b/lib/label_printer/label_printer/pmb_client.rb
@@ -48,7 +48,7 @@ module LabelPrinter
       raise PmbException.new(e), 'something went wrong'
     rescue RestClient::ServiceUnavailable => e
       raise PmbException.new(e), 'is too busy. Please try again later'
-    rescue Errno::ECONNREFUSED => e
+    rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL => e
       raise PmbException.new(e), 'service is down'
     end
 

--- a/spec/features/batches/sort_requests_spec.rb
+++ b/spec/features/batches/sort_requests_spec.rb
@@ -15,15 +15,17 @@ describe 'Batches controller', js: true do
     click_link('Edit batch')
     request_list = find('#requests_list')
     expect(request_list).to have_css('tr', count: request_count)
-    first_request, second_request, third_request = *request_list.all('tr')
-    # drag_to seems to be dragging down but not up
-    # could not make "third_request.drag_to first_request" work
-    first_request.drag_to third_request
-    expect(request_list.all('tr').first).to eq(second_request)
+    first_request, _second_request, third_request = *request_list.all('tr')
+    # drag_to seems to be dragging up but not down
+    # JG: Oddly prior to the Rails 5.2 update this was the other way round.
+    # Suspect this is due to the quite specific locations at which the rows can be dropped.
+    third_request.drag_to first_request
+    expect(request_list.all('tr').first).to eq(third_request)
     wait_for_ajax
+    post_drag = [requests_ids[2], requests_ids[0], requests_ids[1]]
     click_link('Finish editing')
     request_list.all('tr').each_with_index do |request, index|
-      expect(request.text).to include((index + 1).to_s, (requests_ids.rotate(1)[index]).to_s)
+      expect(request.text).to include((index + 1).to_s, (post_drag[index]).to_s)
     end
   end
 end

--- a/spec/features/sample_manifests/uploader_for_manifests_with_tag_sequences_spec.rb
+++ b/spec/features/sample_manifests/uploader_for_manifests_with_tag_sequences_spec.rb
@@ -450,12 +450,4 @@ describe 'Sample manifest with tag sequences' do
       end
     end
   end
-
-  def login_user(user)
-    visit login_path
-    fill_in 'Username', with: user.login
-    fill_in 'Password', with: 'password'
-    click_button 'Login'
-    true
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,19 +31,11 @@ require './lib/plate_map_generation'
 
 require 'pry'
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
-
 Capybara.register_driver :headless_chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
-
-  options.add_argument('--headless')
-  options.add_argument('--disable_gpu')
-  # options.add_argument('--disable-popup-blocking')
-  options.add_argument('--window-size=1600,3200')
-  driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-  enable_chrome_headless_downloads(driver, DownloadHelpers::PATH.to_s)
+  enable_chrome_headless_downloads(
+    Capybara.drivers[:selenium_chrome_headless].call(app),
+    DownloadHelpers::PATH.to_s
+  )
 end
 
 def enable_chrome_headless_downloads(driver, directory)
@@ -149,6 +141,10 @@ RSpec.configure do |config|
     Warren.handler.enable!
     ex.run
     Warren.handler.disable!
+  end
+
+  config.before(:each, js: true) do
+    page.driver.browser.manage.window.resize_to(1024, 800)
   end
 
   # Seed global randomization in this process using the `--seed` CLI option.


### PR DESCRIPTION
Adds a circle CI configuration in case we need to migrate away from travis.
Also ensures we can get code coverage stats constantly, rather than every day.
This is useful as code-climate nukes the information if a branch gets updated.

Minor test changes to support code updates.