### PR TITLE
GPL-557 fix

### DIFF
--- a/app/models/api/messages/well_stock_resource_io.rb
+++ b/app/models/api/messages/well_stock_resource_io.rb
@@ -14,7 +14,7 @@ class Api::Messages::WellStockResourceIO < Api::Base
   map_attribute_to_json_attribute(:subject_type, 'labware_type')
 
   with_association(:plate) do
-    map_attribute_to_json_attribute(:ean13_barcode, 'machine_barcode')
+    map_attribute_to_json_attribute(:machine_barcode, 'machine_barcode')
     map_attribute_to_json_attribute(:human_barcode, 'human_barcode')
   end
 

--- a/spec/models/api/messages/well_stock_resource_io_spec.rb
+++ b/spec/models/api/messages/well_stock_resource_io_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::Messages::WellStockResourceIO, type: :model do
       ],
       'stock_resource_id' => well.id,
       'stock_resource_uuid' => well.uuid,
-      'machine_barcode' => '1220012345855',
+      'machine_barcode' => 'DN12345U',
       'human_barcode' => 'DN12345U',
       'labware_coordinate' => 'A1',
 


### PR DESCRIPTION
Send machine_barcode to warehouse instead of ean13_barcode
- needed because ean13_barcode returns null for foreign barcodes, and the MLWH column can't cope with nulls
- these are methods on plate
- target table is stock_resource, column labware_machine_barcode
- machine_barcode will return the ean13 barcode for old plates
- on newer plates, the actual number encoded by the barcode is the same as the human readable one, so machine_barcode returns the human one

Closes #

Changes proposed in this pull request:

*
*
* ...
