### PR TITLE
Use order insensitive comparison

### DIFF
--- a/spec/models/sample_manifest_spec.rb
+++ b/spec/models/sample_manifest_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SampleManifest, type: :model do
 
           it 'create sample manifest asset' do
             expect { manifest.generate }.to  change(SampleManifestAsset, :count).by(count)
-            expect(manifest.assets).to eq(LibraryTube.with_barcode(manifest.barcodes).sort_by(&:human_barcode).map(&:receptacle))
+            expect(manifest.assets).to contain_exactly(*LibraryTube.with_barcode(manifest.barcodes).map(&:receptacle))
           end
 
           context 'after generation' do


### PR DESCRIPTION
Tests were failing due to variation in sort order. We don't especially
care in this context, so use a matcher which doesn't care about order.t
push origin