### PR TITLE
Add Kingfisher Plate type to PlateType list

### DIFF
--- a/config/default_records/plate_types/plate_types.yml
+++ b/config/default_records/plate_types/plate_types.yml
@@ -1,0 +1,11 @@
+---
+ABgene_0765:
+  maximum_volume: 800
+ABgene_0800:
+  maximum_volume: 180
+FluidX075:
+  maximum_volume: 500
+FluidX03:
+  maximum_volume: 280
+KingFisher 96 2ml:
+  maximum_volume: 2000

--- a/db/seeds/plate_types.rb
+++ b/db/seeds/plate_types.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-plate_types_with_maximum_volume = { 'ABgene_0765' => 800, 'ABgene_0800' => 180, 'FluidX075' => 500, 'FluidX03' => 280 }
+plate_types_with_maximum_volume = {
+  'ABgene_0765' => 800,
+  'ABgene_0800' => 180,
+  'FluidX075' => 500,
+  'FluidX03' => 280,
+  'KingFisher 96 2ml' => 2000
+}
 
 plate_types_with_maximum_volume.each do |name, maximum_volume|
   PlateType.create!(name: name, maximum_volume: maximum_volume)

--- a/db/seeds/plate_types.rb
+++ b/db/seeds/plate_types.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-plate_types_with_maximum_volume = {
-  'ABgene_0765' => 800,
-  'ABgene_0800' => 180,
-  'FluidX075' => 500,
-  'FluidX03' => 280,
-  'KingFisher 96 2ml' => 2000
-}
-
-plate_types_with_maximum_volume.each do |name, maximum_volume|
-  PlateType.create!(name: name, maximum_volume: maximum_volume)
-end
+# Automatically generate the plate types listed in
+# config/default_records/plate_types/*.yml
+RecordLoader::PlateTypeLoader.new.create!

--- a/lib/record_loader/plate_type_loader.rb
+++ b/lib/record_loader/plate_type_loader.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module RecordLoader
+  # Creates the specified plate types if they are not present
+  class PlateTypeLoader < RecordLoader::Base
+    self.config_folder = 'plate_types'
+
+    def create!
+      ActiveRecord::Base.transaction do
+        @config.each do |name, options|
+          PlateType.create_with(options).find_or_create_by!(name: name)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/plate_type_update.rake
+++ b/lib/tasks/plate_type_update.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :plate_type do
+  desc 'Automatically generate absent plate types'
+  task update: :environment do
+    RecordLoader::PlateTypeLoader.new.create!
+  end
+end


### PR DESCRIPTION
Closes #2621

Changes proposed in this pull request:

* Add Kingfisher Plate Type to seeds
* Add a RecordLoader for maintaining PlateTypes
* rake plate_type:update will automatically update plate
types

Alternatively:
> bundle exec rails c
> PlateType.create_with(maximum_volume: 2000).find_or_create_by!(name: 'KingFisher 96 2ml')

