### PR TITLE
Create a Heron plate from a rack in Sequencescape plate creator UI

### DIFF
--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -32,6 +32,14 @@ class PlatesController < ApplicationController
         if scanned_user.nil?
           flash[:error] = 'Please scan your user barcode'
           format.html { redirect_to(new_plate_path) }
+        elsif tube_rack_sources?
+          if plate_creator.create_plates_from_tube_racks!(tube_racks, barcode_printer, scanned_user)
+            flash[:notice] = 'Created and printed barcodes from tube rack into plates'
+            format.html { redirect_to(new_plate_path) }
+          else
+            flash[:error] = 'Failed to create plates'
+            format.html { redirect_to(new_plate_path) }
+          end
         elsif plate_creator.execute(source_plate_barcodes, barcode_printer, scanned_user, Plate::CreatorParameters.new(params[:plates]))
           flash[:notice] = 'Created plates and printed barcodes'
           format.html { redirect_to(new_plate_path) }
@@ -46,6 +54,22 @@ class PlatesController < ApplicationController
       flash[:error] = e.message
       format.html { redirect_to(new_plate_path) }
     end
+  end
+
+  def tube_rack_barcodes
+    return [] unless params.dig(:plates).dig(:source_plates)
+
+    params[:plates][:source_plates].split(/[\s,]+/)
+  end
+
+  def tube_rack_sources?
+    return false if tube_rack_barcodes.empty?
+
+    tube_racks.count == tube_rack_barcodes.length
+  end
+
+  def tube_racks
+    @tube_racks ||= TubeRack.joins(:barcodes).where(barcodes: { barcode: tube_rack_barcodes })
   end
 
   def to_sample_tubes

--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -37,7 +37,7 @@ class PlatesController < ApplicationController
             flash[:notice] = 'Created and printed barcodes from tube rack into plates'
             format.html { redirect_to(new_plate_path) }
           else
-            flash[:error] = 'Failed to create plates'
+            flash[:error] = 'Failed to print plate barcodes'
             format.html { redirect_to(new_plate_path) }
           end
         elsif plate_creator.execute(source_plate_barcodes, barcode_printer, scanned_user, Plate::CreatorParameters.new(params[:plates]))

--- a/app/heron/factories/plate.rb
+++ b/app/heron/factories/plate.rb
@@ -6,20 +6,17 @@ module Heron
     class Plate
       include ActiveModel::Model
 
-      PURPOSE_NAME = 'RNA Stock Plate'
+      attr_accessor :tube_rack, :plate, :plate_purpose
 
-      attr_accessor :tube_rack, :plate
-
-      validates_presence_of :tube_rack
+      validates_presence_of :tube_rack, :plate_purpose
       validate :check_tube_rack_persisted
 
       def save
         return false unless valid?
 
         ActiveRecord::Base.transaction do
-          purpose = PlatePurpose.where(name: PURPOSE_NAME).first
-          @plate = purpose.create!
-          ExtractionAttribute.create!(attributes_update: plate_contents, target: plate, created_by: 'heron')
+          @plate = plate_purpose.create!
+          ExtractionAttribute.create!(attributes_update: plate_contents, target: @plate, created_by: 'heron')
 
           AssetLink.create_edge(tube_rack, plate)
         end

--- a/app/heron/factories/tube.rb
+++ b/app/heron/factories/tube.rb
@@ -53,9 +53,10 @@ module Heron
       end
 
       def create_sample!
