### PR TITLE
Load SimpleCov before linting factories

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -11,7 +11,15 @@ task :test do
 end
 
 namespace :test do
-  # lib/tasks/factory_bot.rake
+  # Code coverage needs to be one of the very first things you do
+  # as coverage is only tracked on first run. As a result, if we don't
+  # initialize it before running our factory linters we MASSIVELY under-report
+  # coverage. Any code paths hit by the linters will have a coverage of zero,
+  # regardless of subsequent processing.
+  task :load_cov do
+    require 'simplecov'
+  end
+
   namespace :factory_bot do
     desc 'Verify that all FactoryBot factories are valid'
     task lint: :environment do
@@ -35,4 +43,4 @@ namespace :test do
   end
 end
 
-task test: 'test:factory_bot:lint'
+task test: ['test:load_cov', 'test:factory_bot:lint']


### PR DESCRIPTION
Code coverage only flags a line the first time it is run, so it
is important that SimpleCov is loaded very early on. If we lint
before loading, then we under-report coverage significantly as any
code hit by linting will have zero coverage, EVEN if it is subsequently
hit by our tests.