### PR TITLE
GPL-374 fix - label templates

### DIFF
--- a/lib/label_printer/label_printer/label/asset_plate.rb
+++ b/lib/label_printer/label_printer/label/asset_plate.rb
@@ -8,11 +8,15 @@ module LabelPrinter
       end
 
       def top_right(plate)
-        "#{plate.prefix} #{plate.barcode_number}"
+        plate.plate_purpose.name.to_s
       end
 
       def bottom_right(plate)
-        "#{plate.name_for_label} #{plate.barcode_number}"
+        plate.studies.first&.abbreviation
+      end
+
+      def top_far_right(plate)
+        plate.parent.try(:barcode_number).to_s
       end
     end
   end

--- a/spec/lib/label_printer/asset_labels_spec.rb
+++ b/spec/lib/label_printer/asset_labels_spec.rb
@@ -32,9 +32,9 @@ context 'printing plates' do
         { main_label:
           { top_left: date,
             bottom_left: asset.human_barcode.to_s,
-            top_right: "#{asset.prefix} #{asset.barcode_number}",
-            bottom_right: "#{asset.name_for_label} #{asset.barcode_number}",
-            top_far_right: nil,
+            top_right: asset.plate_purpose.name.to_s,
+            bottom_right: asset.studies.first&.abbreviation,
+            top_far_right: asset.parent.try(:barcode_number).to_s,
             barcode: asset.machine_barcode.to_s } }
       end
     end


### PR DESCRIPTION
Make AssetPlate template similar to PlateCreator template
- without the user login as there is no scanned user barcode in this context
- handling plate purposes in a different way because there is no plate purposes selected on the page in this context