### PR TITLE
Don't restrict builds to certain branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ env:
   global:
   - TZ=Europe/London
   - CUCUMBER_FORMAT=DebugFormatter
-branches:
-  only:
-  - master
-  - develop
 before_install:
 - mv config/aker.yml.example config/aker.yml
 - yarn install


### PR DESCRIPTION
don't restrict to these branches for now, because it sabotaged the 'tag' builds, which we need to create release.tar.gz files for deployment

Possibilities for the future -
- We can restrict to certain branches and explicitly include tag builds, if we decide on a naming convention for the releases
- We could automatically make a tag and build the release.tar.gz on merge into develop / master - we've done this on other repos but issue was making the tag name nice