### PR TITLE
GPL060 - Add receptacles/:receptacle_id/parent

### DIFF
--- a/app/assets/stylesheets/all/sequencescape.scss
+++ b/app/assets/stylesheets/all/sequencescape.scss
@@ -193,6 +193,11 @@ div.quota {
 
 .field_with_errors { input { @extend .is-invalid; } }
 
+.receptacle-list {
+  @extend .list-group;
+  a { @extend .list-group-item; }
+}
+
 .barcode_list {
   @extend .list-group;
   li {

--- a/app/controllers/parents_controller.rb
+++ b/app/controllers/parents_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Nested under receptacles controller, redirects the user to the upstream asset, or
+# provides a disambiguation page if there are multiple.
+# Used by clients of the ML Warehouse to provide links to multiplexed library tubes
+# without us needing to expose the id of the library tube itself.
+# (Or for the user to track it)
+# Note: Parents go via requests here, not transfer requests or asset links.
+class ParentsController < ApplicationController
+  def show
+    @child = child
+    @parents = @child.source_receptacles
+
+    if @parents.empty?
+      render :show, status: :not_found
+    elsif @parents.one?
+      redirect_to receptacle_path(@parents.first)
+    else
+      render :show, status: :multiple_choices
+    end
+  end
+
+  private
+
+  def child
+    Receptacle.find(params[:receptacle_id])
+  end
+end

--- a/app/models/receptacle.rb
+++ b/app/models/receptacle.rb
@@ -47,6 +47,7 @@ class Receptacle
   has_many :requests_as_target, ->() { includes(:request_metadata) }, class_name: 'Request', foreign_key: :target_asset_id
   has_many :creation_batches, class_name: 'Batch', through: :requests_as_target, source: :batch
   has_many :source_batches, class_name: 'Batch', through: :requests_as_source, source: :batch
+  has_many :source_receptacles, through: :requests_as_target, source: :asset
 
   # A receptacle can hold many aliquots.  For example, a multiplexed library tube will contain more than
   # one aliquot.

--- a/app/views/parents/_parent.html.erb
+++ b/app/views/parents/_parent.html.erb
@@ -1,0 +1,1 @@
+<%= link_to parent.display_name, receptacle_path(parent) %>

--- a/app/views/parents/show.html.erb
+++ b/app/views/parents/show.html.erb
@@ -1,0 +1,11 @@
+<%= page_title 'Parents', @child.display_name %>
+
+<% if @parents.empty? %>
+  <p class='lead'>Could not find parents for <%= @child.display_name %>.</p>
+  <%= link_to "Back to #{@child.display_name}", receptacle_path(@child) %>
+<% else %>
+ <p class='lead'>Multiple parents for <%= @child.display_name %>.</p>
+  <div class="receptacle-list">
+    <%= render partial: 'parent', collection: @parents %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -495,6 +495,14 @@ Rails.application.routes.draw do
     resources :comments, controller: 'assets/comments'
   end
 
+  # Merge conflict tip: Specifying controller: :assets here is to
+  # handle the current lack of the receptacles controller. If you're seeing
+  # the more fully specced route alongside this, then it should be enough to
+  # add resource :parent, only: :show to the more fully specced route
+  resources :receptacles, only: [:show], controller: :assets do
+    resource :parent, only: :show
+  end
+
   resources :plates do
     collection do
       post :create

--- a/spec/controllers/parents_controller_spec.rb
+++ b/spec/controllers/parents_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ParentsController do
+  let(:current_user) { create :user }
+
+  it_behaves_like 'it requires login', 'show', parent: :receptacle
+
+  describe '#show' do
+    let(:child) { create :lane }
+    let(:parents) { create_list :library_tube, parent_number }
+
+    setup do
+      parents.each { |parent| create :sequencing_request, target_asset: child, asset: parent }
+      child.reload
+      get :show, params: { receptacle_id: child.id }, session: { user: current_user.id }
+    end
+
+    context 'with a parentless receptacle' do
+      let(:parent_number) { 0 }
+
+      it 'returns a 404' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'with a single parent receptacle' do
+      let(:parent_number) { 1 }
+
+      it 'redirects to the parent' do
+        expect(response).to redirect_to(receptacle_path(parents.first))
+      end
+    end
+
+    context 'with a multiple parent receptacle' do
+      let(:parent_number) { 2 }
+
+      it 'renders multiple options' do
+        expect(response).to have_http_status(:multiple_choices)
+      end
+
+      it 'renders a disambiguation page' do
+        expect(assigns(:parents)).to eq(parents)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The asset refactor will eventually impact the baehaviour of assets.xml,
with the long term goal being to remove this page entirely. Research
through Splunk revealed a single user, who was scraping the page to
retrieve the multiplexed library tube id for lanes. This was in order to
provide a deep-link for users of their own software.

When applied, this commit adds a new endpoint 'receptacles/:id/parent'
which will automatically direct users looking up a lane to the
corresponding multiplexed library tube. This removes the need to scrape
assets.xml, and drastically minimizes shanges both in our software, and
that of the user.

The endpoint also aliases the assets#show as receptacles#show to reduce
friction as future changes are made.

Given the endpoint may also recieve non lane receptacles we also handle
the following:

No parent: 404 page linking back to the receptacle
Multiple page: 300 page listing all parents

Parents are found via requests as:
1) Asset links tend to link labware, not receptacles
2) Transfer requests aren't actually present for lanes, just SequencingRequests
3) Requests are more customer focussesd