### PR TITLE
gpl375 Deduplication of aliquots in transfer requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
     before_script:
     - bundle exec rake assets:precompile
     - bundle exec rake db:setup
-    script: bundle exec rake test -f
+    script: bundle exec rake test
     name: Rake Test
   - if: type != cron AND tag IS blank
     env:

--- a/app/api/core/service/error_handling.rb
+++ b/app/api/core/service/error_handling.rb
@@ -7,7 +7,8 @@ module Core::Service::ErrorHandling
         ::IllegalOperation,
         ::Core::Service::Error,
         ActiveRecord::ActiveRecordError,
-        ActiveModel::ValidationError
+        ActiveModel::ValidationError,
+        Aliquot::TagClash
       ) do
         buffer = [exception_thrown.message, exception_thrown.backtrace].join("\n")
         Rails.logger.error("API[error]: #{buffer}")
@@ -96,3 +97,5 @@ class IllegalOperation < RuntimeError
   self.api_error_code    = 501
   self.api_error_message = 'requested action is not supported on this resource'
 end
+
+Aliquot::TagClash.api_error_code = 422

--- a/app/api/core/service/error_handling.rb
+++ b/app/api/core/service/error_handling.rb
@@ -98,4 +98,5 @@ class IllegalOperation < RuntimeError
   self.api_error_message = 'requested action is not supported on this resource'
 end
 
+Aliquot::TagClash.include ::Core::Service::Error::Behaviour
 Aliquot::TagClash.api_error_code = 422

--- a/app/api/endpoints/transfer_request_collections.rb
+++ b/app/api/endpoints/transfer_request_collections.rb
@@ -1,7 +1,10 @@
 module Endpoints
   class TransferRequestCollections < ::Core::Endpoint::Base
     model do
-      action(:create, to: :standard_create!)
+      # action(:create, to: :standard_create!)
+      action(:create) do |request, response|
+        standard_create!(request, response)
+      end
     end
 
     instance do

--- a/app/api/endpoints/transfer_request_collections.rb
+++ b/app/api/endpoints/transfer_request_collections.rb
@@ -1,10 +1,7 @@
 module Endpoints
   class TransferRequestCollections < ::Core::Endpoint::Base
     model do
-      # action(:create, to: :standard_create!)
-      action(:create) do |request, response|
-        standard_create!(request, response)
-      end
+      action(:create, to: :standard_create!)
     end
 
     instance do

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -24,7 +24,8 @@ class Aliquot < ApplicationRecord
 
   self.lazy_uuid_generation = true
 
-  TagClash = Class.new(ActiveRecord::RecordInvalid)
+  # TagClash = Class.new(ActiveRecord::RecordInvalid)
+  TagClash = Class.new(StandardError)
 
   # An aliquot can represent a library, which is a processed sample that has been fragmented.  In which case it
   # has a receptacle that held the library aliquot and has an insert size describing the fragment positions.


### PR DESCRIPTION
Closes GPL375

Changes proposed in this pull request:

* Added deduplication of aliquots when copying from multiple plates.
* TagClash error raised again by the API as it was not working.

Relates to Limber <https://github.com/sanger/limber/issues/410>
