### PR TITLE
Fully strip out working:setup

### DIFF
--- a/db/seeds/0000_barcode_printer_types.rb
+++ b/db/seeds/0000_barcode_printer_types.rb
@@ -3,3 +3,4 @@
 BarcodePrinterType1DTube.create(name: '1D Tube', printer_type_id: 2, label_template_name: 'sqsc_1dtube_label_template')
 BarcodePrinterType96Plate.create(name: '96 Well Plate', printer_type_id: 1, label_template_name: 'sqsc_96plate_label_template')
 BarcodePrinterType384Plate.create(name: '384 Well Plate', printer_type_id: 6, label_template_name: 'sqsc_384plate_label_template')
+BarcodePrinterType384DoublePlate.create_with(printer_type_id: 10, label_template_name: 'plate_6mm_double_code39').find_or_create_by!(name: '384 Well Plate Double')

--- a/db/seeds/9999_dev_only.rb
+++ b/db/seeds/9999_dev_only.rb
@@ -1,0 +1,27 @@
+# This file contains content previously in the working:setup task
+# which is useful in development environments for easy debugging.
+# It has been moved into seeds to streamline the process.
+
+if Rails.env.development?
+  require './lib/working_setup/standard_seeder'
+  # Barcode printers (These match some of the more frequently used printers,
+  # or at least the most frequently used when I first put this together)
+  plate = BarcodePrinterType.find_by!(name: '96 Well Plate')
+  tube = BarcodePrinterType.find_by!(name: '1D Tube')
+  BarcodePrinter.find_or_create_by!(name: 'g312bc2', barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'g311bc2', barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'g316bc',  barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'g317bc',  barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'g314bc',  barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'f225bc',  barcode_printer_type: plate)
+  BarcodePrinter.find_or_create_by!(name: 'g311bc1', barcode_printer_type: tube)
+
+  # Previous content of working:basic provides a few example studies
+  # and the admin user
+  seeder = WorkingSetup::StandardSeeder.new
+  seeder.user
+  seeder.study
+  seeder.study_b
+  seeder.project
+  seeder.supplier
+end

--- a/db/seeds/9999_dev_only.rb
+++ b/db/seeds/9999_dev_only.rb
@@ -8,6 +8,8 @@ if Rails.env.development?
   # or at least the most frequently used when I first put this together)
   plate = BarcodePrinterType.find_by!(name: '96 Well Plate')
   tube = BarcodePrinterType.find_by!(name: '1D Tube')
+  plate384 = BarcodePrinterType384DoublePlate.find_by!(name: '384 Well Plate Double')
+
   BarcodePrinter.find_or_create_by!(name: 'g312bc2', barcode_printer_type: plate)
   BarcodePrinter.find_or_create_by!(name: 'g311bc2', barcode_printer_type: plate)
   BarcodePrinter.find_or_create_by!(name: 'g316bc',  barcode_printer_type: plate)
@@ -15,13 +17,17 @@ if Rails.env.development?
   BarcodePrinter.find_or_create_by!(name: 'g314bc',  barcode_printer_type: plate)
   BarcodePrinter.find_or_create_by!(name: 'f225bc',  barcode_printer_type: plate)
   BarcodePrinter.find_or_create_by!(name: 'g311bc1', barcode_printer_type: tube)
+  BarcodePrinter.find_or_create_by!(name: 'dnapbc2', barcode_printer_type: plate384)
+  BarcodePrinter.find_or_create_by!(name: 'ogilviebc', barcode_printer_type: plate384)
 
   # Previous content of working:basic provides a few example studies
   # and the admin user
-  seeder = WorkingSetup::StandardSeeder.new
+  seeder = WorkingSetup::StandardSeeder.new([['Stock Plate', 1]])
   seeder.user
   seeder.study
   seeder.study_b
   seeder.project
   seeder.supplier
+  # Generates a handful of samples and robots
+  seeder.seed
 end

