### PR TITLE
Gpl 273 duplex seq library type

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -250,7 +250,8 @@ namespace :limber do
           'Ribozero RNA depletion',
           'Ribozero RNA-seq (Bacterial)',
           'Ribozero RNA-seq (HMR)',
-          'TraDIS'
+          'TraDIS',
+          'Chromium Visium'
         ],
         product_line: 'Bespoke',
         default_purposes: ['LBB Cherrypick'] # It requires default_purpose to accept an array.

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -155,6 +155,12 @@ namespace :limber do
       %w[WGS LCMB].each do |prefix|
         Limber::Helper::RequestTypeConstructor.new(prefix).build!
       end
+
+      Limber::Helper::RequestTypeConstructor.new(
+        'Duplex-Seq',
+        library_types: ['Duplex-Seq']
+      ).build!
+
       Limber::Helper::RequestTypeConstructor.new(
         'PCR Free',
         library_types: ['HiSeqX PCR free', 'PCR Free 384', 'Chromium single cell CNV', 'DAFT-seq'],
@@ -438,6 +444,9 @@ namespace :limber do
 
       lcbm_catalogue = ProductCatalogue.create_with(selection_behaviour: 'SingleProduct').find_or_create_by!(name: 'LCMB')
       Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'LCMB', catalogue: lcbm_catalogue).build!
+
+      duplex_seq_catalogue = ProductCatalogue.create_with(selection_behaviour: 'SingleProduct').find_or_create_by!(name: 'Duplex-Seq')
+      Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'Duplex-Seq', catalogue: duplex_seq_catalogue).build!
 
       mda_catalogue = ProductCatalogue.find_or_create_by!(name: 'GnT MDA')
       Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'GnT MDA', catalogue: mda_catalogue).build!


### PR DESCRIPTION
This code will create one of each of the following:
- Request Type ('Limber Duplex-Seq')
- Library Type ('Duplex-Seq')
- Submission Template ('Limber-Htp - Duplex-Seq')

- Product Catalogue - think this is obsolete, to do with Aker project, but it is required
- Order Role - think this is intended for printing on barcodes, but the existing order roles don't seem to match up to the pipelines very well, and the Adam and Sara didn't recognise them - think in reality the 'prefix' in Limber is used instead. Creating one here to be consistent with the rest of the code in this rake task.