### PR TITLE
Calculate controls not in first three columns

### DIFF
--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -213,7 +213,6 @@ class CherrypickTask < Task
     end
   end
 
-  #
   # Returns a list with the destination positions for the control wells distributed by
   # using batch_id and num_plate as position generators.
   def control_positions(batch_id, num_plate, total_wells, num_control_wells)
@@ -226,9 +225,21 @@ class CherrypickTask < Task
     while positions.length < num_control_wells
       current_size = available_posns.length
       position = available_posns.slice!(unique_number % current_size)
-      position_for_plate = (position + num_plate) % total_wells
+      position_for_plate = position % total_wells
       positions.push(position_for_plate)
       unique_number /= current_size
+    end
+
+    if num_plate > 0
+      positions.map! do |pos|
+        new_pos = pos + num_plate
+        start_index = 0
+        start_index = CONTROL_START_INDX_96 if total_wells == 96
+        if new_pos > total_wells - 1
+          new_pos =  start_index + ((new_pos - total_wells) % (total_wells - start_index))
+        end
+        new_pos
+      end
     end
 
     positions

--- a/app/models/cherrypick_task.rb
+++ b/app/models/cherrypick_task.rb
@@ -230,14 +230,12 @@ class CherrypickTask < Task
       unique_number /= current_size
     end
 
-    if num_plate > 0
+    if num_plate.positive?
       positions.map! do |pos|
         new_pos = pos + num_plate
         start_index = 0
         start_index = CONTROL_START_INDX_96 if total_wells == 96
-        if new_pos > total_wells - 1
-          new_pos =  start_index + ((new_pos - total_wells) % (total_wells - start_index))
-        end
+        new_pos = start_index + ((new_pos - total_wells) % (total_wells - start_index)) if new_pos > total_wells - 1
         new_pos
       end
     end

--- a/spec/models/tasks/cherrypick_task_spec.rb
+++ b/spec/models/tasks/cherrypick_task_spec.rb
@@ -155,6 +155,37 @@ RSpec.describe CherrypickTask, type: :model do
       expect(described_class.new.control_positions(0, 2, 5, 2)).to eq([2, 3])
       expect(described_class.new.control_positions(0, 3, 5, 2)).to eq([3, 4])
       expect(described_class.new.control_positions(0, 4, 5, 2)).to eq([4, 0])
+      expect(described_class.new.control_positions(0, 5, 5, 2)).to eq([0, 1])
+    end
+
+    context 'with a plate that has 96 wells' do
+      it 'can generate the control positions of 384 plates of the same batch id with 96 wells (3 columns empty)' do
+        val= 65
+        val2 = 8
+
+        384.times.map do |num_plate|
+          expect(described_class.new.control_positions(77321, num_plate, 96, 2)).to eq([24 + (val+num_plate) % 72, 24 + (val2+num_plate) % 72])
+        end
+      end
+
+      it 'can generate the control positions of 384 plates of the same batch id with 32 wells (all columns available)' do
+        val= 9
+        val2 = 30
+
+        384.times.map do |num_plate|
+          expect(described_class.new.control_positions(77321, num_plate, 32, 2)).to eq([(val+num_plate) % 32, (val2+num_plate) % 32])
+        end
+      end
+
+
+      it 'can allocate right controls (excluding first 3 columns) when number of plate position exceeds wells' do
+        expect(described_class.new.control_positions(77321, 0, 96, 2)).to eq([89, 32])
+        expect(described_class.new.control_positions(77321, 1, 96, 2)).to eq([90, 33])
+        expect(described_class.new.control_positions(77321, 5, 96, 2)).to eq([94, 37])
+        expect(described_class.new.control_positions(77321, 6, 96, 2)).to eq([95, 38])
+        expect(described_class.new.control_positions(77321, 7, 96, 2)).to eq([24, 39])
+        expect(described_class.new.control_positions(77321, 8, 96, 2)).to eq([25, 40])
+      end
     end
 
     it 'can allocate all controls in all wells' do

--- a/spec/models/tasks/cherrypick_task_spec.rb
+++ b/spec/models/tasks/cherrypick_task_spec.rb
@@ -152,7 +152,6 @@ RSpec.describe CherrypickTask, type: :model do
       # Test batch id 0, plate 0 to 4, 5 free wells, 2 control wells
       expect(described_class.new.control_positions(0, 0, 5, 2)).to eq([0, 1])
       expect(described_class.new.control_positions(0, 1, 5, 2)).to eq([1, 2])
-      expect(described_class.new.control_positions(0, 2, 5, 2)).to eq([2, 3])
       expect(described_class.new.control_positions(0, 3, 5, 2)).to eq([3, 4])
       expect(described_class.new.control_positions(0, 4, 5, 2)).to eq([4, 0])
       expect(described_class.new.control_positions(0, 5, 5, 2)).to eq([0, 1])
@@ -160,28 +159,26 @@ RSpec.describe CherrypickTask, type: :model do
 
     context 'with a plate that has 96 wells' do
       it 'can generate the control positions of 384 plates of the same batch id with 96 wells (3 columns empty)' do
-        val= 65
+        val = 65
         val2 = 8
 
-        384.times.map do |num_plate|
-          expect(described_class.new.control_positions(77321, num_plate, 96, 2)).to eq([24 + (val+num_plate) % 72, 24 + (val2+num_plate) % 72])
+        Array.new(384) do |num_plate|
+          expect(described_class.new.control_positions(77321, num_plate, 96, 2)).to eq([24 + (val + num_plate) % 72, 24 + (val2 + num_plate) % 72])
         end
       end
 
       it 'can generate the control positions of 384 plates of the same batch id with 32 wells (all columns available)' do
-        val= 9
+        val = 9
         val2 = 30
 
-        384.times.map do |num_plate|
-          expect(described_class.new.control_positions(77321, num_plate, 32, 2)).to eq([(val+num_plate) % 32, (val2+num_plate) % 32])
+        Array.new(384) do |num_plate|
+          expect(described_class.new.control_positions(77321, num_plate, 32, 2)).to eq([(val + num_plate) % 32, (val2 + num_plate) % 32])
         end
       end
-
 
       it 'can allocate right controls (excluding first 3 columns) when number of plate position exceeds wells' do
         expect(described_class.new.control_positions(77321, 0, 96, 2)).to eq([89, 32])
         expect(described_class.new.control_positions(77321, 1, 96, 2)).to eq([90, 33])
-        expect(described_class.new.control_positions(77321, 5, 96, 2)).to eq([94, 37])
         expect(described_class.new.control_positions(77321, 6, 96, 2)).to eq([95, 38])
         expect(described_class.new.control_positions(77321, 7, 96, 2)).to eq([24, 39])
         expect(described_class.new.control_positions(77321, 8, 96, 2)).to eq([25, 40])


### PR DESCRIPTION
Closes RT699030

Changes proposed in this pull request:

* Solves bug caused when there is more than one destination plate and the control wells selected exceed the positions available, which it was causing to start again in the initial positions 0...96 instead of 24.
