### PR TITLE
Add alert to point to new Sequencescape URL

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -259,7 +259,7 @@ module ApplicationHelper
   end
 
   def old_url
-    permitted_urls = ['http://sequencescape.psd.sanger.ac.uk']
+    permitted_urls = ['http://sequencescape.psd.sanger.ac.uk', 'http://uat.sequencescape.psd.sanger.ac.uk', 'http://uat2.sequencescape.psd.sanger.ac.uk', 'http://training.sequencescape.psd.sanger.ac.uk']
     return true unless permitted_urls.include?(request.base_url)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -258,6 +258,7 @@ module ApplicationHelper
     link_to admin_address.to_s, "mailto:#{admin_address}"
   end
 
+  # Used in _header.html.erb. Can be removed after users have been given a time period to switch over.
   def old_url
     permitted_urls = ['http://sequencescape.psd.sanger.ac.uk', 'http://uat.sequencescape.psd.sanger.ac.uk', 'http://uat2.sequencescape.psd.sanger.ac.uk', 'http://training.sequencescape.psd.sanger.ac.uk']
     return true unless permitted_urls.include?(request.base_url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -257,4 +257,9 @@ module ApplicationHelper
     admin_address = configatron.admin_email || 'admin@test.com'
     link_to admin_address.to_s, "mailto:#{admin_address}"
   end
+
+  def old_url
+    permitted_urls = ['http://sequencescape.psd.sanger.ac.uk']
+    return true unless permitted_urls.include?(request.base_url)
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,6 +41,7 @@
 </nav>
 
 <% if old_url %>
+  <!-- This alert can be removed after users have been given a time period to switch over. -->
   <div>
     <%= alert(:warning) do %>
       The Sequencescape URL has changed. Please switch to using the new URL:

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,8 +40,17 @@
   </div><!-- /.navbar-collapse -->
 </nav>
 
-<%- unless custom_text("app_info_box", 1).blank? -%>
-  <div id="app-info-box" class="well well-sm">
-    <span><%= custom_text("app_info_box", 1) %></span>
+<% if old_url %>
+  <div>
+    <%= alert(:warning) do %>
+      The Sequencescape URL has changed. Please switch to using the new URL:
+      <%= link_to 'http://sequencescape.psd.sanger.ac.uk', 'http://sequencescape.psd.sanger.ac.uk', class: "alert-link" %>
+    <% end %>
   </div>
+<% end %>
+
+<%- unless custom_text("app_info_box", 1).blank? -%>
+    <div id="app-info-box" class="well well-sm">
+      <span><%= custom_text("app_info_box", 1) %></span>
+    </div>
 <%- end -%>


### PR DESCRIPTION
display an alert under the navigation bar in the header if the base_url is anything other than http://sequencescape.psd.sanger.ac.uk

- the old_url method is in application_helper.rb, which is available on every page because it is included in application_controller.rb (along with all other helpers)

Putting it above the nav bar had more CSS issues so I've put it underneath so I don't have to fiddle with the CSS.
The placement also matches the 'app_info_box' (which looks like it used to have some styling before a massive rails / bootstrap ugrade (search here for 'app-info-box' if interested - https://github.com/sanger/sequencescape/commit/b5341ab34cdf2e620a351b5645148c564adadc16).