### PR TITLE
UAT action improvement - set supplier name

### DIFF
--- a/app/uat_actions/uat_actions/generate_plates.rb
+++ b/app/uat_actions/uat_actions/generate_plates.rb
@@ -64,7 +64,16 @@ class UatActions::GeneratePlates < UatActions
 
   def construct_wells(plate)
     wells(plate).each do |well|
-      well.aliquots.create!(sample: Sample.create!(name: "sample_#{plate.human_barcode}_#{well.map.description}", studies: [study]), study: study)
+      sample_name = "sample_#{plate.human_barcode}_#{well.map.description}"
+      well.aliquots.create!(
+        sample: Sample.create!(
+          name: sample_name,
+          studies: [study],
+          sample_metadata_attributes: {
+            supplier_name: sample_name
+          }
+        ),
+        study: study)
     end
   end
 

--- a/app/uat_actions/uat_actions/generate_tube_racks.rb
+++ b/app/uat_actions/uat_actions/generate_tube_racks.rb
@@ -39,7 +39,17 @@ class UatActions::GenerateTubeRacks < UatActions
   def construct_tubes(rack)
     rack_map.each do |i|
       tube = Tube::Purpose.standard_sample_tube.create!
-      tube.aliquots.create!(sample: Sample.create!(name: "sample_#{rack.human_barcode}_#{i}", studies: [study]), study: study)
+
+      sample_name = "sample_#{rack.human_barcode}_#{i}"
+      tube.aliquots.create!(
+        sample: Sample.create!(
+          name: sample_name,
+          studies: [study],
+          sample_metadata_attributes: {
+            supplier_name: sample_name
+          }
+        ),
+        study: study)
 
       racked_tube = RackedTube.create!(tube_rack_id: rack.id, tube_id: tube.id, coordinate: i)
       rack.racked_tubes << racked_tube


### PR DESCRIPTION
get plate and rack UAT action creators to set supplier name
- needed by Samples Extraction to display the contents of the plates or racks
- doesn't slow down creation noticeably
- made to make testing GPL-476 and other Samples Extraction stories easier