### PR TITLE
Set case_sensitive:false for uniqueness validators

### DIFF
--- a/app/models/asset_group.rb
+++ b/app/models/asset_group.rb
@@ -13,7 +13,7 @@ class AssetGroup < ApplicationRecord
   has_many :assets, through: :asset_group_assets
   has_many :samples, through: :assets, source: :samples
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :study, presence: true
 
   scope :for_search_query, ->(query) { where(['name LIKE ?', "%#{query}%"]) }

--- a/app/models/bait_library.rb
+++ b/app/models/bait_library.rb
@@ -20,8 +20,7 @@ class BaitLibrary < ApplicationRecord
     self.table_name = ('bait_library_suppliers')
 
     # The names of suppliers needs to be unique
-    validates :name, presence: true
-    validates :name, uniqueness: true
+    validates :name, presence: true, uniqueness: { case_sensitive: false }
 
     scope :visible, -> { where(visible: true) }
 
@@ -44,8 +43,7 @@ class BaitLibrary < ApplicationRecord
   before_validation :blank_as_nil
 
   # The names of the bait library are considered unique within the supplier
-  validates :name, presence: true
-  validates :name, uniqueness: { scope: :bait_library_supplier_id }
+  validates :name, presence: true, uniqueness: { scope: :bait_library_supplier_id, case_sensitive: false }
 
   # All bait libraries target a specific species and cannot be mixed
   validates :target_species, presence: true

--- a/app/models/bait_library.rb
+++ b/app/models/bait_library.rb
@@ -39,7 +39,7 @@ class BaitLibrary < ApplicationRecord
 
   # Within a supplier we have a unique identifier for each bait library.  Custom bait libraries
   # do not have this identifier, so nil is permitted.
-  validates :supplier_identifier, uniqueness: { scope: :bait_library_supplier_id, allow_nil: true }
+  validates :supplier_identifier, uniqueness: { scope: :bait_library_supplier_id, allow_nil: true, case_sensitive: false }
   before_validation :blank_as_nil
 
   # The names of the bait library are considered unique within the supplier

--- a/app/models/bait_library_type.rb
+++ b/app/models/bait_library_type.rb
@@ -11,7 +11,7 @@ class BaitLibraryType < ApplicationRecord
 
   # Types have names, need to be unique
   validates :name, :category, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   scope :visible, -> { where(visible: true) }
 

--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -22,7 +22,7 @@ class Barcode < ApplicationRecord
   FOREIGN_BARCODE_FORMATS = %i[cgap fluidx_barcode].freeze
 
   validate :barcode_valid?
