### PR TITLE
Add webdrivers to manage chrome-driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
     - haveged
-    - chromium-chromedriver
 cache:
   bundler: true
 bundler_args: "--without warehouse deployment"
@@ -18,7 +17,6 @@ env:
   global:
   - TZ=Europe/London
   - CUCUMBER_FORMAT=DebugFormatter
-  - PATH=$PATH:/usr/lib/chromium-browser/
 before_install:
 - mv config/aker.yml.example config/aker.yml
 jobs:
@@ -26,8 +24,8 @@ jobs:
   - stage: test
     if: type = cron
     before_script:
-    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-      > ./cc-test-reporter
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update
+    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     - chmod +x ./cc-test-reporter
     - "./cc-test-reporter before-build"
     script: "xvfb-run -a ./run_coverage"
@@ -47,6 +45,7 @@ jobs:
   - if: type != cron
     env:
     before_script:
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rspec
@@ -57,6 +56,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=0
     before_script:
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 1
@@ -67,6 +67,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=1
     before_script:
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 2

--- a/Gemfile
+++ b/Gemfile
@@ -200,6 +200,8 @@ group :test, :cucumber do
   # - Patches rails to share a database connection between threads while Testing
   # - Pathes rspec to ensure capybara has done its stuff before killing the connection
   gem 'transactional_capybara'
+  # Keep webdriver in sync with chrome to prevent frustrating CI failures
+  gem 'webdrivers', require: false
 end
 
 group :cucumber do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,10 @@ GEM
     unicode-display_width (1.6.0)
     uniform_notifier (1.12.1)
     uuidtools (2.1.5)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.6.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -582,6 +586,7 @@ DEPENDENCIES
   travis
   uglifier (>= 1.0.3)
   uuidtools
+  webdrivers
   webmock
   whenever
   will_paginate

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'webdrivers/chromedriver'
 require 'selenium/webdriver'
 require 'capybara'
+
+Webdrivers::Chromedriver.update
 
 # Capybara.configure do |config|
 #   config.server = :puma

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@
 
 require 'simplecov'
 
+require 'webdrivers/chromedriver'
+Webdrivers::Chromedriver.update
+
 require 'factory_bot'
 require 'capybara/rspec'
 require 'selenium/webdriver'


### PR DESCRIPTION
Our travis ci builds are breaking due to a mismatch between the chrome
version and chromedriver. This is mainly are there doesn't seem to be a
single source which provides both, and is similar to an issue we had a
couple of months bak.

While chrome-driver does seem to install a compatible version of
chromium, our suite uses the installed chrome version that appears to be
par tof the base image. I briefly tried specifying this with
CHROME_BINARY but had no luck.

The weddrivers gem automatically matches the webdriver version to the
chrome version. If we don't hav emuch luck here we'll probably need to
be installing chromedriver manually.