### PR TITLE
Restrict builds to master and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
   global:
   - TZ=Europe/London
   - CUCUMBER_FORMAT=DebugFormatter
+branches:
+  only:
+  - master
+  - release
 before_install:
 - mv config/aker.yml.example config/aker.yml
 - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
   - if: type != cron
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=0
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -62,7 +62,7 @@ jobs:
   - if: type != cron
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=1
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -73,7 +73,7 @@ jobs:
   - if: type != cron
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=5
+    - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=2
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
@@ -84,8 +84,8 @@ jobs:
   - if: type != cron
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=5
-    - CI_NODE_INDEX=3
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=0
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
@@ -95,8 +95,8 @@ jobs:
   - if: type != cron
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=5
-    - CI_NODE_INDEX=4
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=1
     before_script:
     - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile


### PR DESCRIPTION
restrict builds to be only on master and release branches
- builds on feature branches create lots of noise, and we still have pull request builds to rely on