### PR TITLE
GPL-452 See if sample is control

### DIFF
--- a/app/models/api/sample_io.rb
+++ b/app/models/api/sample_io.rb
@@ -30,7 +30,7 @@ class Api::SampleIO < Api::Base
     'control' => '1',
     'positive_control' => '1',
     'negative_control' => '1'
-  }
+  }.freeze
 
   renders_model(::Sample)
 
@@ -80,11 +80,7 @@ class Api::SampleIO < Api::Base
     if json_attributes['reference_genome'].blank?
       json_attributes['reference_genome'] = nil
     end
-    if CONTROL_DATA_MAPPING.has_key?(json_attributes['control'])
-      json_attributes['control'] = CONTROL_DATA_MAPPING[json_attributes['control']]
-    else
-      json_attributes['control'] = nil
-    end
+    json_attributes['control'] = CONTROL_DATA_MAPPING[json_attributes['control']] # sets to nil if not found in hash
   end
 
   # Whenever we create samples through the API we also need to register a sample tube too.  The user

--- a/app/models/api/sample_io.rb
+++ b/app/models/api/sample_io.rb
@@ -21,6 +21,17 @@ class Api::SampleIO < Api::Base
     end
   end
 
+  # Sequencescape field 'control' was changed to an enum May 2020
+  # MLWH field retained as a boolean
+  # because difficult to change the legacy warehouse which receives same message
+  # map all types of control to 1
+  CONTROL_DATA_MAPPING = {
+    'not_control' => '0',
+    'control' => '1',
+    'positive_control' => '1',
+    'negative_control' => '1'
+  }
+
   renders_model(::Sample)
 
   map_attribute_to_json_attribute(:uuid)
@@ -68,6 +79,11 @@ class Api::SampleIO < Api::Base
   extra_json_attributes do |_object, json_attributes|
     if json_attributes['reference_genome'].blank?
       json_attributes['reference_genome'] = nil
+    end
+    if CONTROL_DATA_MAPPING.has_key?(json_attributes['control'])
+      json_attributes['control'] = CONTROL_DATA_MAPPING[json_attributes['control']]
+    else
+      json_attributes['control'] = nil
     end
   end
 

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -482,7 +482,7 @@ class Sample < ApplicationRecord
     # replace underscores with spaces to make more readable for UIs
     return 'Not specified' unless control
 
-    control.gsub('_', ' ').capitalize
+    control.tr('_', ' ').capitalize
   end
 
   private

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -480,7 +480,9 @@ class Sample < ApplicationRecord
 
   def control_formatted
     # replace underscores with spaces to make more readable for UIs
-    control&.gsub('_', ' ')
+    return 'Not specified' unless control
+
+    control.gsub('_', ' ').capitalize
   end
 
   private

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -272,6 +272,13 @@ class Sample < ApplicationRecord
 
   validate :name_unchanged, if: :will_save_change_to_name?, on: :update
 
+  enum control: {
+    not_control: 0,
+    control: 1, # here to support legacy data from when this column was a boolean
+    positive_control: 2,
+    negative_control: 3
+  }
+
   # this method has to be before validation_guarded_by
   def rename_to!(new_name)
     update!(name: new_name)

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -272,6 +272,7 @@ class Sample < ApplicationRecord
 
   validate :name_unchanged, if: :will_save_change_to_name?, on: :update
 