-  validates :barcode, uniqueness: { scope: :format }
+  validates :barcode, uniqueness: { scope: :format, case_sensitive: false }
 
   scope(:sanger_barcode, lambda do |prefix, number|
     human_barcode = SBCF::SangerBarcode.from_prefix_and_number(prefix, number).human_barcode

--- a/app/models/barcode_printer_type.rb
+++ b/app/models/barcode_printer_type.rb
@@ -4,8 +4,9 @@
 # in them
 class BarcodePrinterType < ApplicationRecord
   has_many :barcode_printers
-  validates :name, presence: true
-  validates :name, uniqueness: { on: :create, message: 'already in use' }
+  validates :name,
+            presence: true,
+            uniqueness: { on: :create, message: 'already in use', case_sensitive: false }
   # printer_type_id is used by the perl script printing service to decide on the positioning of information on the label
 
   def self.double_label?

--- a/app/models/budget_division.rb
+++ b/app/models/budget_division.rb
@@ -10,7 +10,7 @@ class BudgetDivision < ApplicationRecord
   has_many :projects
 
   validates :name, presence: true
-  validates :name, uniqueness: { message: 'of budget division already present in database' }
+  validates :name, uniqueness: { message: 'of budget division already present in database', case_sensitive: false }
 
   module Associations
     def self.included(base)

--- a/app/models/custom_metadatum.rb
+++ b/app/models/custom_metadatum.rb
@@ -2,7 +2,7 @@ class CustomMetadatum < ApplicationRecord
   belongs_to :custom_metadatum_collection
 
   validates :value, presence: true
-  validates :key, uniqueness: { scope: :custom_metadatum_collection_id }
+  validates :key, uniqueness: { scope: :custom_metadatum_collection_id, case_sensitive: false }
 
   def to_h
     { key => value }

--- a/app/models/data_release_study_type.rb
+++ b/app/models/data_release_study_type.rb
@@ -3,8 +3,9 @@ class DataReleaseStudyType < ApplicationRecord
 
   has_many :study
 
-  validates :name, presence: true
-  validates :name, uniqueness: { message: 'of data release study type already present in database' }
+  validates :name,
+            presence: true,
+            uniqueness: { message: 'of data release study type already present in database', case_sensitive: false }
 
   scope :assay_types, -> { where(is_assay_type: true) }
   scope :non_assay_types, -> { where(is_assay_type: false) }

--- a/app/models/faculty_sponsor.rb
+++ b/app/models/faculty_sponsor.rb
@@ -4,8 +4,9 @@ class FacultySponsor < ApplicationRecord
 
   default_scope { order(:name) }
 
-  validates :name, presence: true
-  validates :name, uniqueness: { message: 'of faculty sponsor already present in database' }
+  validates :name,
+            presence: true,
+            uniqueness: { message: 'of faculty sponsor already present in database', case_sensitive: false }
 
   has_many :study_metadata, class_name: 'Study::Metadata'
   has_many :studies, through: :study_metadata

--- a/app/models/lot.rb
+++ b/app/models/lot.rb
@@ -24,7 +24,7 @@ class Lot < ApplicationRecord
   has_many :stamps, inverse_of: :lot
 
   validates :lot_number, :lot_type, :user, :template, :received_at, presence: true
-  validates :lot_number, uniqueness: true
+  validates :lot_number, uniqueness: { case_sensitive: false }
 
   validate :valid_template?
 

--- a/app/models/lot_type.rb
+++ b/app/models/lot_type.rb
@@ -9,7 +9,7 @@ class LotType < ApplicationRecord
   belongs_to :target_purpose, class_name: 'Purpose'
 
   validates :name, :template_class, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   def valid_template_class
     template_class.constantize

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -66,7 +66,7 @@ class Pipeline < ApplicationRecord
   has_many :inbox, class_name: 'Request', extend: Pipeline::RequestsInStorage
 
   validates :name, :request_types, presence: true
-  validates :name, uniqueness: { on: :create, message: 'name already in use' }
+  validates :name, uniqueness: { on: :create, message: 'name already in use', case_sensitive: false }
 
   scope :externally_managed, -> { where(externally_managed: true) }
   scope :internally_managed, -> { where(externally_managed: false) }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,7 +3,7 @@ class Product < ApplicationRecord
   include SharedBehaviour::Deprecatable
 
   validates :name, presence: true
-  validates :name, uniqueness: { scope: :deprecated_at }
+  validates :name, uniqueness: { scope: :deprecated_at, case_sensitive: false }
   has_many :product_product_catalogues, dependent: :destroy
   has_many :product_catalogues, through: :product_product_catalogues
   has_many :submission_templates, inverse_of: :product, through: :product_catalogues

--- a/app/models/product_criteria.rb
+++ b/app/models/product_criteria.rb
@@ -13,7 +13,7 @@ class ProductCriteria < ApplicationRecord
   belongs_to :product
   validates :product, :stage, :behaviour, presence: true
 
-  validates :stage, uniqueness: { scope: %i[product_id deprecated_at] }
+  validates :stage, uniqueness: { scope: %i[product_id deprecated_at], case_sensitive: false }
   validates :behaviour, inclusion: { in: registered_behaviours }
 
   serialize :configuration

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -3,8 +3,9 @@ class Program < ApplicationRecord
 
   default_scope ->() { order(:name) }
 
-  validates :name, presence: true
-  validates :name, uniqueness: { message: 'of programs already present in database' }
+  validates :name,
+            presence: true,
+            uniqueness: { message: 'of programs already present in database', case_sensitive: false }
 
   has_many :study_metadata, class_name: 'Study::Metadata'
   has_many :studies, through: :study_metadata

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -55,7 +55,7 @@ class Project < ApplicationRecord
   has_many :aliquots
 
   validates :name, :state, presence: true
-  validates :name, uniqueness: { on: :create, message: "already in use (#{name})" }
+  validates :name, uniqueness: { on: :create, message: "already in use (#{name})", case_sensitive: false }
 
   scope :for_search_query, ->(query) {
     where(['name LIKE ? OR id=?', "%#{query}%", query])

--- a/app/models/project_manager.rb
+++ b/app/models/project_manager.rb
@@ -8,7 +8,7 @@ class ProjectManager < ApplicationRecord
   has_many :projects
 
   validates :name, presence: true
-  validates :name, uniqueness: { message: 'of project manager already present in database' }
+  validates :name, uniqueness: { message: 'of project manager already present in database', case_sensitive: false }
 
   module Associations
     def self.included(base)

--- a/app/models/purpose.rb
+++ b/app/models/purpose.rb
@@ -16,7 +16,7 @@ class Purpose < ApplicationRecord
 
   before_validation :set_default_barcode_prefix
 
-  validates :name, format: { with: /\A\w[\s\w\.\-]+\w\z/i }, presence: true, uniqueness: true
+  validates :name, format: { with: /\A\w[\s\w\.\-]+\w\z/i }, presence: true, uniqueness: { case_sensitive: false }
 
   # Note: We should validate against valid asset subclasses, but running into some issues with
   # subclass loading while seeding.

--- a/app/models/reference_genome.rb
+++ b/app/models/reference_genome.rb
@@ -6,7 +6,9 @@ class ReferenceGenome < ApplicationRecord
 
   has_many :studies
   has_many :samples
-  validates :name, uniqueness: { message: 'of reference genome already present in database', allow_blank: true }
+  validates :name, uniqueness: { message: 'of reference genome already present in database',
+                                 allow_blank: true,
+                                 case_sensitive: false }
   broadcast_via_warren
 
   module Associations

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -242,7 +242,7 @@ class Sample < ApplicationRecord
   validates :name, presence: true
   validates :name, format: { with: /\A[\w_-]+\z/i, message: I18n.t('samples.name_format'), if: :new_name_format, on: :create }
   validates :name, format: { with: /\A[\(\)\+\s\w._-]+\z/i, message: I18n.t('samples.name_format'), if: :new_name_format, on: :update }
-  validates :name, uniqueness: { on: :create, message: 'already in use', unless: :sample_manifest_id? }
+  validates :name, uniqueness: { on: :create, message: 'already in use', unless: :sample_manifest_id?, case_sensitive: false }
 
   validate :name_unchanged, if: :will_save_change_to_name?, on: :update
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -9,7 +9,6 @@
 class Search < ApplicationRecord
   include Uuid::Uuidable
 
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
   serialize :default_parameters, Hash
 end

--- a/app/models/study_type.rb
+++ b/app/models/study_type.rb
@@ -3,8 +3,9 @@ class StudyType < ApplicationRecord
 
   has_many :study
 
-  validates :name, presence: true
-  validates :name, uniqueness: { message: 'of study type already present in database' }
+  validates :name,
+            presence: true,
+            uniqueness: { message: 'of study type already present in database', case_sensitive: false }
 
   scope :for_selection, ->() { order(:name).where(valid_for_creation: true) }
 

--- a/app/models/subclass_attribute.rb
+++ b/app/models/subclass_attribute.rb
@@ -1,5 +1,5 @@
 class SubclassAttribute < ApplicationRecord
   belongs_to :attributable, polymorphic: true
 
-  validates :name, uniqueness: { scope: :attributable_id }
+  validates :name, uniqueness: { scope: :attributable_id, case_sensitive: false }
 end

--- a/app/models/tag2_layout_template.rb
+++ b/app/models/tag2_layout_template.rb
@@ -5,9 +5,7 @@ class Tag2LayoutTemplate < ApplicationRecord
 
   belongs_to :tag
   validates :tag, presence: true
-
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   scope :include_tag, ->() { includes(:tag) }
 

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -12,8 +12,7 @@ class TagGroup < ApplicationRecord
 
   scope :chromium, -> { visible.joins(:adapter_type).where(tag_group_adapter_types: { name: CHROMIUM_ADAPTER_TYPE }) }
 
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   def tags_sorted_by_map_id
     tags.sort_by(&:map_id)

--- a/app/models/tag_layout_template.rb
+++ b/app/models/tag_layout_template.rb
@@ -9,8 +9,7 @@ class TagLayoutTemplate < ApplicationRecord
   belongs_to :tag_group, optional: false
   belongs_to :tag2_group, class_name: 'TagGroup'
 
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   validates :direction_algorithm, presence: true
   validates :walking_algorithm, presence: true

--- a/app/models/transfer_template.rb
+++ b/app/models/transfer_template.rb
@@ -8,8 +8,7 @@ class TransferTemplate < ApplicationRecord
   include Uuid::Uuidable
 
   # A name is a useful way to identify templates!
-  validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 
   # A template creates a particular Transfer subclass.
   validates :transfer_class_name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,9 +30,7 @@ class User < ApplicationRecord
   before_save :encrypt_password
   before_create { |record| record.new_api_key if record.api_key.blank? }
 
-  validates :login, presence: true
-  validates :login, uniqueness: true
-
+  validates :login, presence: true, uniqueness: { case_sensitive: false }
   validates :password, confirmation: { if: :password_required? }
 
   scope :with_login, ->(*logins) { where(login: logins.flatten) }

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ApplicationRecord
   belongs_to :pipeline, inverse_of: :workflow
   validates :pipeline_id, uniqueness: { message: 'only one workflow per pipeline!' }
 
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   def batch_limit?
     item_limit.present?

--- a/spec/models/lot_type_spec.rb
+++ b/spec/models/lot_type_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LotType do
       create :lot
     end
 
-    it { is_expected.to validate_uniqueness_of :name }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive }
   end
 
   it 'is validated', :aggregate_failures do

--- a/test/unit/tag_qc/lot_test.rb
+++ b/test/unit/tag_qc/lot_test.rb
@@ -18,7 +18,7 @@ class LotTest < ActiveSupport::TestCase
         create :lot
       end
 
-      should validate_uniqueness_of :lot_number
+      should validate_uniqueness_of(:lot_number).case_insensitive
     end
 
     context '#lot' do


### PR DESCRIPTION
Rails 6.0 raises the following deprecation warning:
```
DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :login attribute in User model, pass `case_sensitive: true` option explicitly to the uniqueness validator.
```
This is occurs if the MySQL2 adapter detects the database is using a
case-insensitive collation, which we are. The new defaults avoid the
situation in which Rails allows two entires with different cases: Eg.
'My Study' and 'My study' but then Study.find_by(name: 'My study')
behaves unpredictably, and could find either study.

We've been bitten by this behaviour before, so the new defaults make
sense. Rather than maintaining the existing behaviour we opt in to the
new defaults early, and simultaneously avoid the deprecation warnings.

See https://github.com/sanger/sequencescape/issues/2360