### PR TITLE
Gpl 216 edit study bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,36 +51,14 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
-    - CI_NODE_TOTAL=3
-    - CI_NODE_INDEX=0
+    # - CI_NODE_TOTAL=3
+    # - CI_NODE_INDEX=0
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
-    script: xvfb-run -a bundle exec rake knapsack:rspec
+    script: xvfb-run -a bundle exec rspec
     name: RSpec 1
-  - if: type != cron AND tag IS blank
-    env:
-    - RAILS_ENV=test
-    - CI_NODE_TOTAL=3
-    - CI_NODE_INDEX=1
-    before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
-    - bundle exec rake assets:precompile
-    - bundle exec rake db:setup
-    script: xvfb-run -a bundle exec rake knapsack:rspec
-    name: RSpec 2
-  - if: type != cron AND tag IS blank
-    env:
-    - RAILS_ENV=test
-    - CI_NODE_TOTAL=3
-    - CI_NODE_INDEX=2
-    before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
-    - bundle exec rake assets:precompile
-    - bundle exec rake db:setup
-    script: xvfb-run -a bundle exec rake knapsack:rspec
-    name: RSpec 3
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,25 +62,25 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=2
-    - CI_NODE_INDEX=0
+    # - CI_NODE_TOTAL=2
+    # - CI_NODE_INDEX=0
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 1
-    script: xvfb-run -a bundle exec rake knapsack:cucumber
+    script: xvfb-run -a bundle exec cucumber
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    - CI_NODE_TOTAL=2
-    - CI_NODE_INDEX=1
+    # - CI_NODE_TOTAL=2
+    # - CI_NODE_INDEX=1
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 2
-    script: xvfb-run -a bundle exec rake knapsack:cucumber
+    script: xvfb-run -a bundle exec cucumber
   - stage: build
     if: tag IS present
     script: "./compile-build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
   - stage: test
     if: type = cron
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update
     - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     - chmod +x ./cc-test-reporter
     - "./cc-test-reporter before-build"
@@ -54,7 +54,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=0
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -65,7 +65,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=1
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -76,7 +76,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=2
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -87,7 +87,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=0
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 1
@@ -98,7 +98,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=1
     before_script:
-    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,25 +62,25 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    # - CI_NODE_TOTAL=2
-    # - CI_NODE_INDEX=0
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=0
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 1
-    script: xvfb-run -a bundle exec cucumber
+    script: xvfb-run -a bundle exec rake knapsack:cucumber
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber
-    # - CI_NODE_TOTAL=2
-    # - CI_NODE_INDEX=1
+    - CI_NODE_TOTAL=2
+    - CI_NODE_INDEX=1
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 2
-    script: xvfb-run -a bundle exec cucumber
+    script: xvfb-run -a bundle exec rake knapsack:cucumber
   - stage: build
     if: tag IS present
     script: "./compile-build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,36 @@ jobs:
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=test
-    # - CI_NODE_TOTAL=3
-    # - CI_NODE_INDEX=0
+    - CI_NODE_TOTAL=3
+    - CI_NODE_INDEX=0
     before_script:
     # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
-    script: xvfb-run -a bundle exec rspec
+    script: xvfb-run -a bundle exec rake knapsack:rspec
     name: RSpec 1
+  - if: type != cron AND tag IS blank
+    env:
+    - RAILS_ENV=test
+    - CI_NODE_TOTAL=3
+    - CI_NODE_INDEX=1
+    before_script:
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - bundle exec rake assets:precompile
+    - bundle exec rake db:setup
+    script: xvfb-run -a bundle exec rake knapsack:rspec
+    name: RSpec 2
+  - if: type != cron AND tag IS blank
+    env:
+    - RAILS_ENV=test
+    - CI_NODE_TOTAL=3
+    - CI_NODE_INDEX=2
+    before_script:
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    - bundle exec rake assets:precompile
+    - bundle exec rake db:setup
+    script: xvfb-run -a bundle exec rake knapsack:rspec
+    name: RSpec 3
   - if: type != cron AND tag IS blank
     env:
     - RAILS_ENV=cucumber

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
   - stage: test
     if: type = cron
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update
     - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
     - chmod +x ./cc-test-reporter
     - "./cc-test-reporter before-build"
