### PR TITLE
Remove actionpack-page_caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ group :default do
   gem 'formtastic'
   gem 'rest-client' # curb substitute.
 
-  # Caching, primarily of batch.xml Can be removed once our xml interfaces are retired.
-  gem 'actionpack-page_caching'
   # Legacy support for parsing XML into params
   gem 'actionpack-xml_parser'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,8 +52,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionpack-page_caching (1.1.1)
-      actionpack (>= 4.0.0, < 6)
     actionpack-xml_parser (2.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -486,7 +484,6 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  actionpack-page_caching
   actionpack-xml_parser
   activerecord-import
   activerecord-nulldb-adapter


### PR DESCRIPTION
We no-longer cache batch.xml or other xml pages, as cache invalidation
was becoming more expensive than the operations it was saving.

Removing now as currently blocking Rails6 upgrade.