### PR TITLE
 Add rake task for creating qc_results (RT-666755)

### DIFF
--- a/lib/tasks/create_qc_results.rake
+++ b/lib/tasks/create_qc_results.rake
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/SymbolArray
+
 namespace :qc_assay do
+  barcodes_values = [
+    ['DN581639U', 100], ['DN575795T', 50], ['DN575798W', 50], ['DN575799A', 50],
+    ['DN575800W', 50], ['DN575801A', 50], ['DN575802B', 50], ['DN575803C', 50]
+  ]
 
-barcodes_values = [
-  ['DN581639U', 100], ['DN575795T', 50], ['DN575798W', 50], ['DN575799A', 50],
-  ['DN575800W', 50], ['DN575801A', 50], ['DN575802B', 50], ['DN575803C', 50]
-]
-
-key = 'volume'
+  key = 'volume'
 
   desc 'Create forged QcResults'
   task create: [:environment] do
@@ -37,10 +40,12 @@ key = 'volume'
         plate.wells.each do |w|
           act_vol = w.get_current_volume
           check = volume == act_vol
-          puts "#{barcode}:#{w.map_description} : #{volume} = #{act_vol} #{check ? '✔' : '✗'*20}"
-          raise "Unexpected volume" unless check
+          puts "#{barcode}:#{w.map_description} : #{volume} = #{act_vol} #{check ? '✔' : '✗' * 20}"
+          raise 'Unexpected volume' unless check
         end
       end
     end
   end
 end
+
+# rubocop:enable Style/SymbolArray

--- a/lib/tasks/create_qc_results.rake
+++ b/lib/tasks/create_qc_results.rake
@@ -1,0 +1,46 @@
+namespace :qc_assay do
+
+barcodes_values = [
+  ['DN581639U', 100], ['DN575795T', 50], ['DN575798W', 50], ['DN575799A', 50],
+  ['DN575800W', 50], ['DN575801A', 50], ['DN575802B', 50], ['DN575803C', 50]
+]
+
+key = 'volume'
+
+  desc 'Create forged QcResults'
+  task create: [:environment] do
+    # Update
+    ActiveRecord::Base.transaction do
+      qc_assay = QcAssay.create!
+      barcodes_values.each do |barcode, value|
+        plate = Plate.includes(:wells).with_barcode(barcode).first
+        plate.wells.each do |w|
+          qc_assay.qc_results.create!(
+            asset: w,
+            key: key,
+            value: value.to_f,
+            assay_type: 'RT_666755_reset',
+            units: 'ul',
+            assay_version: 'v0.0'
+          )
+        end
+      end
+    end
+  end
+
+  desc 'Check current volumes'
+  task check: [:environment] do
+    # Check
+    ActiveRecord::Base.transaction do
+      barcodes_values.each do |barcode, volume|
+        plate = Plate.includes(wells: [:well_attribute, :map]).with_barcode(barcode).first
+        plate.wells.each do |w|
+          act_vol = w.get_current_volume
+          check = volume == act_vol
+          puts "#{barcode}:#{w.map_description} : #{volume} = #{act_vol} #{check ? '✔' : '✗'*20}"
+          raise "Unexpected volume" unless check
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/create_qc_results.rake
+++ b/lib/tasks/create_qc_results.rake
@@ -9,10 +9,10 @@ namespace :qc_assay do
   ]
 
   key = 'volume'
+  assay_type = 'RT_666755_reset'
 
   desc 'Create forged QcResults'
   task create: [:environment] do
-    # Update
     ActiveRecord::Base.transaction do
       qc_assay = QcAssay.create!
       barcodes_values.each do |barcode, value|
@@ -22,7 +22,7 @@ namespace :qc_assay do
             asset: w,
             key: key,
             value: value.to_f,
-            assay_type: 'RT_666755_reset',
+            assay_type: assay_type,
             units: 'ul',
             assay_version: 'v0.0'
           )
@@ -33,7 +33,6 @@ namespace :qc_assay do
 
   desc 'Check current volumes'
   task check: [:environment] do
-    # Check
     ActiveRecord::Base.transaction do
       barcodes_values.each do |barcode, volume|
         plate = Plate.includes(wells: [:well_attribute, :map]).with_barcode(barcode).first


### PR DESCRIPTION
Taken from an RT solution by @JamesGlover, this rake task can be useful when creating QC results for entire plates.

Not sure if this is the best place where to store this code, feel free to move it or ditch it or make it more generic.