+  # 'control' was changed from a boolean to an enum May 2020
   enum control: {
     not_control: 0,
     control: 1, # here to support legacy data from when this column was a boolean

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -478,6 +478,11 @@ class Sample < ApplicationRecord
     end
   end
 
+  def control_formatted
+    # replace underscores with spaces to make more readable for UIs
+    control&.gsub('_', ' ')
+  end
+
   private
 
   def safe_to_destroy

--- a/app/resources/api/v2/sample_resource.rb
+++ b/app/resources/api/v2/sample_resource.rb
@@ -12,6 +12,7 @@ module Api
       attribute :name
       attribute :sanger_sample_id
       attribute :uuid
+      attribute :control
     end
   end
 end

--- a/app/views/assets/samples_partials/_plate_samples.erb
+++ b/app/views/assets/samples_partials/_plate_samples.erb
@@ -19,6 +19,7 @@
           <th>Sanger Sample Id</th>
           <th>Tag</th>
           <th>Tag2</th>
+          <th>Control?</th>
         </tr>
       </thead>
       <tbody>
@@ -30,12 +31,14 @@
               <td><%= aliquot.sample.sanger_sample_id %></td>
               <td><%= render partial: 'shared/tag_info', locals: {tag: aliquot.tag } if aliquot.tag.present? %></td>
               <td><%= render partial: 'shared/tag_info', locals: {tag: aliquot.tag2 } if aliquot.tag2.present? %></td>
+              <td><%= aliquot.sample.control_formatted %></td>
             </tr>
           <% end %>
           <% if well.aliquots.empty? %>
             <tr class="empty-well">
               <td><%= link_to well.map.description, receptacle_path(well) %></td>
               <td>[Empty]</td>
+              <td></td>
               <td></td>
               <td></td>
               <td></td>

--- a/app/views/assets/samples_partials/_tube_rack_samples.erb
+++ b/app/views/assets/samples_partials/_tube_rack_samples.erb
@@ -18,6 +18,7 @@
           <th>Tube Barcode</th>
           <th>Sample Name</th>
           <th>Sanger Sample Id</th>
+          <th>Control?</th>
         </tr>
       </thead>
       <tbody>
@@ -28,6 +29,7 @@
               <td><%= link_to tube.primary_barcode.barcode, labware_path(tube) %></td>
               <td><strong><%= link_to aliquot.sample.name, aliquot.sample -%></strong></td>
               <td><%= aliquot.sample.sanger_sample_id %></td>
+              <td><%= aliquot.sample.control_formatted %></td>
             </tr>
           <% end %>
           <% if tube.aliquots.empty? %>
@@ -35,6 +37,7 @@
               <td><%= link_to tube.coordinate, labware_path(tube) %></td>
               <td><%= link_to tube.primary_barcode.barcode, labware_path(tube) %></td>
               <td>[Empty]</td>
+              <td></td>
               <td></td>
             </tr>
           <% end %>

--- a/app/views/samples/_summary.html.erb
+++ b/app/views/samples/_summary.html.erb
@@ -26,6 +26,10 @@
       <td class="item">Created at:</td>
       <td><strong><%=h @sample.created_at.to_formatted_s(:day_full_with_time) %></strong></td>
     </tr>
+    <tr>
+      <td class="item">Control:</td>
+      <td><%=h @sample.control_formatted %></td>
+    </tr>
   </table>
   <div id="template_form_body">
       <%= render(partial: 'shared/metadata/show/sample', locals: { sample: @sample }) %>

--- a/db/migrate/20200511101742_change_control_column_data_type.rb
+++ b/db/migrate/20200511101742_change_control_column_data_type.rb
@@ -1,9 +1,10 @@
-class ChangeControlColumnDataType < ActiveRecord::Migration[5.2]
+# frozen_string_literal: true
 
-  # Change data type of control column to enum (stored as integer), from boolean
-  # This is to store whether the sample is a positive or negative control, for project Heron
-  # This field seemed like it hadn't been used for a while at the time of changing
-  # Corresponding change in MLWH was from tinyint to string
+# Change data type of control column to enum (stored as integer), from boolean
+# This is to store whether the sample is a positive or negative control, for project Heron
+# This field seemed like it hadn't been used for a while at the time of changing
+# Corresponding change in MLWH was from tinyint to string
+class ChangeControlColumnDataType < ActiveRecord::Migration[5.2]
   def up
     change_column :samples, :control, :integer
   end

--- a/db/migrate/20200511101742_change_control_column_data_type.rb
+++ b/db/migrate/20200511101742_change_control_column_data_type.rb
@@ -1,4 +1,9 @@
 class ChangeControlColumnDataType < ActiveRecord::Migration[5.2]
+
+  # Change data type of control column to enum (stored as integer), from boolean
+  # This is to store whether the sample is a positive or negative control, for project Heron
+  # This field seemed like it hadn't been used for a while at the time of changing
+  # Corresponding change in MLWH was from tinyint to string
   def up
     change_column :samples, :control, :integer
   end

--- a/db/migrate/20200511101742_change_control_column_data_type.rb
+++ b/db/migrate/20200511101742_change_control_column_data_type.rb
@@ -1,0 +1,9 @@
+class ChangeControlColumnDataType < ActiveRecord::Migration[5.2]
+  def up
+    change_column :samples, :control, :integer
+  end
+
+  def down
+    change_column :samples, :control, :boolean # rows with integer values > 1 will return true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_133731) do
+ActiveRecord::Schema.define(version: 2020_05_11_101742) do
 
   create_table "aker_containers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "barcode"
@@ -1377,7 +1377,7 @@ ActiveRecord::Schema.define(version: 2020_04_03_133731) do
     t.datetime "updated_at"
     t.string "sanger_sample_id"
     t.integer "sample_manifest_id"
-    t.boolean "control"
+    t.integer "control"
     t.boolean "empty_supplier_sample_name", default: false
     t.boolean "updated_by_manifest", default: false
     t.boolean "migrated_consent_withdrawn_to_metadata", default: false, null: false

--- a/spec/features/assets/show_plate_spec.rb
+++ b/spec/features/assets/show_plate_spec.rb
@@ -14,10 +14,10 @@ describe 'Show plate', js: true do
     login_user user
     visit asset_path(plate)
     expect(fetch_table('#plate-samples-table')).to eq([
-      ['Well', 'Sample Name', 'Sanger Sample Id', 'Tag', 'Tag2'],
-      ['A1',   '[Empty]',     '',                 '',    ''],
-      ['B1',   '[Empty]',     '',                 '',    ''],
-      ['C1',   '[Empty]',     '',                 '',    '']
+      ['Well', 'Sample Name', 'Sanger Sample Id', 'Tag', 'Tag2', 'Control?'],
+      ['A1',   '[Empty]',     '',                 '',    '',     ''],
+      ['B1',   '[Empty]',     '',                 '',    '',     ''],
+      ['C1',   '[Empty]',     '',                 '',    '',     '']
     ])
   end
 end

--- a/spec/heron/factories/sample_spec.rb
+++ b/spec/heron/factories/sample_spec.rb
@@ -185,9 +185,9 @@ RSpec.describe Heron::Factories::Sample, type: :model, lighthouse: true, heron: 
 
       context 'when providing other arguments' do
         it 'updates other sample attributes' do
-          factory = described_class.new(study: study, control: true)
+          factory = described_class.new(study: study, control: 'control')
           sample = factory.create
-          expect(sample.control).to eq(true)
+          expect(sample.control).to eq('control')
         end
 
         it 'updates other sample_metadata attributes' do

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Sample, type: :model, accession: true, aker: true do
     end
   end
 
-  context '#control_formatted' do
+  describe '#control_formatted' do
     it 'removes underscores and capitalizes' do
       sample = create(:sample, control: 'positive_control')
       expect(sample.control_formatted).to eq('Positive control')

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -109,4 +109,16 @@ RSpec.describe Sample, type: :model, accession: true, aker: true do
       expect(sample.sample_metadata.genome_size).to eq(1000)
     end
   end
+
+  context '#control_formatted' do
+    it 'removes underscores and capitalizes' do
+      sample = create(:sample, control: 'positive_control')
+      expect(sample.control_formatted).to eq('Positive control')
+    end
+
+    it 'handles nil' do
+      sample = create(:sample, control: nil)
+      expect(sample.control_formatted).to eq('Not specified')
+    end
+  end
 end


### PR DESCRIPTION
Converts existing 'control' field from boolean to enum, so it can hold more information.

Add 'control' field to samples show, plates show and tube_racks show views (screenshots attached).

Add 'control' field to API for use by Limber and Quanthub in coming stories.

To do:
* Wait for reply from David Jackson about whether NPG use existing field (although have now manipulated message so will keep sending consistent data)
* Make new story for backlog for editing this field, whether through UI or manifests