### PR TITLE
Use validation to generate better error

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -241,7 +241,7 @@ class AssetsController < ApplicationController
       return
     else
       @asset = Asset.find_from_barcode(barcode)
-      redirect_to action: 'find_by_barcode', error: "Unable to find anything with this barcode: #{barcode}" if @asset.nil?
+      redirect_to action: 'find_by_barcode', alert: "Unable to find anything with this barcode: #{barcode}" if @asset.nil?
     end
   end
 

--- a/app/uat_actions/uat_actions/generate_tag_plates.rb
+++ b/app/uat_actions/uat_actions/generate_tag_plates.rb
@@ -13,6 +13,9 @@ class UatActions::GenerateTagPlates < UatActions
   form_field :lot_type_name, :select, label: 'Lot Type', help: 'The lot type to use.', select_options: -> { LotType.where(template_class: 'TagLayoutTemplate').pluck(:name) }
   form_field :plate_count, :number_field, label: 'Plate Count', help: 'The number of plates to generate', options: { minimum: 1, maximum: 20 }
 
+  validates :tag_layout_template, presence: { message: 'could not be found' }
+  validates :lot_type, presence: { message: 'could not be found' }
+
   def self.default
     new(plate_count: 4)
   end
@@ -34,17 +37,17 @@ class UatActions::GenerateTagPlates < UatActions
   def lot
     @lot ||= lot_type.lots.create!(
       lot_number: "UAT#{Time.current.to_i}",
-      template: template,
+      template: tag_layout_template,
       user: user,
       received_at: Time.current
     )
   end
 
   def lot_type
-    LotType.find_by!(name: lot_type_name)
+    @lot_type ||= LotType.find_by(name: lot_type_name)
   end
 
-  def template
-    TagLayoutTemplate.find_by!(name: tag_layout_template_name)
+  def tag_layout_template
+    @tag_layout_template ||= TagLayoutTemplate.find_by(name: tag_layout_template_name)
   end
 end

--- a/app/uat_actions/uat_actions/test_submission.rb
+++ b/app/uat_actions/uat_actions/test_submission.rb
@@ -21,6 +21,8 @@ class UatActions::TestSubmission < UatActions
                    'Leave blank to automatically generate compatible labware. '\
                    'This page does not currently support cross-plate submissions.'
 
+  validates :submission_template, presence: { message: 'could not be found' }
+
   #
   # Returns a default copy of the UatAction which will be used to fill in the form
   #


### PR DESCRIPTION
If templates etc. are missing we either end up with a 500,
or a 404. Instead we use validation to make bugs easier
to diagnose.