### PR TITLE
Sample public name rolled back to be nil

### DIFF
--- a/app/heron/factories/tube.rb
+++ b/app/heron/factories/tube.rb
@@ -59,7 +59,6 @@ module Heron
           sanger_sample_id: sanger_sample_id
         ) do |sample|
           sample.sample_metadata.update!(
-            sample_public_name: supplier_sample_id,
             supplier_name: supplier_sample_id
           )
           sample.studies << study

--- a/spec/heron/factories/tube_spec.rb
+++ b/spec/heron/factories/tube_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe Heron::Factories::Tube, type: :model, heron: true do
       expect(sample_tube.samples.first.name).to eq(sample_tube.samples.first.sanger_sample_id)
     end
 
-    it 'creates a tube with the public name as supplier_sample_id from MLWH' do
+    it 'creates a tube with the public name set to nil' do
       tube = described_class.new(params)
       sample_tube = tube.create
-      expect(sample_tube.samples.first.sample_metadata.sample_public_name).to eq('PHEC-nnnnnnn1')
+      expect(sample_tube.samples.first.sample_metadata.sample_public_name).to be_nil
     end
 
     it 'creates a tube with the supplier name as supplier_sample_id from MLWH' do


### PR DESCRIPTION
Closes GPL356 .

Changes proposed in this pull request:
* Public name will not store any value
