### PR TITLE
Bugfix printer failure avoids creating plates

### DIFF
--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -42,7 +42,7 @@ class PlatesController < ApplicationController
       end
       format.html { render(new_plate_path) }
     end
-  rescue Plate::Creator::PlateCreationError, ActiveRecord::RecordNotFound => e
+  rescue StandardError => e
     respond_to do |format|
       flash[:error] = e.message
       format.html { render(new_plate_path) }

--- a/app/controllers/plates_controller.rb
+++ b/app/controllers/plates_controller.rb
@@ -20,29 +20,27 @@ class PlatesController < ApplicationController
   end
 
   def create
-    ActiveRecord::Base.transaction do
-      @creator = plate_creator = Plate::Creator.find(params[:plates][:creator_id])
-      barcode_printer = BarcodePrinter.find(params[:plates][:barcode_printer])
-      source_plate_barcodes = params[:plates][:source_plates]
+    @creator = plate_creator = Plate::Creator.find(params[:plates][:creator_id])
+    barcode_printer = BarcodePrinter.find(params[:plates][:barcode_printer])
+    source_plate_barcodes = params[:plates][:source_plates]
 
-      scanned_user = User.find_with_barcode_or_swipecard_code(params[:plates][:user_barcode])
+    scanned_user = User.find_with_barcode_or_swipecard_code(params[:plates][:user_barcode])
 
-      respond_to do |format|
-        if scanned_user.nil?
-          flash[:error] = 'Please scan your user barcode'
-        elsif tube_rack_sources?
-          if plate_creator.create_plates_from_tube_racks!(tube_racks, barcode_printer, scanned_user)
-            flash[:notice] = 'Created and printed barcodes from tube rack into plates'
-          else
-            flash[:error] = 'Failed to print plate barcodes'
-          end
-        elsif plate_creator.execute(source_plate_barcodes, barcode_printer, scanned_user, Plate::CreatorParameters.new(params[:plates]))
-          flash[:notice] = 'Created plates and printed barcodes'
+    respond_to do |format|
+      if scanned_user.nil?
+        flash[:error] = 'Please scan your user barcode'
+      elsif tube_rack_sources?
+        if plate_creator.create_plates_from_tube_racks!(tube_racks, barcode_printer, scanned_user)
+          flash[:notice] = 'Created and printed barcodes from tube rack into plates'
         else
-          flash[:error] = 'Failed to create plates'
+          flash[:error] = 'Failed to print plate barcodes'
         end
-        format.html { render(new_plate_path) }
+      elsif plate_creator.execute(source_plate_barcodes, barcode_printer, scanned_user, Plate::CreatorParameters.new(params[:plates]))
+        flash[:notice] = 'Created plates and printed barcodes'
+      else
+        flash[:error] = 'Failed to create plates'
       end
+      format.html { render(new_plate_path) }
     end
   rescue Plate::Creator::PlateCreationError, ActiveRecord::RecordNotFound => e
     respond_to do |format|

--- a/test/controllers/plates_controller_test.rb
+++ b/test/controllers/plates_controller_test.rb
@@ -76,24 +76,32 @@ class PlatesControllerTest < ActionController::TestCase
               tube_rack_factory.save
               @tube_rack = tube_rack_factory.tube_rack
               @plate_count = Plate.count
-              post :create, params: { plates: { creator_id: @dilution_plates_creator.id,
-                                                source_plates: @tube_rack.barcodes.first.barcode,
-                                                barcode_printer: @barcode_printer.id, user_barcode: '1234567' } }
             end
 
-            should 'change Plate.count by 1' do
-              assert_equal 1, Plate.count - @plate_count, 'Expected Plate.count to change by 1'
-            end
-            should respond_with :ok
-            should set_flash.to(/Created/)
+            context 'when creating a plate from a tube rack' do
+              setup do
+                post :create, params: { plates: { creator_id: @dilution_plates_creator.id,
+                                                  source_plates: @tube_rack.barcodes.first.barcode,
+                                                  barcode_printer: @barcode_printer.id, user_barcode: '1234567' } }
+              end
 
-            should 'display the printed barcode' do
-              assert_equal(true, response.body.include?(@tube_rack.children.first.barcodes.first.barcode))
+              should 'change Plate.count by 1' do
+                assert_equal 1, Plate.count - @plate_count, 'Expected Plate.count to change by 1'
+              end
+              should respond_with :ok
+              should set_flash.to(/Created/)
+
+              should 'display the printed barcode' do
+                assert_equal(true, response.body.include?(@tube_rack.children.first.barcodes.first.barcode))
+              end
             end
 
             context 'when the printer fails to print' do
               setup do
                 LabelPrinter::PrintJob.stubs(:new).raises('Boom!!')
+                post :create, params: { plates: { creator_id: @dilution_plates_creator.id,
+                                                  source_plates: @tube_rack.barcodes.first.barcode,
+                                                  barcode_printer: @barcode_printer.id, user_barcode: '1234567' } }
               end
               should 'still display the printed barcode' do
                 assert_equal(true, response.body.include?(@tube_rack.children.first.barcodes.first.barcode))

--- a/test/controllers/plates_controller_test.rb
+++ b/test/controllers/plates_controller_test.rb
@@ -90,6 +90,19 @@ class PlatesControllerTest < ActionController::TestCase
             should 'display the printed barcode' do
               assert_equal(true, response.body.include?(@tube_rack.children.first.barcodes.first.barcode))
             end
+
+            context 'when the printer fails to print' do
+              setup do
+                LabelPrinter::PrintJob.stubs(:new).raises('Boom!!')
+              end
+              should 'still display the printed barcode' do
+                assert_equal(true, response.body.include?(@tube_rack.children.first.barcodes.first.barcode))
+              end
+              should 'keep the created labware persisted' do
+                barcode = @tube_rack.children.first.barcodes.first.barcode
+                assert_equal(1, Plate.joins(:barcodes).where(barcodes: { barcode: barcode }).count)
+              end
+            end
           end
 
           context 'with one source plate' do


### PR DESCRIPTION
When the printer raises an exception, the created plates are rolled back from the database, but we want to keep them.