### PR TITLE
Attempt to fix build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ env:
   global:
   - TZ=Europe/London
   - CUCUMBER_FORMAT=DebugFormatter
+branches:
+  only:
+  - master
+  - develop
 before_install:
 - mv config/aker.yml.example config/aker.yml
 - yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
   global:
   - TZ=Europe/London
   - CUCUMBER_FORMAT=DebugFormatter
-branches:
-  only:
-  - master
-  - develop
 before_install:
 - mv config/aker.yml.example config/aker.yml
 - yarn install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ GEM
     safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
This is an attempt to fix the following build issue, which occurs erratically while executing the webdrivers:chromedriver:update command on the rspec or cucumber test jobs:

/home/travis/build/sanger/sequencescape/vendor/bundle/ruby/2.5.0/gems/ffi-1.11.3/lib/ffi/library.rb:112: 
[BUG] Illegal instruction at 0x00007f469b4da5c7
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]

I have downgraded sassc to 2.1.0 from 2.2.1. Got this idea from this post: https://github.com/sass/sassc-ruby/issues/146

It seems to be to do with how it figures out the location of a library it is trying to load. 
Error occurs on line 112 of this ffi file - https://github.com/ffi/ffi/blob/1.11.3/lib/ffi/library.rb
That function gets passed a path to a file from line 11 of this file - https://github.com/sass/sassc-ruby/blob/v2.2.1/lib/sassc/native.rb (2.2.1) / https://github.com/sass/sassc-ruby/blob/v2.1.0/lib/sassc/native.rb (2.1.0)

Branch build has passed 5 times in a row, as opposed to only 1 out of 5 times before I made the change, so hopefully it is fixed?

P.S. Here is a link to a failing build (different branch), just for an easy reference to the error message - https://travis-ci.org/sanger/sequencescape/jobs/624172858