### PR TITLE
Allow to receive a size argument to be able to create racks of 96 or 48 tubes.

### DIFF
--- a/app/controllers/api/v2/heron/tube_racks_controller.rb
+++ b/app/controllers/api/v2/heron/tube_racks_controller.rb
@@ -20,7 +20,7 @@ module Api
         private
 
         def params_for_tube_rack
-          params.require(:data).require(:attributes).require(:tube_rack).permit(:barcode, tubes: %i[barcode supplier_sample_id coordinate])
+          params.require(:data).require(:attributes).require(:tube_rack).permit(:barcode, :size, tubes: %i[barcode supplier_sample_id coordinate])
         end
       end
     end

--- a/app/models/tube_rack.rb
+++ b/app/models/tube_rack.rb
@@ -7,6 +7,7 @@ class TubeRack < Labware
 
   include Barcode::Barcodeable
 
+  belongs_to :plate_purpose
   has_many :racked_tubes, dependent: :destroy, inverse_of: :tube_rack
   has_many :tubes, through: :racked_tubes
   has_many :contained_samples, through: :tubes, source: :samples

--- a/spec/controllers/api/v2/heron/tube_racks_controller_spec.rb
+++ b/spec/controllers/api/v2/heron/tube_racks_controller_spec.rb
@@ -4,8 +4,10 @@ require 'rails_helper'
 require 'support/barcode_helper'
 
 RSpec.describe Api::V2::Heron::TubeRacksController, type: :request, heron: true do
+  let(:size) { 96 }
+
   before do
-    create(:purpose, target_type: 'TubeRack', size: Heron::Factories::TubeRack::RACK_SIZE)
+    create(:plate_purpose, target_type: 'TubeRack', size: 96)
     create(:study, id: Heron::Factories::TubeRack::HERON_STUDY)
   end
 
@@ -33,6 +35,7 @@ RSpec.describe Api::V2::Heron::TubeRacksController, type: :request, heron: true 
         "data": {
           "attributes": {
             "tube_rack": {
+              "size": size,
               "barcode": tube_rack_barcode,
               "tubes": tubes
             }
@@ -72,6 +75,12 @@ RSpec.describe Api::V2::Heron::TubeRacksController, type: :request, heron: true 
     end
 
     context 'when there is some data missing/incorrect' do
+      context 'when there is not plate purpose that match the rack size' do
+        let(:size) { 33 }
+
+        it_behaves_like 'an incorrect tube rack message'
+      end
+
       context 'when the tube rack doesnt have a barcode' do
         let(:tube_rack_barcode) { nil }
 

--- a/spec/heron/factories/tube_rack_spec.rb
+++ b/spec/heron/factories/tube_rack_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
     expect(tube_rack).not_to be_valid
   end
 
+  it 'is not valid without the size' do
+    tube_rack = described_class.new(params.except(:size))
+    expect(tube_rack).not_to be_valid
+  end
+
+  it 'is not valid if the size do not match a purpose' do
+    params[:size] = 44
+    tube_rack = described_class.new(params)
+    expect(tube_rack).not_to be_valid    
+  end
+
   it 'is not valid without tubes' do
     tube_rack = described_class.new(params.except(:tubes))
     expect(tube_rack).not_to be_valid

--- a/spec/heron/factories/tube_rack_spec.rb
+++ b/spec/heron/factories/tube_rack_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
   it 'is not valid if the size do not match a purpose' do
     params[:size] = 44
     tube_rack = described_class.new(params)
-    expect(tube_rack).not_to be_valid    
+    expect(tube_rack).not_to be_valid
   end
 
   it 'is not valid without tubes' do

--- a/spec/heron/factories/tube_rack_spec.rb
+++ b/spec/heron/factories/tube_rack_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
   before do
-    create(:purpose, target_type: 'TubeRack', size: Heron::Factories::TubeRack::RACK_SIZE)
     create(:study, id: Heron::Factories::TubeRack::HERON_STUDY)
   end
 
   let(:params) do
     {
       "barcode": '0000000001',
+      "size": '96',
       "tubes": [
         {
           "coordinate": 'A01',
@@ -32,6 +32,9 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
       "barcode": 'FD00000003'
     }
   end
+
+  let!(:purpose_96) { create(:plate_purpose, target_type: 'TubeRack', size: 96) }
+  let!(:purpose_48) { create(:plate_purpose, target_type: 'TubeRack', size: 48) }
 
   it 'is valid with all relevant attributes' do
     tube_rack = described_class.new(params)
@@ -79,6 +82,23 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
     it 'returns true if it saves correctly' do
       tube_rack = described_class.new(params)
       expect(tube_rack.save).to be_truthy
+    end
+
+    it 'creates the rack' do
+      tube_rack = described_class.new(params)
+      expect { tube_rack.save }.to change(TubeRack, :count).by(1)
+    end
+
+    it 'can create a 96 rack' do
+      tube_rack = described_class.new(params.merge(size: 96))
+      tube_rack.save
+      expect(tube_rack.tube_rack.plate_purpose).to eq(purpose_96)
+    end
+
+    it 'can create a 48 rack' do
+      tube_rack = described_class.new(params.merge(size: 48))
+      tube_rack.save
+      expect(tube_rack.tube_rack.plate_purpose).to eq(purpose_48)
     end
 
     it 'creates the tubes' do


### PR DESCRIPTION

Closes GPL-367 .

Changes proposed in this pull request:
* Allow to receive the size argument from tube rack wrangler and create a tube rack using the purpose that matches that size as it is stored in the database