--- a/lib/tasks/working_setup.rake
+++ b/lib/tasks/working_setup.rake
@@ -4,11 +4,11 @@ namespace :working do
   # We don't want to load Sequencescape just to tell the user that nothing happens.
   # rubocop:disable Rails/RakeEnvironment
   task :basic do
-    puts '📣 working:basic no loger generates records. These are made automatically when seeding development.'
+    puts '📣 working:basic no longer generates records. These are made automatically when seeding development.'
   end
 
   task :printers do
-    puts '📣 working:printers no loger generates printers. These are made automatically when seeding development.'
+    puts '📣 working:printers no longer generates printers. These are made automatically when seeding development.'
   end
 
   task :generate_tag_plates do

--- a/lib/tasks/working_setup.rake
+++ b/lib/tasks/working_setup.rake
@@ -1,56 +1,24 @@
 require './lib/oligo_enumerator'
 
 namespace :working do
-  desc 'Confirms that the environment is correct for the task'
-  task env_check: :environment do
-    require_relative '../working_setup/standard_seeder'
-    unless Rails.env.development?
-      puts "CAUTION! You are running this task in the #{Rails.env} environment."
-      puts 'This script is intended for the development environment only.'
-      puts 'Running this task in test WILL cause failures, and could cause issues in other environments.'
-      puts 'Are you sure you wish to continue? (Y for yes)'
-      exit unless STDIN.gets.chomp == 'Y'
-    end
+  # We don't want to load Sequencescape just to tell the user that nothing happens.
+  # rubocop:disable Rails/RakeEnvironment
+  task :basic do
+    puts '📣 working:basic no loger generates records. These are made automatically when seeding development.'
   end
 
-  desc 'Provide a user, study and projects'
-  task basic: ['working:env_check', :environment] do
-    seeder = WorkingSetup::StandardSeeder.new
-    seeder.user
-    seeder.study
-    seeder.study_b
-    seeder.project
-    seeder.supplier
+  task :printers do
+    puts '📣 working:printers no loger generates printers. These are made automatically when seeding development.'
   end
 
-  desc 'Build the expected barcode printers'
-  task printers: ['working:env_check', :environment] do
-    plate = BarcodePrinterType.find_by!(name: '96 Well Plate')
-    tube = BarcodePrinterType.find_by!(name: '1D Tube')
-    BarcodePrinter.find_or_create_by!(name: 'g312bc2', barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'g311bc2', barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'g316bc',  barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'g317bc',  barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'g314bc',  barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'f225bc',  barcode_printer_type: plate)
-    BarcodePrinter.find_or_create_by!(name: 'g311bc1', barcode_printer_type: tube)
+  task :generate_tag_plates do
+    puts '📣 working:generate_tag_plates has been removed. Use UAT actions instead.'
   end
 
-  desc 'Provides 30 tag plates for use'
-  task generate_tag_plates: :environment do
-    WorkingSetup::StandardSeeder.new.tag_plates
+  task :setup do
+    puts '📣 working:setup is no more.'
+    puts 'Users, studies, projects, suppliers and printers have all been moved to seeds specific to the development environment.'
+    puts 'Tag plates, and various stock plates can all be generated through UAT actions.'
   end
-
-  desc 'Provide some much needed records for quickly testing new work'
-  task setup: ['working:env_check', 'working:printers', 'working:basic', :environment] do
-    ActiveRecord::Base.transaction do
-      seeder = WorkingSetup::StandardSeeder.new([
-        ['Stock Plate', 1],
-        # ['LB Cherrypick', 4],
-        ['ILC Stock', 4]
-      ])
-      seeder.seed
-      seeder.tag_plates
-    end
-  end
+  # rubocop:enable Rails/RakeEnvironment
 end


### PR DESCRIPTION
Changes proposed in this pull request:

* Deprecate working:setup in favour of seeds and UAT actions
* Move cheap working setup tasks to development specific seeds
* Direct users to UAT actions for more expensive working setup actions

Consider removing some of the limber:dev tasks as well, although I notice other developers are adding to them, so perhaps people still find them useful.