### PR TITLE
Add placeholder task for application:post-deploy

### DIFF
--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -2,4 +2,6 @@
 
 namespace :application do
   task deploy: ['limber:setup']
+  # Placeholder task for RecordLoader behaviour
+  task :post_deploy # rubocop:disable Rails/RakeEnvironment
 end


### PR DESCRIPTION
Placeholder task to allow changes to be made in psd-deployment
without major co-ordination of releases/merges