### PR TITLE
Add verbose query logging

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,6 +49,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Highlight code that triggered database queries in logs.
+  config.active_record.verbose_query_logs = true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
Verbose logging adds line numbers as comments to SQL queries,
which means you can see exactly where each query is coming from
in the debug logs in the console.