### PR TITLE
Fix error handling

### DIFF
--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -315,7 +315,7 @@ class CherrypickTask < Task
   def do_task(workflow_controller, params)
     workflow_controller.do_cherrypick_task(self, params)
   rescue Cherrypick::Error => e
-    workflow.send(:flash)[:error] = e.message
+    workflow_controller.send(:flash)[:error] = e.message
     false
   end
 


### PR DESCRIPTION
Push errors out to the workflow_controller, not the workflow.
In a sane world we'd have the task return false and populate and error message, rather than  constantly making calls into the controller.

Closes #

Changes proposed in this pull request:

*
*
* ...
