### PR TITLE
Add heron foreign barcode support

### DIFF
--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -17,9 +17,23 @@ class Barcode < ApplicationRecord
   after_commit :broadcast_barcode
 
   # Caution! Do not adjust the index of existing formats.
-  enum format: { sanger_ean13: 0, infinium: 1, fluidigm: 2, external: 3, aker_barcode: 4, cgap: 5, sanger_code39: 6, fluidx_barcode: 7 }
+  enum format: {
+    sanger_ean13: 0,
+    infinium: 1,
+    fluidigm: 2,
+    external: 3,
+    aker_barcode: 4,
+    cgap: 5,
+    sanger_code39: 6,
+    fluidx_barcode: 7,
+    uk_biocentre_v1: 8,
+    uk_biocentre_v2: 9,
+    alderly_park_v1: 10,
+    alderly_park_v2: 11
+  }
+
   # Barcode formats which may be submitted via sample manifests
-  FOREIGN_BARCODE_FORMATS = %i[cgap fluidx_barcode fluidigm].freeze
+  FOREIGN_BARCODE_FORMATS = %i[cgap fluidx_barcode fluidigm uk_biocentre_v1 uk_biocentre_v2 alderly_park_v1 alderly_park_v2].freeze
 
   validate :barcode_valid?
   validates :barcode, uniqueness: { scope: :format, case_sensitive: false }

--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -28,12 +28,15 @@ class Barcode < ApplicationRecord
     fluidx_barcode: 7,
     uk_biocentre_v1: 8,
     uk_biocentre_v2: 9,
-    alderly_park_v1: 10,
-    alderly_park_v2: 11
+    uk_biocentre_unid: 10,
+    alderly_park_v1: 11,
+    alderly_park_v2: 12
   }
 
   # Barcode formats which may be submitted via sample manifests
-  FOREIGN_BARCODE_FORMATS = %i[cgap fluidx_barcode fluidigm uk_biocentre_v1 uk_biocentre_v2 alderly_park_v1 alderly_park_v2].freeze
+  FOREIGN_BARCODE_FORMATS = %i[cgap fluidx_barcode fluidigm
+                               uk_biocentre_v1 uk_biocentre_v2 uk_biocentre_unid
+                               alderly_park_v1 alderly_park_v2].freeze
 
   validate :barcode_valid?
   validates :barcode, uniqueness: { scope: :format, case_sensitive: false }

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -202,7 +202,7 @@ module Barcode::FormatHandlers
   # nnnnnnnnnnNBC (Early UK Biocenter)
   # where n is a digit
   class UkBiocentreV1 < BaseRegExBarcode
-    self.format = /\A(?<number>\d{10})(?<suffix>NBC)\z/
+    self.format = /\A(?<number>\d{9,11})(?<suffix>NBC)\z/
   end
 
   # Added to support plates from UK Biocentre https://www.ukbiocentre.com/
@@ -212,7 +212,7 @@ module Barcode::FormatHandlers
   # nnnnnnnnnANBC (Later UK Biocenter)
   # where n is a digit
   class UkBiocentreV2 < BaseRegExBarcode
-    self.format = /\A(?<number>\d{9})(?<suffix>ANBC)\z/
+    self.format = /\A(?<number>\d{9,10})(?<suffix>ANBC)\z/
   end
 
   # Added to support plates from Alderley park:

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -215,6 +215,15 @@ module Barcode::FormatHandlers
     self.format = /\A(?<number>\d{9,10})(?<suffix>ANBC)\z/
   end
 
+  # Added to support plates from UK Biocentre https://www.ukbiocentre.com/
+  # as part of project Heron
+  # See issue: https://github.com/sanger/sequencescape/issues/2634
+  # Format identified during validation:
+  # RNADWPnnn
+  class UkBiocentreUnid < BaseRegExBarcode
+    self.format = /\A(?<prefix>RNADWP)(?<number>\d{3})\z/
+  end
+
   # Added to support plates from Alderley park:
   # as part of project Heron
   # See issue: https://github.com/sanger/sequencescape/issues/2634

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -194,4 +194,43 @@ module Barcode::FormatHandlers
   class FluidxBarcode < BaseRegExBarcode
     self.format = /\A(?<prefix>[A-Za-z]{2})(?<number>\d{8})\z/
   end
+
+  # Added to support plates from UK Biocentre https://www.ukbiocentre.com/
+  # as part of project Heron
+  # See issue: https://github.com/sanger/sequencescape/issues/2634
+  # Expected formats:
+  # nnnnnnnnnnNBC (Early UK Biocenter)
+  # where n is a digit
+  class UkBiocentreV1 < BaseRegExBarcode
+    self.format = /\A(?<number>\d{10})(?<suffix>NBC)\z/
+  end
+
+  # Added to support plates from UK Biocentre https://www.ukbiocentre.com/
+  # as part of project Heron
+  # See issue: https://github.com/sanger/sequencescape/issues/2634
+  # Expected formats:
+  # nnnnnnnnnANBC (Later UK Biocenter)
+  # where n is a digit
+  class UkBiocentreV2 < BaseRegExBarcode
+    self.format = /\A(?<number>\d{9})(?<suffix>ANBC)\z/
+  end
+
+  # Added to support plates from Alderley park:
+  # as part of project Heron
+  # See issue: https://github.com/sanger/sequencescape/issues/2634
+  # Expected formats:
+  # RNA_nnnn (Early Alderley park: Temporary barcodes on early plates)
+  class AlderlyParkV1 < BaseRegExBarcode
+    self.format = /\A(?<prefix>RNA)_(?<number>\d{4})\z/
+  end
+
+  # Added to support plates from Alderley park:
+  # as part of project Heron
+  # See issue: https://github.com/sanger/sequencescape/issues/2634
+  # Expected formats:
+  # AP-ccc-nnnnnnnn (Later Alderley park: The new permanent barcodes are AP-rna-00110029
+  #                @note some RNA plates had the AP-kfr-00090016 barcode applied in error
+  class AlderlyParkV2 < BaseRegExBarcode
+    self.format = /\A(?<prefix>AP\-[a-z]{3})\-(?<number>\d{8})\z/
+  end
 end

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -53,6 +53,15 @@ describe Barcode::FormatHandlers do
     it_has_an_invalid_barcode " 1234567890NCB\na"
   end
 
