### PR TITLE
Don't run tests on tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ jobs:
     name: Coverage
     after_script:
     - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     script: bundle exec rubocop
     name: Rubocop
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RUBYOPT='-W0'
     before_script:
@@ -44,7 +44,7 @@ jobs:
     - bundle exec rake db:setup
     script: bundle exec rake test
     name: Rake Test
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
     - CI_NODE_TOTAL=5
@@ -55,7 +55,7 @@ jobs:
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
     name: RSpec 1
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
     - CI_NODE_TOTAL=5
@@ -66,7 +66,7 @@ jobs:
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
     name: RSpec 2
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
     - CI_NODE_TOTAL=5
@@ -77,7 +77,7 @@ jobs:
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
     name: RSpec 3
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
     - CI_NODE_TOTAL=5
@@ -88,7 +88,7 @@ jobs:
     - bundle exec rake db:setup
     name: Cucumber Test 1
     script: xvfb-run -a bundle exec rake knapsack:cucumber
-  - if: type != cron
+  - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
     - CI_NODE_TOTAL=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=0
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -58,7 +58,7 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=1
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -69,7 +69,7 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=2
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -80,8 +80,8 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=5
-    - CI_NODE_INDEX=3
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=0
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
@@ -91,8 +91,8 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=5
-    - CI_NODE_INDEX=4
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=1
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ the table of contents, run:
 
 ### CI
 
-The Travis builds use the Knapsack gem to parallelize the RSpec and Cucumber tests, to reduce build time. When a Travis build runs, Knapsack uses the knapsack_rspec_report.json and knapsack_cucumber_report.json files, which list out test run times, to split the tests into equal length jobs. These report files don't need to be regenerated if tests are deleted or added unless the tests in question are particularly slow and will therefore impact the build times significantly. To regenerate a report file, run one of the following, and commit the resulting changes to the report files:
+The Travis builds use the Knapsack gem to reduce build time by parallelizing the RSpec and Cucumber tests. When a Travis build runs, Knapsack uses the knapsack_rspec_report.json and knapsack_cucumber_report.json files, which list out test run times, to split the tests into equal length jobs. These report files don't need to be regenerated if tests are deleted or added unless the tests in question are particularly slow and will therefore impact the build times significantly. To regenerate a report file, run one of the following, and commit the resulting changes to the report files:
 
     KNAPSACK_GENERATE_REPORT=true bundle exec rspec
     KNAPSACK_GENERATE_REPORT=true bundle exec cucumber


### PR DESCRIPTION
Running tests on tag builds is unnecessary because the build will have run on the pull request anyway.