### PR TITLE
Ensure creators with no dilution use the default

### DIFF
--- a/app/views/plates/new.html.erb
+++ b/app/views/plates/new.html.erb
@@ -26,11 +26,11 @@
 
 <script type="text/javascript">
 (function($) {
-  const defaultOption = { valid_dilution_factors: ["1.0"] }
+  const defaultOption = ["1.0"]
   const plate_creator_parameters = <%= raw json_escape(plate_creator_parameters_json(@plate_creators)) %>
 
   const validDilutionFactorsForName = (name) => {
-    return (plate_creator_parameters[name] || defaultOption).valid_dilution_factors
+    return (plate_creator_parameters[name] || {}).valid_dilution_factors || defaultOption
   }
 
   const dataForName = (name) => {


### PR DESCRIPTION
Fixes #2651

Plate creators without configured dilution options are returning
empty javascript objects not null.

This restores the previous behaviour, although replaces the safe
navigation operator with something with wider browser compatibility.

I'm not actually sure why we need to handle null values here, as
all plate creators will be present in the hash.

