### PR TITLE
Add library only submission templates for heron

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -513,6 +513,8 @@ namespace :limber do
 
       heron_catalogue = ProductCatalogue.find_or_create_by!(name: 'Heron')
       Limber::Helper::TemplateConstructor.new(prefix: 'Heron', catalogue: heron_catalogue, sequencing_keys: base_list).build!
+      Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'Heron', catalogue: heron_catalogue).build!
+      Limber::Helper::LibraryAndMultiplexingTemplateConstructor.new(prefix: 'Heron', catalogue: heron_catalogue).build!
 
       lcbm_catalogue = ProductCatalogue.create_with(selection_behaviour: 'SingleProduct').find_or_create_by!(name: 'LCMB')
       Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'LCMB', catalogue: lcbm_catalogue).build!


### PR DESCRIPTION
fixes #2615

Templates will be generated on running either:
`bundle exec rake limber:setup`
OR
`bundle exec rake limber:create_submission_templates`