### PR TITLE
Allow filtering tag groups by name

### DIFF
--- a/app/resources/api/v2/tag_group_resource.rb
+++ b/app/resources/api/v2/tag_group_resource.rb
@@ -22,6 +22,7 @@ module Api
 
       # Filters
       filter :visible, default: true
+      filter :name
 
       # Custom methods
       # These shouldn't be used for business logic, and a more about

--- a/spec/requests/api/v2/tag_groups_spec.rb
+++ b/spec/requests/api/v2/tag_groups_spec.rb
@@ -19,6 +19,14 @@ describe 'TagGroups API', with: :api_v2 do
     end
 
     # Check filters, ESPECIALLY if they aren't simple attribute filters
+
+    it 'filters tag_groups by name' do
+      api_get "/api/v2/tag_groups?filter[name]=#{TagGroup.first.name}"
+      expect(response).to have_http_status(:success)
+      # check to make sure the right tag group is returned
+      expect(json['data'].length).to eq(1)
+      expect(json['data'][0]['attributes']['name']).to eq(TagGroup.first.name)
+    end
   end
 
   context 'with a TagGroup' do


### PR DESCRIPTION
Links to [GPL-403](https://github.com/sanger/traction-service/issues/221) (Traction)

* Allow getting tag set groups filtered by name through endpoint, for example, `http://localhost:3000/api/v2/tag_groups?filter[name]=ONT_EXP-PBC096`
