### PR TITLE
GPL-553 Add new plate purpose 'LHR Cherrypick'

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -201,6 +201,20 @@ namespace :limber do
       )
     end
 
+    unless Purpose.where(name: 'LHR Cherrypick').exists?
+      PlatePurpose.create!(
+        name: 'LHR Cherrypick',
+        target_type: 'Plate',
+        stock_plate: true,
+        input_plate: false,
+        default_state: 'pending',
+        barcode_printer_type: BarcodePrinterType.find_by(name: '96 Well Plate'),
+        cherrypickable_target: true,
+        size: 96,
+        asset_shape: AssetShape.find_by(name: 'Standard')
+      )
+    end
+
     unless Purpose.where(name: 'LHR RT').exists?
       PlatePurpose.create!(
         name: 'LHR RT',


### PR DESCRIPTION
- for picking positive samples from Lighthouse 'LHR Stock' plates into, prior to quad-stamping into an 'LHR-384 RT' plate for reverse transcription