### PR TITLE
Bugfix local dev - Not printing plate barcodes

### DIFF
--- a/db/seeds/0000_barcode_printer_types.rb
+++ b/db/seeds/0000_barcode_printer_types.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 BarcodePrinterType1DTube.create(name: '1D Tube', printer_type_id: 2, label_template_name: 'sqsc_1dtube_label_template')
-BarcodePrinterType96Plate.create(name: '96 Well Plate', printer_type_id: 1, label_template_name: 'sqsc_96plate_label_template')
+BarcodePrinterType96Plate.create(name: '96 Well Plate', printer_type_id: 1, label_template_name: 'sqsc_96plate_label_template_code39')
 BarcodePrinterType384Plate.create(name: '384 Well Plate', printer_type_id: 6, label_template_name: 'sqsc_384plate_label_template')


### PR DESCRIPTION
When printing barcodes, the string sent is in the format DN... instead of
the previous numeric version. After moving plate labels to code 39 we
can support alphanumeric, but not in ean 13. In local development, the
default label template is not code39, which it causes the label not to be
printed from development machines and appears as empty space in the label.