### PR TITLE
Improved robustness of aliquot equivalence check

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -95,6 +95,13 @@ class Aliquot < ApplicationRecord
       .count
   end
 
+  # Returns a list of attributes which must be the same for two Aliquots to be considered
+  # {#equivalent?} Generated dynamically to avoid accidental introduction of false positives
+  # when new columns are added
+  def self.equivalent_attributes
+    @equivalent_attributes ||= attribute_names - %w[id receptacle_id created_at updated_at]
+  end
+
   def aliquot_index_value
     aliquot_index.try(:aliquot_index)
   end
@@ -181,10 +188,7 @@ class Aliquot < ApplicationRecord
   # Unlike the above methods, which allow untagged to match with tagged, this looks for exact matches only
   # only id, timestamps and receptacles are excluded
   def equivalent?(other)
-    %i[
-      sample_id tag_id tag2_id library_id bait_library_id
-      insert_size_from insert_size_to library_type project_id study_id
-    ].all? do |attrib|
+    Aliquot.equivalent_attributes.all? do |attrib|
       send(attrib) == other.send(attrib)
     end
   end


### PR DESCRIPTION
The previous version of the check compared hard-coded
attributes when checking equivalence. This resulted in
newer columns, such as primer_panel_id getting missed
from the check.

To avoid the need to remember that this method needs to
be updated when extending Aliquot, the columns to compare
are now generated dynamically from the database columns.
Columns which are permitted to change are now whitelisted.

This should substantially reduce the risk of future bugs
being introduced, and will ensure that the comparison
remains conservative, rather than permissive.

Closes #

Changes proposed in this pull request:

*
*
* ...
