### PR TITLE
Improve message performance

### DIFF
--- a/app/models/api/base.rb
+++ b/app/models/api/base.rb
@@ -1,4 +1,6 @@
 class Api::Base
+  class_attribute :includes
+  self.includes = []
   # TODO[xxx]: This class is in a state of flux at the moment, please don't hack at this too much!
   #
   # Basically this is in a transition as I move more of the behaviour of the API into these model classes,

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -4,6 +4,27 @@
 class Api::Messages::FlowcellIO < Api::Base
   MANUAL_QC_BOOLS = { 'passed' => true, 'failed' => false }
 
+  self.includes = {
+    requests: [
+      { target_asset: {
+        aliquots: [
+          :aliquot_index,
+          :library,
+          {
+            tag: :tag_group,
+            tag2: :tag_group,
+            sample: :uuid_object,
+            study: :uuid_object,
+            project: :uuid_object
+          }
+        ]
+      } },
+      :lab_events,
+      :batch_request,
+      :request_metadata
+    ]
+  }
+
   module LaneExtensions # Included in SequencingRequest
     def self.included(base)
       base.class_eval do

--- a/app/models/api/messages/fluidigm_plate_io.rb
+++ b/app/models/api/messages/fluidigm_plate_io.rb
@@ -1,5 +1,23 @@
 # Generates warehouse messages describing a fluidigm plate.
 class Api::Messages::FluidigmPlateIO < Api::Base
+  self.includes = [
+    :barcodes,
+    :uuid_object,
+    { wells: [
+      :map,
+      :uuid_object,
+      {
+        primary_aliquot: [
+          :project,
+          {
+            sample: :uuid_object,
+            study: :uuid_object
+          }
+        ]
+      }
+    ] }
+  ]
+
   module WellExtensions
     def cost_code
       return nil if primary_aliquot.nil?

--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -1,5 +1,5 @@
 class Messenger < ApplicationRecord
-  belongs_to :target, polymorphic: true
+  belongs_to :target, ->(messenger) { includes(messenger.render_class.includes) }, polymorphic: true
   validates_presence_of :target, :root, :template
   broadcast_via_warren
 


### PR DESCRIPTION
Very large flowcells would take ages to broadcast, due to n+1 query
problems. This change adds eager loading of most the dependencies.

We still generate n+1 queries for library barcodes, due to having to
handle both wells and tubes. This issue will be resolved post-asset
refactor.