@@ -54,7 +54,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=0
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -65,7 +65,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=1
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -76,7 +76,7 @@ jobs:
     - CI_NODE_TOTAL=3
     - CI_NODE_INDEX=2
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     script: xvfb-run -a bundle exec rake knapsack:rspec
@@ -87,7 +87,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=0
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 1
@@ -98,7 +98,7 @@ jobs:
     - CI_NODE_TOTAL=2
     - CI_NODE_INDEX=1
     before_script:
-    - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
+    # - RAILS_ENV=test bundle exec rails webdrivers:chromedriver:update -r webdrivers
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
     name: Cucumber Test 2

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -19,25 +19,69 @@
         return (value.length == 0) ? 'blank' : value;
       };
 
-      observe = function(id) {
-        var selectRelatedFor, element;
+      var selectRelatedFor = function(id, value) {
+        return jQuery('.related_to.' + id + '.' + value);
+      };
 
-        selectRelatedFor = function(value) { return jQuery('.related_to.' + id + '.' + value); };
-        element = document.getElementById('<%= root %>_' + id) ||
-                    $("input[name='study[study_metadata_attributes]["+id+"]']:checked")[0] ||
-                    document.getElementById('<%= root %>_' + id + '_id');
+      var processForOneDiv = function(divToProcess) {
+        var fieldToCheckValueOfName;
+        <% related.each do |field| %>
+          if($(divToProcess).hasClass("<%= field.to_s %>")) {
+            fieldToCheckValueOfName = "<%= field.to_s %>"
+          }
+        <% end %>
+
+        var fieldToCheckValueOf = document.getElementById('<%= root %>_' + fieldToCheckValueOfName) ||
+                $("input[name='study[study_metadata_attributes]["+fieldToCheckValueOfName+"]']:checked")[0] ||
+                document.getElementById('<%= root %>_' + fieldToCheckValueOfName + '_id');
+
+        var relatedToDivs = jQuery('.related_to.' + fieldToCheckValueOfName);
+        hide(relatedToDivs);
+
+        var valueFromElement = valueFrom(fieldToCheckValueOf);
+
+        var relatedToDivsWithRelevantValue = selectRelatedFor(fieldToCheckValueOfName, valueFromElement);
+        show(relatedToDivsWithRelevantValue);
+
+        relatedToDivsWithRelevantValue.each(function(index2){
+          processForOneDiv(this)
+        });
+      }
+
+      observe = function(id) {
+
+        var element = document.getElementById('<%= root %>_' + id) ||
+                      $("input[name='study[study_metadata_attributes]["+id+"]']:checked")[0] ||
+                      document.getElementById('<%= root %>_' + id + '_id');
+
         // Hide all of the DIVs and then show the current value.  We assume that the first identified element
         // is the one we're supposed to be using and that, if there are multiple fields, then they have the
         // same initial value.
         hide(jQuery('.related_to.' + id));
-        show(selectRelatedFor(valueFrom(element)));
+
+        var valueFromElement = valueFrom(element);
+        show(selectRelatedFor(id, valueFromElement));
 
         // Now we can delegate handling of the click to the body element of the document.  This enables us to
         // handle multiple different fields with the same identifier as though they were one, hopefully.
         selector = '[id=<%= root %>_' + id + '],[id=<%= root %>_' + id + '_id],[name=\'study[study_metadata_attributes]['+id+']\']';
+
         jQuery('body').delegate(selector, 'change', function() {
-          hide(jQuery('.related_to.' + id));
-          show(selectRelatedFor(valueFrom(this)));
+
+          var relatedToDivs = jQuery('.related_to.' + id);
+          var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(this));
+
+          hide(relatedToDivs);
+          show(relatedToDivsWithRelevantValue);
+
+          relatedToDivsWithRelevantValue.each(function(index){
+            var div = this;
+            var children = $(this).children('.related_to');
+            children.each(function(index2){
+              processForOneDiv(this)
+            });
+          });
+
         });
       };
 

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -23,6 +23,12 @@
         return jQuery('.related_to.' + id + '.' + value);
       };
 
