### PR TITLE
GPL-394 Asset audits bed verification

### DIFF
--- a/app/resources/api/v2/tube_rack_resource.rb
+++ b/app/resources/api/v2/tube_rack_resource.rb
@@ -37,7 +37,6 @@ module Api
           'human_barcode' => _model.human_barcode
         }
       end
-
     end
   end
 end

--- a/app/resources/api/v2/tube_rack_resource.rb
+++ b/app/resources/api/v2/tube_rack_resource.rb
@@ -17,6 +17,7 @@ module Api
 
       # Attributes
       attribute :uuid, readonly: true
+      attribute :labware_barcode, readonly: true
 
       # Filters
 
@@ -25,6 +26,18 @@ module Api
       # I/O and isolating implementation details.
 
       # Class method overrides
+
+      # Custom methods
+      # These shouldn't be used for business logic, and are more about
+      # I/O and isolating implementation details.
+      def labware_barcode
+        {
+          'ean13_barcode' => _model.ean13_barcode,
+          'machine_barcode' => _model.machine_barcode,
+          'human_barcode' => _model.human_barcode
+        }
+      end
+
     end
   end
 end


### PR DESCRIPTION
Changed call from Asset Audits to use v2 API rather than v1
- It needs this added to the Tube Rack resource, to match the Plate resource...
- ...if the parent of the 'destination plate' in bed verification is a TubeRack rather than a Plate
