### PR TITLE
Fix - uat actions set study on aliquots

### DIFF
--- a/app/uat_actions/uat_actions/generate_plates.rb
+++ b/app/uat_actions/uat_actions/generate_plates.rb
@@ -50,6 +50,7 @@ class UatActions::GeneratePlates < UatActions
         report["plate_#{i}"] = plate.human_barcode
       end
     end
+    true
   end
 
   private
@@ -63,7 +64,7 @@ class UatActions::GeneratePlates < UatActions
 
   def construct_wells(plate)
     wells(plate).each do |well|
-      well.aliquots.create!(sample: Sample.create!(name: "sample_#{plate.human_barcode}_#{well.map.description}", studies: [study]))
+      well.aliquots.create!(sample: Sample.create!(name: "sample_#{plate.human_barcode}_#{well.map.description}", studies: [study]), study: study)
     end
   end
 

--- a/app/uat_actions/uat_actions/generate_tube_racks.rb
+++ b/app/uat_actions/uat_actions/generate_tube_racks.rb
@@ -31,6 +31,7 @@ class UatActions::GenerateTubeRacks < UatActions
         report["rack_#{i}"] = rack.human_barcode
       end
     end
+    true
   end
 
   private
@@ -38,7 +39,7 @@ class UatActions::GenerateTubeRacks < UatActions
   def construct_tubes(rack)
     rack_map.each do |i|
       tube = Tube::Purpose.standard_sample_tube.create!
-      tube.aliquots.create!(sample: Sample.create!(name: "sample_#{rack.human_barcode}_#{i}", studies: [study]))
+      tube.aliquots.create!(sample: Sample.create!(name: "sample_#{rack.human_barcode}_#{i}", studies: [study]), study: study)
 
       racked_tube = RackedTube.create!(tube_rack_id: rack.id, tube_id: tube.id, coordinate: i)
       rack.racked_tubes << racked_tube

--- a/spec/uat_actions/generate_plates_spec.rb
+++ b/spec/uat_actions/generate_plates_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UatActions::GeneratePlates do
+  context 'with valid options' do
+    let(:study) { create(:study, name: 'Test Study') }
+    let(:uat_action) { described_class.new(parameters) }
+
+    context 'when creating a single plate' do
+      let(:parameters) do
+        {
+          plate_purpose_name: PlatePurpose.stock_plate_purpose.name,
+          plate_count: 1,
+          well_count: 1,
+          study_name: study.name,
+          well_layout: 'Column'
+        }
+      end
+      let(:report) do
+        # A report is a hash of key value pairs which get returned to the user.
+        # It should include information such as barcodes and identifiers
+        { 'plate_0' => 'DN2T' }
+      end
+      let(:barcode_1) { build(:plate_barcode, barcode: 2) }
+
+      before do
+        allow(PlateBarcode).to receive(:create).and_return(barcode_1)
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report['plate_0']).to eq report['plate_0']
+        expect(Plate.find_by_barcode(report['plate_0']).wells.first.aliquots.first.study).to eq study
+      end
+    end
+
+    context 'when creating multiple plates' do
+      let(:parameters) do
+        {
+          plate_purpose_name: PlatePurpose.stock_plate_purpose.name,
+          plate_count: 3,
+          well_count: 1,
+          study_name: study.name,
+          well_layout: 'Column'
+        }
+      end
+      let(:report) do
+        # A report is a hash of key value pairs which get returned to the user.
+        # It should include information such as barcodes and identifiers
+        {
+          'plate_0' => 'DN3U',
+          'plate_1' => 'DN4V',
+          'plate_2' => 'DN5W'
+        }
+      end
+      let(:barcode_1) { build(:plate_barcode, barcode: 3) }
+      let(:barcode_2) { build(:plate_barcode, barcode: 4) }
+      let(:barcode_3) { build(:plate_barcode, barcode: 5) }
+
+      before do
+        allow(PlateBarcode).to receive(:create).and_return(barcode_1, barcode_2, barcode_3)
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report['plate_0']).to eq report['plate_0']
+        expect(uat_action.report['plate_1']).to eq report['plate_1']
+        expect(uat_action.report['plate_2']).to eq report['plate_2']
+      end
+    end
+  end
+
+  it 'returns a default' do
+    expect(described_class.default).to be_a described_class
+  end
+end

--- a/spec/uat_actions/generate_tube_racks_spec.rb
+++ b/spec/uat_actions/generate_tube_racks_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UatActions::GenerateTubeRacks do
+  context 'with valid options' do
+    let(:study) { create(:study, name: 'Test Study') }
+    let(:parameters) do
+      {
+        rack_count: 1,
+        study_name: study.name
+      }
+    end
+    let(:uat_action) { described_class.new(parameters) }
+
+    context 'when creating a single tube rack' do
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report['rack_0']).to be_present
+        expect(TubeRack.find_by_barcode(uat_action.report['rack_0']).tube_receptacles.first.aliquots.first.study).to eq study
+      end
+    end
+
+    context 'when creating multiple tube racks' do
+      let(:parameters) do
+        {
+          rack_count: 3,
+          study_name: study.name
+        }
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report['rack_0']).to be_present
+        expect(uat_action.report['rack_1']).to be_present
+        expect(uat_action.report['rack_2']).to be_present
+      end
+    end
+  end
+
+  it 'returns a default' do
+    expect(described_class.default).to be_a described_class
+  end
+end


### PR DESCRIPTION
Fixes an issue whereby the UAT actions for generating plates and tube racks were not linking their aliquots to the study. This has a knock on effect that they don't appear in things like the QC reports which select aliquots by study.