### PR TITLE
Improve developer onboarding

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,9 +12,24 @@ end
 chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
+  puts '== Checking basics'
+  expected_version = (/[\d.]+/.match(File.read('.ruby-version')))[0]
+  unless RUBY_VERSION == expected_version
+    puts "Expected ruby #{expected_version} got #{RUBY_VERSION}"
+    puts "Please install ruby #{expected_version}"
+    puts "You may want to install a ruby version manager"
+    puts "https://github.com/rbenv/rbenv"
+  end
 
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
+
+  # Check to see if we can install the oracle gems
+  unless ENV['DYLD_LIBRARY_PATH'] || ENV['DYLD_FALLBACK_LIBRARY_PATH'] || ENV['OCI_DIR']
+    puts "No Oracle configuration detected disabling associated gems"
+    system!('bundle config without warehouse')
+  end
+
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies if using Yarn


### PR DESCRIPTION
On getting my new laptop I used bin/setup to get my Sequencescape
install working, and it was almost perfect.

This commit automatically disables the warehouse gems if no
Oracle drivers are present.

It also adds a simple ruby version check, with a link to rbenv.
