### PR TITLE
set a default barcode prefix for tube racks (TR)

### DIFF
--- a/app/models/tube_rack/purpose.rb
+++ b/app/models/tube_rack/purpose.rb
@@ -3,6 +3,8 @@
 # The purpose of a tube rack is to hold tubes.
 # Created to hold the size of the tube rack for use when generating manifests.
 class TubeRack::Purpose < ::Purpose
+  self.default_prefix = 'TR'
+
   has_many :sample_manifests, inverse_of: :tube_rack_purpose, dependent: :restrict_with_exception
 
   def self.standard_tube_rack


### PR DESCRIPTION
- the limber:rake task on deploy was inserting a 'null' row into the barcode prefix table
- this prefix is not actually used anywhere yet, because they use fluidx barcodes