### PR TITLE
Add PCR with TruSeq tails amplicon library type

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -370,7 +370,8 @@ namespace :limber do
         request_class: 'IlluminaHtp::Requests::HeronRequest',
         library_types:  [
           'PCR amplicon ligated adapters',
-          'PCR amplicon ligated adapters 384'
+          'PCR amplicon ligated adapters 384',
+          'PCR with TruSeq tails amplicon'
         ],
         default_purposes: ['LHR RT', 'LHR-384 RT']             # It requires default_purpose to accept an array.
       ).build!

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -371,7 +371,8 @@ namespace :limber do
         library_types:  [
           'PCR amplicon ligated adapters',
           'PCR amplicon ligated adapters 384',
-          'PCR with TruSeq tails amplicon'
+          'PCR with TruSeq tails amplicon',
+          'PCR with TruSeq tails amplicon 384'
         ],
         default_purposes: ['LHR RT', 'LHR-384 RT']             # It requires default_purpose to accept an array.
       ).build!


### PR DESCRIPTION
Awaiting clarification on whether a 384 well variety is required
and clarification on whether it should be associated with other
request types

fixes #2633

Changes proposed in this pull request:
* Adds PCR with TruSeq tails amplicon library type
* Adds it to the Heron request types