+      var getElementByFieldName = function(fieldName) {
+        return  document.getElementById('<%= root %>_' + fieldName) ||
+                $("input[name='study[study_metadata_attributes]["+fieldName+"]']:checked")[0] ||
+                document.getElementById('<%= root %>_' + fieldName + '_id');
+      }
+
       var processForOneDiv = function(divToProcess) {
         var fieldToCheckValueOfName;
         <% related.each do |field| %>
@@ -31,9 +37,7 @@
           }
         <% end %>
 
-        var fieldToCheckValueOf = document.getElementById('<%= root %>_' + fieldToCheckValueOfName) ||
-                $("input[name='study[study_metadata_attributes]["+fieldToCheckValueOfName+"]']:checked")[0] ||
-                document.getElementById('<%= root %>_' + fieldToCheckValueOfName + '_id');
+        var fieldToCheckValueOf = getElementByFieldName(fieldToCheckValueOfName);
 
         var relatedToDivs = $(divToProcess).find('.related_to.' + fieldToCheckValueOfName);
         hide(relatedToDivs);
@@ -50,16 +54,15 @@
 
       observe = function(id) {
 
-        var element = document.getElementById('<%= root %>_' + id) ||
-                      $("input[name='study[study_metadata_attributes]["+id+"]']:checked")[0] ||
-                      document.getElementById('<%= root %>_' + id + '_id');
+        var fieldToCheckValueOf = getElementByFieldName(id);
 
         // Hide all of the DIVs and then show the current value.  We assume that the first identified element
         // is the one we're supposed to be using and that, if there are multiple fields, then they have the
         // same initial value.
-        hide(jQuery('.related_to.' + id));
+        var relatedToDivs = jQuery('.related_to.' + id);
+        hide(relatedToDivs);
 
-        var valueFromElement = valueFrom(element);
+        var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(fieldToCheckValueOf));
         show(selectRelatedFor(id, valueFromElement));
 
         // Now we can delegate handling of the click to the body element of the document.  This enables us to
@@ -69,9 +72,9 @@
         jQuery('body').delegate(selector, 'change', function() {
 
           var relatedToDivs = jQuery('.related_to.' + id);
-          var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(this));
-
           hide(relatedToDivs);
+
+          var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(this));
           show(relatedToDivsWithRelevantValue);
 
           relatedToDivsWithRelevantValue.each(function(index){

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -63,7 +63,7 @@
         hide(relatedToDivs);
 
         var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(fieldToCheckValueOf));
-        show(selectRelatedFor(id, valueFromElement));
+        show(relatedToDivsWithRelevantValue);
 
         // Now we can delegate handling of the click to the body element of the document.  This enables us to
         // handle multiple different fields with the same identifier as though they were one, hopefully.
@@ -88,16 +88,16 @@
         });
       };
 
