### PR TITLE
Fix null delay permission blocking update

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -91,9 +91,7 @@ class Study < ApplicationRecord
     DATA_RELEASE_DELAY_FOR_OTHER
   ]
 
-  DATA_RELEASE_DELAY_LONG  = ['6 months', '9 months', '12 months', '18 months']
-  DATA_RELEASE_DELAY_SHORT = ['3 months']
-  DATA_RELEASE_DELAY_PERIODS = DATA_RELEASE_DELAY_SHORT + DATA_RELEASE_DELAY_LONG
+  DATA_RELEASE_DELAY_PERIODS = ['3 months', '6 months', '9 months', '12 months', '18 months']
 
   # Class variables
   self.per_page = 500

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -4,7 +4,7 @@
     (function(undefined) {
       var hide = function(elements) {
         elements.each(function(index) {
-          $(this).hide().find('input').attr('disabled','disabled');;
+          $(this).hide().find('input').attr('disabled','disabled');
         });
       };
       var show = function(elements) {

--- a/app/views/shared/metadata/edit/_study.html.erb
+++ b/app/views/shared/metadata/edit/_study.html.erb
@@ -72,10 +72,12 @@
           %>
 
           <%= group.select(:data_release_delay_period, Study::DATA_RELEASE_DELAY_PERIODS) %>
+          <% metadata_fields.related_fields(to: :data_release_delay_period, in: Study::DATA_RELEASE_DELAY_PERIODS) do %>
+              <%= group.radio_select(:data_release_delay_approval, Study::YES_OR_NO) %>
+            <% end %>
           <% metadata_fields.related_fields(to: :data_release_delay_reason, when: Study::DATA_RELEASE_DELAY_FOR_OTHER) do %>
             <%= group.text_area(:data_release_delay_other_comment) %>
             <% metadata_fields.related_fields(to: :data_release_delay_period, in: Study::DATA_RELEASE_DELAY_PERIODS) do %>
-              <%= group.radio_select(:data_release_delay_approval, Study::YES_OR_NO) %>
               <%= group.text_area(:data_release_delay_reason_comment) %>
             <% end %>
           <% end %>


### PR DESCRIPTION
On updating studies the hidden data_release_delay_approval field
wasn't being properly disabled. For update studies without a
delay this value was null, and so the form was rejected as having
incomplete fields. However because they were hidden, the browser could
not show the error, and just did nothing.

The related fields javascript is supposed to handle this, however it
interacted badly with the nested options, so got disabled, then
immediately enabled again.

While this bug has existed for a while, it was previously hidden, as the
select dropdown meant it was defaulting to 'No'.

This fix moves the field out, to be visible for all delayed studies, not
just PhD sttudies. Spoke to RC and LE, who agreeed. Originally the field
had been hidden for PhD studies, as they are approved by default.
However, as a result of this bug, they were inadvertantly being recorded
as unapproved anyway.

Following this change the SSRs WILL need to select *yes* for PhD
studies, but at least the correct information will be recorded.