### PR TITLE
Filter all requests if none selected

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -422,6 +422,7 @@ class BatchesController < ApplicationController
   def standard_create(requests)
     return pipeline_error_on_batch_creation('All plates in a submission must be selected') unless @pipeline.all_requests_from_submissions_selected?(requests)
     return pipeline_error_on_batch_creation("Maximum batch size is #{@pipeline.max_size}") if @pipeline.max_size && requests.length > @pipeline.max_size
+    return pipeline_error_on_batch_creation('Batches must contain at least one request') if requests.empty?
 
     begin
       ActiveRecord::Base.transaction do

--- a/app/models/pipeline/grouper_by_parent_and_submission.rb
+++ b/app/models/pipeline/grouper_by_parent_and_submission.rb
@@ -15,7 +15,8 @@ class Pipeline::GrouperByParentAndSubmission < Pipeline::GrouperForPipeline
     # to trigger at different levels. We probably only want to switch to the
     # native function when it no longer builds its queries recursively. (Or when
     # ruby handles recursive method calls differently.)
-    base_scope.where(queries.join(' OR '))
+    combined_queries = queries.join(' OR ').presence || 'FALSE'
+    base_scope.where(combined_queries)
   end
 
   private


### PR DESCRIPTION
If no requests were selected, no condition would be applied.
Instead all requests on base scope would be returned.
By returning false if there are no conditions we ensure that no requests
will be found.

We also add a bit of error handling to the requests controller to prevent creation
of empty batches. Ideally that would be handled
by the batch validation but things
are currently hooked up incorrectly for
that, and this fix is urgent.

Closes #

Changes proposed in this pull request:

*
*
* ...
