### PR TITLE
Database uses TubeRack::Purpose to represent tube rack purposes. 

### DIFF
--- a/app/heron/factories/tube_rack.rb
+++ b/app/heron/factories/tube_rack.rb
@@ -11,7 +11,7 @@ module Heron
 
       attr_accessor :barcode, :sample_tubes, :tube_rack, :size
 
-      validates_presence_of :barcode, :tubes, :heron_study, :size, :plate_purpose
+      validates_presence_of :barcode, :tubes, :heron_study, :size, :purpose
 
       validate :check_tubes, :check_rack_barcode
 
@@ -29,8 +29,8 @@ module Heron
         @racked_tubes ||= []
       end
 
-      def plate_purpose
-        @plate_purpose ||= Purpose.where(target_type: 'TubeRack', size: size).first
+      def purpose
+        @purpose ||= ::TubeRack::Purpose.where(target_type: 'TubeRack', size: size).first
       end
 
       def tubes
@@ -41,7 +41,7 @@ module Heron
         return false unless valid?
 
         ActiveRecord::Base.transaction do
-          @tube_rack = ::TubeRack.create!(size: size, plate_purpose: plate_purpose)
+          @tube_rack = ::TubeRack.create!(size: size, purpose: purpose)
 
           Barcode.create!(asset: tube_rack, barcode: barcode, format: barcode_format)
 

--- a/app/models/tube_rack.rb
+++ b/app/models/tube_rack.rb
@@ -7,7 +7,6 @@ class TubeRack < Labware
 
   include Barcode::Barcodeable
 
-  belongs_to :plate_purpose
   has_many :racked_tubes, dependent: :destroy, inverse_of: :tube_rack
   has_many :tubes, through: :racked_tubes
   has_many :contained_samples, through: :tubes, source: :samples

--- a/spec/controllers/api/v2/heron/tube_racks_controller_spec.rb
+++ b/spec/controllers/api/v2/heron/tube_racks_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V2::Heron::TubeRacksController, type: :request, heron: true 
   let(:size) { 96 }
 
   before do
-    create(:plate_purpose, target_type: 'TubeRack', size: 96)
+    create(:purpose, type: 'TubeRack::Purpose', target_type: 'TubeRack', size: 96)
     create(:study, id: Heron::Factories::TubeRack::HERON_STUDY)
   end
 

--- a/spec/heron/factories/tube_rack_spec.rb
+++ b/spec/heron/factories/tube_rack_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
     }
   end
 
-  let!(:purpose_96) { create(:plate_purpose, target_type: 'TubeRack', size: 96) }
-  let!(:purpose_48) { create(:plate_purpose, target_type: 'TubeRack', size: 48) }
+  let!(:purpose_96) { create(:tube_rack_purpose, target_type: 'TubeRack', size: 96) }
+  let!(:purpose_48) { create(:tube_rack_purpose, target_type: 'TubeRack', size: 48) }
 
   it 'is valid with all relevant attributes' do
     tube_rack = described_class.new(params)
@@ -103,13 +103,13 @@ RSpec.describe Heron::Factories::TubeRack, type: :model, heron: true do
     it 'can create a 96 rack' do
       tube_rack = described_class.new(params.merge(size: 96))
       tube_rack.save
-      expect(tube_rack.tube_rack.plate_purpose).to eq(purpose_96)
+      expect(tube_rack.tube_rack.purpose).to eq(purpose_96)
     end
 
     it 'can create a 48 rack' do
       tube_rack = described_class.new(params.merge(size: 48))
       tube_rack.save
-      expect(tube_rack.tube_rack.plate_purpose).to eq(purpose_48)
+      expect(tube_rack.tube_rack.purpose).to eq(purpose_48)
     end
 
     it 'creates the tubes' do


### PR DESCRIPTION
Added changes to find this specific type of purpose.

Closes GPL367 .

Changes proposed in this pull request:

* Find TubeRack::Purpose instead of plate purpose for tube rack creation
