### PR TITLE
Return user errors if invalid files uploaded

### DIFF
--- a/spec/sample_manifest_excel/upload/data_spec.rb
+++ b/spec/sample_manifest_excel/upload/data_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe SampleManifestExcel::Upload::Data, type: :model, sample_manifest_
     expect(data.cell(spreadsheet.last_row - 10, spreadsheet.last_column - 1)).not_to be nil
     expect(data.cell(spreadsheet.last_row - 10, spreadsheet.last_column - 1)).to eq(spreadsheet.cell(spreadsheet.last_row, spreadsheet.last_column - 1))
   end
+
+  context 'when the file is invalid' do
+    let(:test_file) { File.open('./tmp/nonsense.xlsx', 'w+') { |f| f << 'INVALID FILE CONTENT' } }
+
+    it 'is invalid' do
+      expect(described_class.new(test_file, 3)).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
We see a range of exceptions in production from users uploading
unreadable manifest files:

```
A Zip::Error occurred in sample_manifest_upload_with_tag_sequences#create:

 File /tmp/RackMultipart20190910-10288-15lyzar.xlsx has zero size. Did you mean to pass the create flag?
 app/sample_manifest_excel/sample_manifest_excel/upload/data.rb:26:in `initialize'

An ArgumentError occurred in sample_manifest_upload_with_tag_sequences#create:

 invalid byte sequence in UTF-8
 app/sample_manifest_excel/sample_manifest_excel/upload/data.rb:27:in `initialize'

A CSV::MalformedCSVError occurred in sample_manifest_upload_with_tag_sequences#create:

 Unquoted fields do not allow \r or \n (line 3).
 app/sample_manifest_excel/sample_manifest_excel/upload/data.rb:27:in `initialize'
```

This rescues any failureas at reading the files, and returns an error to
the user.