### PR TITLE
GPL-557 fix 2

### DIFF
--- a/app/models/api/messages/tube_stock_resource_io.rb
+++ b/app/models/api/messages/tube_stock_resource_io.rb
@@ -14,7 +14,7 @@ class Api::Messages::TubeStockResourceIO < Api::Base
   map_attribute_to_json_attribute(:subject_type, 'labware_type')
 
   with_association(:labware) do
-    map_attribute_to_json_attribute(:ean13_barcode, 'machine_barcode')
+    map_attribute_to_json_attribute(:machine_barcode, 'machine_barcode')
     map_attribute_to_json_attribute(:human_barcode, 'human_barcode')
   end
 


### PR DESCRIPTION
do the same for tubes as I did for wells - because ean13 is null for foreign barcodes
