### PR TITLE
Allow submission from any plate purpose

### DIFF
--- a/app/views/submissions/_order.html.erb
+++ b/app/views/submissions/_order.html.erb
@@ -46,7 +46,7 @@
           <div class="col">
             <%= form.label :plate_purpose_id, 'Type of Plate' %>
             <%= form.collection_select :plate_purpose_id,
-              PlatePurpose.for_submissions.all, :id, :name,
+              PlatePurpose.all, :id, :name,
               { selected: PlatePurpose.stock_plate_purpose.id },
               class: 'submission_plate_purpose_id select-2'
             %>


### PR DESCRIPTION
Had a request to add an individual plate to the dropdown, which would either:
1) require flagging it as a stock plate, which has other side effects
2) Adding it to the hard-coded scope
3) Adding a new flag to control this list in future

However the only benefit of filtering the list is a UX advantage of navigating a short list, and after brief consultation with the SSRs they mentioned that they'd prefer the flexibility.