+  describe Barcode::FormatHandlers::UkBiocentreUnid do
+    it_has_a_valid_barcode 'RNADWP004', prefix: 'RNADWP', number: 4, suffix: nil
+    it_has_an_invalid_barcode 'DNADWP004'
+    it_has_an_invalid_barcode 'DNA_1234'
+    it_has_an_invalid_barcode '1234567890NCB'
+    it_has_an_invalid_barcode 'RNA_1234 '
+    it_has_an_invalid_barcode "RNA_1234\n1"
+  end
+
   describe Barcode::FormatHandlers::AlderlyParkV1 do
     it_has_a_valid_barcode 'RNA_1234', prefix: 'RNA', number: 1234, suffix: nil
     it_has_an_invalid_barcode 'RNA_12345'

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Barcode::FormatHandlers' do
+describe Barcode::FormatHandlers do
   # Set up the expectations for a valid barcode
   # @example
   #  it_has_a_valid_barcode 'DN12345S', number: 12345, prefix: 'DN', suffix: 'S'

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Barcode::FormatHandlers' do
+  # Set up the expectations for a valid barcode
+  # @example
+  #  it_has_a_valid_barcode 'DN12345S', number: 12345, prefix: 'DN', suffix: 'S'
+  def self.it_has_a_valid_barcode(barcode, number: nil, prefix: nil, suffix: nil)
+    context "with the barcode #{barcode}" do
+      subject(:format_handler) { described_class.new(barcode) }
+
+      it 'parses the barcode correctly', :aggregate_failures do
+        expect(format_handler).to be_valid
+        expect(format_handler).to have_attributes(number: number, barcode_prefix: prefix, suffix: suffix)
+      end
+    end
+  end
+
+  # Set up the expectations for an invalid barcode
+  # @example
+  #  it_has_an_invalid_barcode 'INVALID'
+  def self.it_has_an_invalid_barcode(barcode)
+    context "with the barcode #{barcode}" do
+      subject(:format_handler) { described_class.new(barcode) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  # These groups aren't empty, we just use a helper to generate the tests
+  # rubocop:disable RSpec/EmptyExampleGroup
+  describe Barcode::FormatHandlers::UkBiocentreV1 do
+    it_has_a_valid_barcode '1234567890NBC', prefix: nil, number: 1234567890, suffix: 'NBC'
+    it_has_an_invalid_barcode '123456789ANBC'
+    it_has_an_invalid_barcode 'INVALID'
+    it_has_an_invalid_barcode '123456789NCB'
+    it_has_an_invalid_barcode '123456789MBC'
+    it_has_an_invalid_barcode '1234567890ANBC'
+    it_has_an_invalid_barcode 'RNA_1234'
+    it_has_an_invalid_barcode ' 1234567890NBC'
+    it_has_an_invalid_barcode " 1234567890NBC\na"
+  end
+
+  describe Barcode::FormatHandlers::UkBiocentreV2 do
+    it_has_a_valid_barcode '123456789ANBC', prefix: nil, number: 123456789, suffix: 'ANBC'
+    it_has_an_invalid_barcode 'INVALID'
+    it_has_an_invalid_barcode '123456789NCB'
+    it_has_an_invalid_barcode '123456789MBC'
+    it_has_an_invalid_barcode '1234567890ANCB'
+    it_has_an_invalid_barcode 'RNA_1234'
+    it_has_an_invalid_barcode ' 1234567890NCB'
+    it_has_an_invalid_barcode " 1234567890NCB\na"
+  end
+
+  describe Barcode::FormatHandlers::AlderlyParkV1 do
+    it_has_a_valid_barcode 'RNA_1234', prefix: 'RNA', number: 1234, suffix: nil
+    it_has_an_invalid_barcode 'RNA_12345'
+    it_has_an_invalid_barcode 'DNA_1234'
+    it_has_an_invalid_barcode '1234567890NCB'
+    it_has_an_invalid_barcode 'RNA_1234 '
+    it_has_an_invalid_barcode "RNA_1234\n1"
+  end
+
+  describe Barcode::FormatHandlers::AlderlyParkV2 do
+    it_has_a_valid_barcode 'AP-rna-12345678', prefix: 'AP-rna', number: 12345678
+    it_has_a_valid_barcode 'AP-rna-00110029', prefix: 'AP-rna', number: 110029
+    it_has_a_valid_barcode 'AP-kfr-00090016', prefix: 'AP-kfr', number: 90016
+    it_has_an_invalid_barcode 'SD-rna-1234567'
+    it_has_an_invalid_barcode 'AP-rna-123456789'
+    it_has_an_invalid_barcode 'AP-cdna-1234567'
+    it_has_an_invalid_barcode 'AP-rna-1234567 '
+    it_has_an_invalid_barcode "AP-rna-1234567\n1"
+  end
+  # rubocop:enable RSpec/EmptyExampleGroup
+end


### PR DESCRIPTION
Closes #2634

Changes proposed in this pull request:

- Adds early and late UK Biocentre barcode handlers
- Adds early and late Alderly park barcode handlers
- Adds both sets of handlers to the foreign barcodes
  to allow reciept in manifests

