### PR TITLE
Don't inherit from assets IO for plate template

### DIFF
--- a/app/api/io/plate_template.rb
+++ b/app/api/io/plate_template.rb
@@ -1,5 +1,5 @@
 # Controls API V1 IO for PlateTemplate
-class Io::PlateTemplate < Io::Asset
+class Io::PlateTemplate < Core::Io::Base
   set_model_for_input(::PlateTemplate)
   set_json_root(:plate_template)
 


### PR DESCRIPTION
Removal of qc_state on labware was cuaing issues.