### PR TITLE
Reset barcode counter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -149,9 +149,9 @@ RSpec.configure do |config|
   end
 
   config.before do
-    # Reset the barcode_number sequence at the beginning of each
+    # Reset the all sequences at the beginning of each
     # test to reduce the impact test order has on test execution
-    FactoryBot.sequence_by_name(:barcode_number).rewind
+    FactoryBot.rewind_sequences
   end
 
   config.before(:each, js: true) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,12 @@ RSpec.configure do |config|
     Warren.handler.disable!
   end
 
+  config.before do
+    # Reset the barcode_number sequence at the beginning of each
+    # test to reduce the impact test order has on test execution
+    FactoryBot.sequence_by_name(:barcode_number).rewind
+  end
+
   config.before(:each, js: true) do
     page.driver.browser.manage.window.resize_to(1024, 1024)
   end


### PR DESCRIPTION
FactoryBot sequences are scoped to the entire test suite, and help ensure that we maintain unique values.

However, this does mean that the values vary depending on when in the test suite the test
is run. This is especially significant for barcodes. While this avoids unintentional coupling of test expectations to the order in which plates are created, it results in frustrating random failures if the generated barcodes happen to coincide with explicitly defined ones.

**Pros**
1. Consistent sequences per test, removing one source of test-order linked failure.
2. Keeps generated barcodes nice and low, just a little easier to read.

**Cons**
1. Makes it easier to inadvertently couple test behaviour to order or operations. Could result in red-herring failures if refactoring changed the order of operations.
2. Could hide any failures associated with getting different barcodes that generated with the test suite. (Unlikely, but on a handful of occasions I've hardcoded a barcode when prototyping, and this could hide that)