### PR TITLE
GPL145 Fix for Donor Id column shifted right in manifests

### DIFF
--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -724,11 +724,6 @@ rnai:
   unlocked: true
   conditional_formattings:
     empty_cell:
-rnai2:
-  heading: RNAi
-  unlocked: true
-  conditional_formattings:
-    empty_cell:
 organism_part:
   heading: Organism part
   unlocked: true

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -80,7 +80,6 @@ plate_full:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment
@@ -166,7 +165,6 @@ plate_library:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment
@@ -224,7 +222,6 @@ plate_chromium_library:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment
@@ -312,7 +309,6 @@ tube_full:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment

--- a/spec/data/sample_manifest_excel/columns.yml
+++ b/spec/data/sample_manifest_excel/columns.yml
@@ -702,11 +702,6 @@ rnai:
   unlocked: true
   conditional_formattings:
     empty_cell:
-rnai2:
-  heading: RNAi
-  unlocked: true
-  conditional_formattings:
-    empty_cell:
 organism_part:
   heading: Organism part
   unlocked: true

--- a/spec/data/sample_manifest_excel/manifest_types.yml
+++ b/spec/data/sample_manifest_excel/manifest_types.yml
@@ -78,7 +78,6 @@ plate_full:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment
@@ -163,7 +162,6 @@ plate_chromium_library:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment
@@ -249,7 +247,6 @@ tube_full:
     - :immunoprecipitate
     - :growth_condition
     - :rnai
-    - :rnai2
     - :organism_part
     - :time_point
     - :treatment


### PR DESCRIPTION
Removed unused RNAi_2 column from manifest configs. Had same column heading as RNAi, and was shifting row cell data right by one for all following columns including Donor Id.
