### PR TITLE
Specify 'sassc' version explicitly in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,6 +150,7 @@ group :development, :test, :cucumber do
   gem 'jquery-ui-rails'
   gem 'knapsack'
   gem 'sass-rails'
+  gem 'sassc', '2.1.0'
   gem 'select2-rails'
   gem 'webmock'
 end


### PR DESCRIPTION
- this is to try to prevent it from being automatically updated
- we need it at this version because build failures happen when it's at 2.2.1 (see pull request https://github.com/sanger/sequencescape/pull/2464)