+        sanger_sample_id = create_sanger_sample_id!
         Sample.create!(
-          sanger_sample_id: create_sanger_sample_id!,
-          name: supplier_sample_id
+          name: sanger_sample_id,
+          sanger_sample_id: sanger_sample_id
         ) do |sample|
           sample.sample_metadata.update!(
             sample_public_name: supplier_sample_id,

--- a/app/heron/factories/tube_rack.rb
+++ b/app/heron/factories/tube_rack.rb
@@ -6,7 +6,7 @@ module Heron
     class TubeRack
       include ActiveModel::Model
 
-      HERON_STUDY = 1
+      HERON_STUDY = 6187
       LOCATION_REGEXP = /[A-Z][0-9]{0,1}[0-9]/.freeze
       RACK_SIZE = 96
 

--- a/app/heron/factories/tube_rack.rb
+++ b/app/heron/factories/tube_rack.rb
@@ -6,7 +6,7 @@ module Heron
     class TubeRack
       include ActiveModel::Model
 
-      HERON_STUDY = 6187
+      HERON_STUDY = 1
       LOCATION_REGEXP = /[A-Z][0-9]{0,1}[0-9]/.freeze
       RACK_SIZE = 96
 
@@ -39,7 +39,7 @@ module Heron
 
         ActiveRecord::Base.transaction do
           purpose = Purpose.where(target_type: 'TubeRack', size: ::Heron::Factories::TubeRack::RACK_SIZE).first
-          tube_rack = ::TubeRack.create!(size: ::Heron::Factories::TubeRack::RACK_SIZE, plate_purpose_id: purpose&.id)
+          @tube_rack = ::TubeRack.create!(size: ::Heron::Factories::TubeRack::RACK_SIZE, plate_purpose_id: purpose&.id)
 
           Barcode.create!(asset: tube_rack, barcode: barcode, format: barcode_format)
 
@@ -50,11 +50,18 @@ module Heron
 
       private
 
+      def unpad_location(location)
+        return location unless location
+
+        loc = location.match(/(\w)(0*)(\d*)/)
+        loc[1] + loc[3]
+      end
+
       def create_tubes!(tube_rack)
         tubes.keys.map do |location|
           tube_factory = tubes[location]
           sample_tube = tube_factory.create
-          racked_tubes << RackedTube.create(tube: sample_tube, coordinate: location,
+          racked_tubes << RackedTube.create(tube: sample_tube, coordinate: unpad_location(location),
                                             tube_rack: tube_rack)
         end
       end

--- a/spec/heron/factories/plate_spec.rb
+++ b/spec/heron/factories/plate_spec.rb
@@ -3,15 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe Heron::Factories::Plate, type: :model, heron: true do
+  let(:purpose) do
+    create(:plate_purpose, target_type: 'Plate', name: 'Stock Plate', size: '96')
+  end
+  let(:rack) { create :tube_rack }
+  let(:plate_factory) { described_class.new(tube_rack: rack, plate_purpose: purpose) }
+  let(:tubes) { create_list(:sample_tube, 2) }
+
   include BarcodeHelper
+
   before do
-    create(:plate_purpose, target_type: 'Plate', name: 'RNA Stock Plate', size: '96')
     mock_plate_barcode_service
   end
-
-  let(:rack) { create :tube_rack }
-  let(:plate_factory) { described_class.new(tube_rack: rack) }
-  let(:tubes) { create_list(:sample_tube, 2) }
 
   it 'can build a valid plate factory from a rack' do
     expect(plate_factory).to be_valid

--- a/spec/heron/factories/tube_rack_spec.rb
+++ b/spec/heron/factories/tube_rack_spec.rb
@@ -92,5 +92,12 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
       tube_rack.racked_tubes
       expect(RackedTube.count).to eq(2)
     end
+
+    it 'pads the locations before saving them' do
+      tube_rack = described_class.new(params)
+      tube_rack.save
+      tube_rack.racked_tubes
+      expect(tube_rack.racked_tubes.first.coordinate).to eq('A1')
+    end
   end
 end

--- a/spec/heron/factories/tube_spec.rb
+++ b/spec/heron/factories/tube_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe Heron::Factories::Tube, type: :model, heron: true do
       end.to change(Sample, :count).by(1)
     end
 
-    it 'creates a tube with the name as supplier_sample_id from MLWH' do
+    it 'creates a tube with the name as sanger_sample_id' do
       tube = described_class.new(params)
       sample_tube = tube.create
-      expect(sample_tube.samples.first.name).to eq('PHEC-nnnnnnn1')
+      expect(sample_tube.samples.first.name).not_to be_nil
+      expect(sample_tube.samples.first.name).to eq(sample_tube.samples.first.sanger_sample_id)
     end
 
     it 'creates a tube with the public name as supplier_sample_id from MLWH' do


### PR DESCRIPTION
* Be able to create plates from stock plates by printing the barcode from the plate creator UI in Sequencescape

* *Bugfix* Coordinates from racks were not unpadded, which it created problems when creating plates from them.

* Support to create any plate purpose available in plate creation view