### PR TITLE
GPL-383-2 - minor issue - First message after database error was sent to deadletter without requeuing

### DIFF
--- a/lib/postman/message.rb
+++ b/lib/postman/message.rb
@@ -12,6 +12,7 @@ class Postman
       /Mysql2::Error: closed MySQL connection:/, # 2013,
       /Mysql2::Error: MySQL server has gone away/, # 2006
       /Mysql2::Error: Can't connect to local MySQL server through socket/, # , 2002, 2001, 2003, 2004, 2005,
+      /Mysql2::Error::ConnectionError: Lost connection to MySQL server during query/, # Bugfix - First message was always lost
       /Mysql2::Error: MySQL client is not connected/
     ].freeze
 


### PR DESCRIPTION
When first detecting a mysql connection error, the first exception we receive was not
in the list to use for retrying (requeueing) so the first message was going to deadletters.

Closes #2626 

Related to: sanger/General-Backlog-Items/issues/20

This pull request and the associated merge request 75 into psd-deployment are workarounds (this one solving a minor issue).