### PR TITLE
GPL-289 - Hi-C library type - Sequencescape half

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -251,7 +251,8 @@ namespace :limber do
           'Ribozero RNA-seq (Bacterial)',
           'Ribozero RNA-seq (HMR)',
           'TraDIS',
-          'Chromium Visium'
+          'Chromium Visium',
+          'Hi-C'
         ],
         product_line: 'Bespoke',
         default_purposes: ['LBB Cherrypick'] # It requires default_purpose to accept an array.


### PR DESCRIPTION
Make the Hi-C Library Type available to 'Limber Bespoke PCR' Request Types
- previously, Hi-C libraries were only received pre-prepared by faculty; now, they are going to be prepared by the Bespoke team in a new pipeline