-    <% related.each do |field| %>
-      observe("<%= field.to_s %>");
-    <% end %>
+      <% related.each do |field| %>
+        observe("<%= field.to_s %>");
+      <% end %>
     })();
   });
 
   (function($, undefined) {
-  <% changing_fields.reverse.each do |field, options| %>
-    attach_option_updater("<%= field.to_s %>", "<%= options[:when].to_s %>", {<%= options[:values].map { |k,v| "#{k.inspect}:#{v.inspect}" }.join(',').html_safe %>});
-  <% end %>
+    <% changing_fields.reverse.each do |field, options| %>
+      attach_option_updater("<%= field.to_s %>", "<%= options[:when].to_s %>", {<%= options[:values].map { |k,v| "#{k.inspect}:#{v.inspect}" }.join(',').html_safe %>});
+    <% end %>
 
     function attach_option_updater(target, source, values) {
       $('#<%= root %>_' + source).change(function() {

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -4,20 +4,18 @@
     (function(undefined) {
       var hideSectionAndDisableInputs = function(elements) {
         // disable inputs when hidden so they don't fire validation
-        console.log('hiding: ', elements);
         elements.each(function() {
           $(this).hide().find('input').attr('disabled','disabled');
         });
       };
+
       var showSectionAndEnableInputsIfVisible = function(elements) {
-        console.log('showing if visible: ', elements);
         elements.each(function() {
           $(this).show();
 
           $(this).find('input').each(function() {
             // only enable input if it's not hidden - could be beneath a hidden element in the DOM
             if(!$(this).is(':visible')) return;
-            console.log('enabling: ', this);
             $(this).attr('disabled', null);
           });
         });
@@ -59,7 +57,6 @@
       initialize = function() {
         <% related.each do |field| %>
           var fieldName = "<%= field.to_s %>";
-          console.log('fieldName: ', fieldName);
           var controllingField = getElementByFieldName(fieldName);
 
           rerenderFieldsRelatedToControllingField(fieldName, controllingField);

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -27,9 +27,12 @@
         return  document.getElementById('<%= root %>_' + fieldName) ||
                 $("input[name='study[study_metadata_attributes]["+fieldName+"]']:checked")[0] ||
                 document.getElementById('<%= root %>_' + fieldName + '_id');
-      }
+      };
 
       var processForOneDiv = function(divToProcess) {
+
+        hide($(divToProcess));
+
         var fieldToCheckValueOfName;
         <% related.each do |field| %>
           if($(divToProcess).hasClass("<%= field.to_s %>")) {
@@ -38,19 +41,15 @@
         <% end %>
 
         var fieldToCheckValueOf = getElementByFieldName(fieldToCheckValueOfName);
+        valueFromFieldToCheckValueOf = valueFrom(fieldToCheckValueOf);
 
-        var relatedToDivs = $(divToProcess).find('.related_to.' + fieldToCheckValueOfName);
-        hide(relatedToDivs);
-
-        var valueFromElement = valueFrom(fieldToCheckValueOf);
-
-        var relatedToDivsWithRelevantValue = $(divToProcess).find('.related_to.' + fieldToCheckValueOfName + '.' + valueFromElement);
+        var relatedToDivsWithRelevantValue = $(divToProcess).children('.related_to.' + fieldToCheckValueOfName + '.' + valueFromFieldToCheckValueOf);
         show(relatedToDivsWithRelevantValue);
 
         relatedToDivsWithRelevantValue.each(function(index2){
           processForOneDiv(this)
         });
-      }
+      };
 
       observe = function(id) {
 
@@ -81,7 +80,7 @@
             var div = this;
             var children = $(this).children('.related_to');
             children.each(function(index2){
-              processForOneDiv(this)
+              processForOneDiv(this);
             });
           });
 

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -2,14 +2,24 @@
 <script language="javascript">
   jQuery(function() {
     (function(undefined) {
-      var hideAndDisableInputs = function(elements) {
+      var hideSectionAndDisableInputs = function(elements) {
+        // disable inputs when hidden so they don't fire validation
+        console.log('hiding: ', elements);
         elements.each(function() {
           $(this).hide().find('input').attr('disabled','disabled');
         });
       };
-      var showAndEnableInputs = function(elements) {
+      var showSectionAndEnableInputsIfVisible = function(elements) {
+        console.log('showing if visible: ', elements);
         elements.each(function() {
-          $(this).show().find('input').attr('disabled',null);
+          $(this).show();
+
+          $(this).find('input').each(function() {
+            // only enable input if it's not hidden - could be beneath a hidden element in the DOM
+            if(!$(this).is(':visible')) return;
+            console.log('enabling: ', this);
+            $(this).attr('disabled', null);
+          });
         });
       };
 
@@ -19,12 +29,8 @@
         return (value.length == 0) ? 'blank' : value;
       };
 
-      var selectRelatedFor = function(fieldName, value) {
+      var selectRelatedByFieldAndValue = function(fieldName, value) {
         return jQuery('.related_to.' + fieldName + '.' + value);
-      };
-
-      var selectRelatedForUnderElement = function(element, fieldName, value) {
-        return jQuery(element).children('.related_to.' + fieldName + '.' + value);
       };
 
       var getElementByFieldName = function(fieldName) {
@@ -33,40 +39,12 @@
                 document.getElementById('<%= root %>_' + fieldName + '_id');
       };
 
-      var processForOneDiv = function(divToProcess) {
-
-        hideAndDisableInputs($(divToProcess));
-
-        var controllingFieldName;
-        <% related.each do |field| %>
-          if($(divToProcess).hasClass("<%= field.to_s %>")) {
-            controllingFieldName = "<%= field.to_s %>"
-          }
-        <% end %>
-
-        var controllingField = getElementByFieldName(controllingFieldName);
-        valueFromControllingField = valueFrom(controllingField);
-
-        var relatedToDivsWithRelevantValue = selectRelatedForUnderElement(divToProcess, controllingFieldName, valueFromControllingField);
-        showAndEnableInputs(relatedToDivsWithRelevantValue);
-
-        relatedToDivsWithRelevantValue.each(function(){
-          processForOneDiv(this)
-        });
-      };
-
-      hideAndShowFields = function(fieldName, controllingField) {
+      rerenderFieldsRelatedToControllingField = function(fieldName, controllingField) {
         var relatedToDivs = jQuery('.related_to.' + fieldName);
-        hideAndDisableInputs(relatedToDivs);
+        hideSectionAndDisableInputs(relatedToDivs);
 
-        var relatedToDivsWithRelevantValue = selectRelatedFor(fieldName, valueFrom(controllingField));
-        showAndEnableInputs(relatedToDivsWithRelevantValue);
-        return relatedToDivsWithRelevantValue;
-      };
-
-      hideAndShowFieldsInitially = function(fieldName) {
-        var controllingField = getElementByFieldName(fieldName);
-        hideAndShowFields(fieldName, controllingField);
+        var relatedWithRelevantValue = selectRelatedByFieldAndValue(fieldName, valueFrom(controllingField));
+        showSectionAndEnableInputsIfVisible(relatedWithRelevantValue);
       };
 
       addOnChangeHandler = function(fieldName) {
@@ -74,21 +52,17 @@
 
         jQuery('body').delegate(controllingFieldSelector, 'change', function() {
           controllingField = this;
-          relatedToDivsWithRelevantValue = hideAndShowFields(fieldName, controllingField);
-
-          relatedToDivsWithRelevantValue.each(function(){
-            var children = $(this).children('.related_to');
-            children.each(function(){
-              processForOneDiv(this);
-            });
-          });
+          rerenderFieldsRelatedToControllingField(fieldName, controllingField);
         });
       }
 
       initialize = function() {
         <% related.each do |field| %>
           var fieldName = "<%= field.to_s %>";
-          hideAndShowFieldsInitially(fieldName);
+          console.log('fieldName: ', fieldName);
+          var controllingField = getElementByFieldName(fieldName);
+
+          rerenderFieldsRelatedToControllingField(fieldName, controllingField);
           addOnChangeHandler(fieldName);
         <% end %>
       }

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -9,7 +9,7 @@
       };
       var show = function(elements) {
         elements.each(function(index) {
-          $(this).show().find('input').attr('disabled',null);;
+          $(this).show().find('input').attr('disabled',null);
         });
       };
 

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -2,13 +2,13 @@
 <script language="javascript">
   jQuery(function() {
     (function(undefined) {
-      var hide = function(elements) {
-        elements.each(function(index) {
+      var hideAndDisableInputs = function(elements) {
+        elements.each(function() {
           $(this).hide().find('input').attr('disabled','disabled');
         });
       };
-      var show = function(elements) {
-        elements.each(function(index) {
+      var showAndEnableInputs = function(elements) {
+        elements.each(function() {
           $(this).show().find('input').attr('disabled',null);
         });
       };
@@ -19,8 +19,12 @@
         return (value.length == 0) ? 'blank' : value;
       };
 
-      var selectRelatedFor = function(id, value) {
-        return jQuery('.related_to.' + id + '.' + value);
+      var selectRelatedFor = function(fieldName, value) {
+        return jQuery('.related_to.' + fieldName + '.' + value);
+      };
+
+      var selectRelatedForUnderElement = function(element, fieldName, value) {
+        return jQuery(element).children('.related_to.' + fieldName + '.' + value);
       };
 
       var getElementByFieldName = function(fieldName) {
@@ -31,65 +35,65 @@
 
       var processForOneDiv = function(divToProcess) {
 
-        hide($(divToProcess));
+        hideAndDisableInputs($(divToProcess));
 
-        var fieldToCheckValueOfName;
+        var controllingFieldName;
         <% related.each do |field| %>
           if($(divToProcess).hasClass("<%= field.to_s %>")) {
-            fieldToCheckValueOfName = "<%= field.to_s %>"
+            controllingFieldName = "<%= field.to_s %>"
           }
         <% end %>
 
-        var fieldToCheckValueOf = getElementByFieldName(fieldToCheckValueOfName);
-        valueFromFieldToCheckValueOf = valueFrom(fieldToCheckValueOf);
+        var controllingField = getElementByFieldName(controllingFieldName);
+        valueFromControllingField = valueFrom(controllingField);
 
-        var relatedToDivsWithRelevantValue = $(divToProcess).children('.related_to.' + fieldToCheckValueOfName + '.' + valueFromFieldToCheckValueOf);
-        show(relatedToDivsWithRelevantValue);
+        var relatedToDivsWithRelevantValue = selectRelatedForUnderElement(divToProcess, controllingFieldName, valueFromControllingField);
+        showAndEnableInputs(relatedToDivsWithRelevantValue);
 
-        relatedToDivsWithRelevantValue.each(function(index2){
+        relatedToDivsWithRelevantValue.each(function(){
           processForOneDiv(this)
         });
       };
 
-      observe = function(id) {
+      hideAndShowFields = function(fieldName, controllingField) {
+        var relatedToDivs = jQuery('.related_to.' + fieldName);
+        hideAndDisableInputs(relatedToDivs);
 
-        var fieldToCheckValueOf = getElementByFieldName(id);
+        var relatedToDivsWithRelevantValue = selectRelatedFor(fieldName, valueFrom(controllingField));
+        showAndEnableInputs(relatedToDivsWithRelevantValue);
+        return relatedToDivsWithRelevantValue;
+      };
 
-        // Hide all of the DIVs and then show the current value.  We assume that the first identified element
-        // is the one we're supposed to be using and that, if there are multiple fields, then they have the
-        // same initial value.
-        var relatedToDivs = jQuery('.related_to.' + id);
-        hide(relatedToDivs);
+      hideAndShowFieldsInitially = function(fieldName) {
+        var controllingField = getElementByFieldName(fieldName);
+        hideAndShowFields(fieldName, controllingField);
+      };
 
-        var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(fieldToCheckValueOf));
-        show(relatedToDivsWithRelevantValue);
+      addOnChangeHandler = function(fieldName) {
+        controllingFieldSelector = '[id=<%= root %>_' + fieldName + '],[id=<%= root %>_' + fieldName + '_id],[name=\'study[study_metadata_attributes]['+fieldName+']\']';
 
-        // Now we can delegate handling of the click to the body element of the document.  This enables us to
-        // handle multiple different fields with the same identifier as though they were one, hopefully.
-        selector = '[id=<%= root %>_' + id + '],[id=<%= root %>_' + id + '_id],[name=\'study[study_metadata_attributes]['+id+']\']';
+        jQuery('body').delegate(controllingFieldSelector, 'change', function() {
+          controllingField = this;
+          relatedToDivsWithRelevantValue = hideAndShowFields(fieldName, controllingField);
 
-        jQuery('body').delegate(selector, 'change', function() {
-
-          var relatedToDivs = jQuery('.related_to.' + id);
-          hide(relatedToDivs);
-
-          var relatedToDivsWithRelevantValue = selectRelatedFor(id, valueFrom(this));
-          show(relatedToDivsWithRelevantValue);
-
-          relatedToDivsWithRelevantValue.each(function(index){
-            var div = this;
+          relatedToDivsWithRelevantValue.each(function(){
             var children = $(this).children('.related_to');
-            children.each(function(index2){
+            children.each(function(){
               processForOneDiv(this);
             });
           });
-
         });
-      };
+      }
 
-      <% related.each do |field| %>
-        observe("<%= field.to_s %>");
-      <% end %>
+      initialize = function() {
+        <% related.each do |field| %>
+          var fieldName = "<%= field.to_s %>";
+          hideAndShowFieldsInitially(fieldName);
+          addOnChangeHandler(fieldName);
+        <% end %>
+      }
+
+      initialize();
     })();
   });
 

--- a/app/views/shared/metadata/_related_fields.html.erb
+++ b/app/views/shared/metadata/_related_fields.html.erb
@@ -35,12 +35,12 @@
                 $("input[name='study[study_metadata_attributes]["+fieldToCheckValueOfName+"]']:checked")[0] ||
                 document.getElementById('<%= root %>_' + fieldToCheckValueOfName + '_id');
 
-        var relatedToDivs = jQuery('.related_to.' + fieldToCheckValueOfName);
+        var relatedToDivs = $(divToProcess).find('.related_to.' + fieldToCheckValueOfName);
         hide(relatedToDivs);
 
         var valueFromElement = valueFrom(fieldToCheckValueOf);
 
-        var relatedToDivsWithRelevantValue = selectRelatedFor(fieldToCheckValueOfName, valueFromElement);
+        var relatedToDivsWithRelevantValue = $(divToProcess).find('.related_to.' + fieldToCheckValueOfName + '.' + valueFromElement);
         show(relatedToDivsWithRelevantValue);
 
         relatedToDivsWithRelevantValue.each(function(index2){

--- a/spec/features/studies/edit_study_spec.rb
+++ b/spec/features/studies/edit_study_spec.rb
@@ -4,34 +4,48 @@ require 'rails_helper'
 
 describe 'Edit a study' do
   let(:user) { create :admin }
-  let!(:study) { create :study }
+  let!(:study) { create :not_app_study }
 
-  it 'edit open study', js: true do
-    study.study_metadata.bam = false
+  # it 'edit open study', js: true do
+  #   study.study_metadata.bam = false
+  #   study.save
+  #   login_user(user)
+  #   visit study_path(study)
+  #   click_link 'Edit'
+  #   expect(page).to have_content('Alignments in BAM')
+  #   expect(find('#study_study_metadata_attributes_bam')).not_to be_checked
+  #   check 'study_study_metadata_attributes_bam'
+  #   expect(find('#study_study_metadata_attributes_bam')).to be_checked
+  #   click_button 'Save Study'
+  #   expect(page).to have_content('Your study has been updated')
+  #   click_link 'Study details'
+  #   expect(page).to have_content('Alignments in BAM: true')
+  # end
+
+  # it 'add external customer information', js: true do
+  #   login_user(user)
+  #   visit study_path(study)
+  #   click_link 'Edit'
+  #   fill_in 'S3 email list', with: 'aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk'
+  #   select('3 months', from: 'Data deletion period')
+  #   click_button 'Save Study'
+  #   expect(page).to have_content('Your study has been updated')
+  #   study.reload
+  #   expect(study.study_metadata.s3_email_list).to eq('aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk')
+  #   expect(study.study_metadata.data_deletion_period).to eq('3 months')
+  # end
+
+  it 'edit open study error test', js: true do
+    study.study_metadata.data_release_strategy = 'not applicable'
     study.save
     login_user(user)
     visit study_path(study)
     click_link 'Edit'
-    expect(page).to have_content('Alignments in BAM')
-    expect(find('#study_study_metadata_attributes_bam')).not_to be_checked
-    check 'study_study_metadata_attributes_bam'
-    expect(find('#study_study_metadata_attributes_bam')).to be_checked
+    expect(page).to have_content('What is the data release strategy for this study?')
+    expect(page).to have_content('Open (ENA)')
+    choose('Open (ENA)', allow_label_click: true)
+    # choose('study_study_metadata_attributes_data_release_prevention_approval_yes', allow_label_click: true)
     click_button 'Save Study'
     expect(page).to have_content('Your study has been updated')
-    click_link 'Study details'
-    expect(page).to have_content('Alignments in BAM: true')
-  end
-
-  it 'add external customer information', js: true do
-    login_user(user)
-    visit study_path(study)
-    click_link 'Edit'
-    fill_in 'S3 email list', with: 'aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk'
-    select('3 months', from: 'Data deletion period')
-    click_button 'Save Study'
-    expect(page).to have_content('Your study has been updated')
-    study.reload
-    expect(study.study_metadata.s3_email_list).to eq('aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk')
-    expect(study.study_metadata.data_deletion_period).to eq('3 months')
   end
 end

--- a/spec/features/studies/edit_study_spec.rb
+++ b/spec/features/studies/edit_study_spec.rb
@@ -4,48 +4,51 @@ require 'rails_helper'
 
 describe 'Edit a study' do
   let(:user) { create :admin }
-  let!(:study) { create :not_app_study }
+  let!(:study) { create :study }
 
-  # it 'edit open study', js: true do
-  #   study.study_metadata.bam = false
-  #   study.save
-  #   login_user(user)
-  #   visit study_path(study)
-  #   click_link 'Edit'
-  #   expect(page).to have_content('Alignments in BAM')
-  #   expect(find('#study_study_metadata_attributes_bam')).not_to be_checked
-  #   check 'study_study_metadata_attributes_bam'
-  #   expect(find('#study_study_metadata_attributes_bam')).to be_checked
-  #   click_button 'Save Study'
-  #   expect(page).to have_content('Your study has been updated')
-  #   click_link 'Study details'
-  #   expect(page).to have_content('Alignments in BAM: true')
-  # end
-
-  # it 'add external customer information', js: true do
-  #   login_user(user)
-  #   visit study_path(study)
-  #   click_link 'Edit'
-  #   fill_in 'S3 email list', with: 'aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk'
-  #   select('3 months', from: 'Data deletion period')
-  #   click_button 'Save Study'
-  #   expect(page).to have_content('Your study has been updated')
-  #   study.reload
-  #   expect(study.study_metadata.s3_email_list).to eq('aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk')
-  #   expect(study.study_metadata.data_deletion_period).to eq('3 months')
-  # end
-
-  it 'edit open study error test', js: true do
-    study.study_metadata.data_release_strategy = 'not applicable'
+  it 'edit open study', js: true do
+    study.study_metadata.bam = false
     study.save
     login_user(user)
     visit study_path(study)
     click_link 'Edit'
-    expect(page).to have_content('What is the data release strategy for this study?')
-    expect(page).to have_content('Open (ENA)')
-    choose('Open (ENA)', allow_label_click: true)
-    # choose('study_study_metadata_attributes_data_release_prevention_approval_yes', allow_label_click: true)
+    expect(page).to have_content('Alignments in BAM')
+    expect(find('#study_study_metadata_attributes_bam')).not_to be_checked
+    check 'study_study_metadata_attributes_bam'
+    expect(find('#study_study_metadata_attributes_bam')).to be_checked
     click_button 'Save Study'
     expect(page).to have_content('Your study has been updated')
+    click_link 'Study details'
+    expect(page).to have_content('Alignments in BAM: true')
+  end
+
+  it 'add external customer information', js: true do
+    login_user(user)
+    visit study_path(study)
+    click_link 'Edit'
+    fill_in 'S3 email list', with: 'aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk'
+    select('3 months', from: 'Data deletion period')
+    click_button 'Save Study'
+    expect(page).to have_content('Your study has been updated')
+    study.reload
+    expect(study.study_metadata.s3_email_list).to eq('aa1@sanger.ac.uk;aa2@sanger.ac.uk;aa3@sanger.ac.uk')
+    expect(study.study_metadata.data_deletion_period).to eq('3 months')
+  end
+
+  context 'when data release strategy is Not Applicable' do
+    let!(:study) { create :not_app_study }
+
+    it 'does not error when setting strategy to Open', js: true do
+      study.study_metadata.data_release_strategy = 'not applicable'
+      study.save
+      login_user(user)
+      visit study_path(study)
+      click_link 'Edit'
+      expect(page).to have_content('What is the data release strategy for this study?')
+      expect(page).to have_content('Open (ENA)')
+      choose('Open (ENA)', allow_label_click: true)
+      click_button 'Save Study'
+      expect(page).to have_content('Your study has been updated')
+    end
   end
 end


### PR DESCRIPTION
Steps to reproduce the bug:
- Start with a study where the data release strategy is 'Not Applicable'
- Click Edit Study
- Change the data release strategy to 'Open' or 'Managed'
- Observe that nothing seems to happen on the page, and the following error appears in the JS console:
"An invalid form control with name='study[study_metadata_attributes][data_release_delay_approval]' is not focusable."

This change fixes the above bug. The key line that fixes it is the following:
```
// only enable input if it's not hidden - could be beneath a hidden element in the DOM
if(!$(this).is(':visible')) return;
```
The problem was that it was removing the disabled attribute from inputs that were nested under hidden divs, which meant that the validation fired on save but could not find the field to display the validation message against.

All the other changes are refactoring to try to make it more readable, because I found it quite hard to figure out what was going on!

This javascript file is rendered by the following line in _study.html.erb:
`<% metadata_fields.finalize_related_fields %>`

The other key file to look at to understand this form is form_builder.rb, which seems to be a custom form builder to replace Rails's default one.

P.S. The form still has major validation issues, so the steps to reproduce still produce an error - however, now it is a server side error.