### PR TITLE
GPL-670 Fix large batch request failures

### DIFF
--- a/app/assets/stylesheets/all/sequencescape.scss
+++ b/app/assets/stylesheets/all/sequencescape.scss
@@ -163,7 +163,7 @@ div.quota {
   }
   div.field {
     @extend .col-sm-10;
-    input { @extend .form-control; }
+    input, textarea { @extend .form-control; }
     select { @extend .custom-select; }
     .form-help {
       @extend .text-muted;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ require 'authenticated_system'
 # Likewise, all the methods added will be available for all controllers.
 
 class ApplicationController < ActionController::Base
+  # {FlashTruncation} provides the #truncate_flash method for automatically trimming
+  # large flash messages to prevent cookie overflow.
+  include FlashTruncation
+
   helper :all # include all helpers, all the time
 
   # See ActionController::RequestForgeryProtection for details

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -172,9 +172,9 @@ class BatchesController < ApplicationController
       fail_params = params.permit(:id, requested_fail: {}, requested_remove: {}, failure: %i[reason comment fail_but_charge])
       fail_and_remover = Batch::RequestFailAndRemover.new(fail_params)
       if fail_and_remover.save
-        flash[:notice] = fail_and_remover.notice
+        flash[:notice] = truncate_flash(fail_and_remover.notice)
       else
-        flash[:error] = fail_and_remover.errors.full_messages.join(';')
+        flash[:error] = truncate_flash(fail_and_remover.errors.full_messages.join(';'))
       end
       redirect_to action: :fail, id: params[:id]
     end

--- a/app/controllers/concerns/flash_truncation.rb
+++ b/app/controllers/concerns/flash_truncation.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Module FlashTruncation provides the truncate_flash method to automatically
+# trim long flash messages to prevent them from overflowing the cookie
+#
+# @author Genome Research Ltd.
+#
+module FlashTruncation
+  # Encoding a json string results in a two-byte overhead for the " either side.
+  # Taking this into account is strictly unnecessary, as we've already got a bit
+  # of overhead built in, but lets keep things as predictable as possible.
+  STRING_OVERHEAD = 2
+
+  #
+  # Truncates the flash message to avoid an ActionDispatch::Cookies::CookieOverflow.
+  # Maximum cookie size is checked against ActionDispatch::Cookies::MAX_COOKIE_SIZE which is 4096
+  # bytes; however:
+  # - This is the size of the session cookie post encryption, which inflates the size
+  # - This cookie also needs to contain other data, such as the session_id, user_uuid and user_name
+  #
+  # @param [Array, String] message The flash to truncate
+  # @param [Integer] max_size The maximum allowed flash size
+  #
+  # @return [Array, String] The truncated message
+  #
+  def truncate_flash(message, max_size = max_flash_size)
+    return message if message.to_json.bytesize <= max_size
+
+    case message
+    when String
+      message.truncate(max_size - STRING_OVERHEAD)
+    when Array
+      truncate_flash_array(message, max_size)
+    end
+  end
+
+  # The maximum cookie size is 4096 bytes, however this is post-encryption, which increases the size.
+  # The value of 2048 was obtained by mapping the size of encrypted strings. In practice 2255 bytes was the
+  # largest size, but I rounded down to 2kb to provide a bit of overhead for array serialization, additional
+  # flash information to and allow for slight implementation changes.
+  def max_flash_size
+    2048 - session.to_json.bytesize
+  end
+
+  # @see truncate_flash
+  # Handles truncation of arrays passed to the flash. This is not intended to be used directly,
+  # instead use truncate_flash.
+  #
+  # @param [Array] array The flash to truncate
+  # @param [Integer] max_size The maximum allowed flash size
+  #
+  # @return [Array] The truncated array
+  #
+  def truncate_flash_array(array, max_size = max_flash_size)
+    array.each_with_object([]) do |message, messages|
+      remaining = max_size - messages.to_json.bytesize
+      return messages if remaining <= 0
+
+      messages << truncate_flash(message, remaining)
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -207,14 +207,6 @@ module ApplicationHelper
     tag.div(class: ['tab-pane', 'fade', 'show', active_class], id: id, role: 'tabpanel', aria_labelledby: tab_id, &block)
   end
 
-  def item_status(item)
-    if item.failures.empty?
-      ''
-    else
-      '<span style="color:red;">FAILED</span>'
-    end
-  end
-
   def display_request_information(request, rit, batch = nil)
     r = request.value_for(rit.name, batch)
     r.presence || 'NA'

--- a/app/models/batch/request_fail_and_remover.rb
+++ b/app/models/batch/request_fail_and_remover.rb
@@ -41,16 +41,16 @@ class Batch::RequestFailAndRemover
 
   def fail_requests
     @batch.fail_batch_items(@requested_fail, reason, comment, fail_but_charge)
-    notice << "#{requested_fail.to_sentence} set to failed.#{charge_message}"
+    notice << "#{requested_fail.length} requests failed#{charge_message}: #{requested_fail.to_sentence}."
   end
 
   def remove_requests
     @batch.remove_request_ids(requested_remove, reason, comment)
-    notice << "#{requested_remove.to_sentence} removed."
+    notice << "#{requested_remove.length} requests removed: #{requested_remove.to_sentence}."
   end
 
   def charge_message
-    fail_but_charge ? ' The customer will still be charged.' : ''
+    fail_but_charge ? ', the customer will still be charged.' : ''
   end
 
   def requested_fail

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -381,9 +381,9 @@ class Request < ApplicationRecord
   end
 
   def get_value(request_information_type)
-    return '' unless request_metadata.respond_to?(request_information_type.key.to_sym)
+    return '' unless request_metadata.respond_to?(request_information_type.key)
 
-    value = request_metadata.send(request_information_type.key.to_sym)
+    value = request_metadata.send(request_information_type.key)
     return value.to_s if value.blank? or request_information_type.data_type != 'Date'
 
     value.to_date.strftime('%d %B %Y')
@@ -393,7 +393,10 @@ class Request < ApplicationRecord
     rit = RequestInformationType.find_by(name: name)
     rit_value = get_value(rit) if rit.present?
     return rit_value if rit_value.present?
+    event_value_for(name, batch)
+  end
 
+  def event_value_for(name, batch=nil)
     list = (batch.present? ? lab_events_for_batch(batch) : lab_events)
     list.each { |event| desc = event.descriptor_value_for(name) and return desc }
     ''
@@ -404,7 +407,11 @@ class Request < ApplicationRecord
   end
 
   def lab_events_for_batch(batch)
-    lab_events.where(batch_id: batch.id)
+    if lab_events.loaded?
+      lab_events.select { |le| le.batch_id == batch.id }
+    else
+      lab_events.where(batch_id: batch.id)
+    end
   end
 
   def event_with_key_value(k, v = nil)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -393,10 +393,11 @@ class Request < ApplicationRecord
     rit = RequestInformationType.find_by(name: name)
     rit_value = get_value(rit) if rit.present?
     return rit_value if rit_value.present?
+
     event_value_for(name, batch)
   end
 
-  def event_value_for(name, batch=nil)
+  def event_value_for(name, batch = nil)
     list = (batch.present? ? lab_events_for_batch(batch) : lab_events)
     list.each { |event| desc = event.descriptor_value_for(name) and return desc }
     ''

--- a/app/models/well.rb
+++ b/app/models/well.rb
@@ -311,8 +311,9 @@ class Well < Receptacle
   end
 
   def display_name
-    plate_name = plate.present? ? plate.human_barcode : '(not on a plate)'
-    plate_name ||= plate.display_name # In the even the plate is barcodeless (ie strip tubes) use its name
+    source = association_cached?(:plate) ? plate : labware
+    plate_name = source.present? ? source.human_barcode : '(not on a plate)'
+    plate_name ||= source.display_name # In the even the plate is barcodeless (ie strip tubes) use its name
     "#{plate_name}:#{map_description}"
   end
 

--- a/app/views/batches/_batch_fail.html.erb
+++ b/app/views/batches/_batch_fail.html.erb
@@ -5,7 +5,8 @@
       No libraries found.
     </div>
   <% else -%>
-    <table class="sortable">
+    <% request_actions = @batch.pipeline.request_actions %>
+    <table class="sortable table table-dense-information">
       <thead>
         <tr>
           <th>Sample</th>
@@ -17,26 +18,25 @@
           <th>From</th>
           <th>To</th>
           <th>Conc.</th>
-          <% @batch.pipeline.request_actions.each do |action| -%>
+          <% request_actions.each do |action| -%>
             <th class="nosort">
               <%= action.to_s.capitalize %>
               <input type='checkbox' id='select_all_<%= action.to_s %>' class='select_all' data-action='<%= action.to_s %>'>
             </th>
           <% end %>
-          <th>&nbsp;</th>
         </tr>
       </thead>
       <tbody>
-        <% requests.each_with_index do |request, index| -%>
+        <% requests.includes([:request_metadata, :batch_request, :lab_events, :failures, { asset: [:map, :parents, {labware: [:barcodes]}]}]).each_with_index do |request, index| -%>
           <tr>
-            <td>
+            <td><%# Sample (But shows parent barcodes?) %>
               <% request.asset&.parents&.each do |parent| %>
                 <%= link_to parent.human_barcode, labware_path(parent), target: "_blank" %>
               <% end %>
             </td>
 
             <% if  request.asset %>
-              <td><%= request.asset.try(:numan_barcode) %></td>
+              <td><%= request.asset.try(:human_barcode) %></td>
               <td><%= h(request.asset.display_name) %></td>
             <% else %>
               <td></td>
@@ -44,31 +44,30 @@
             <% end %>
 
             <td><%= link_to request.id, request_url(request), target: "_blank" %></td>
-            <td><%= request.value_for("Read length", @batch) %></td>
+            <td><%= request.request_metadata.read_length %></td>
             <td><%= request.position %></td>
-            <td><%= request.value_for("Fragment size required (from)", @batch) %></td>
-            <td><%= request.value_for("Fragment size required (to)", @batch) %></td>
-            <td><%= request.value_for("Concentration", @batch) %></td>
+            <td><%= request.request_metadata.fragment_size_required_from %></td>
+            <td><%= request.request_metadata.fragment_size_required_to %></td>
+            <td><%= request.event_value_for("Concentration", @batch) %></td>
 
             <% if request.failures.empty? -%>
               <% if request.asset && request.asset.resource? -%>
-                <% @batch.pipeline.request_actions.each do |action| -%>
-                  <td class="7%"><input name='requested_fail[control]' type='checkbox'></td>
+                <% request_actions.each do |action| -%>
+                  <td><input name='requested_fail[control]' type='checkbox'></td>
                 <% end %>
               <% else -%>
-                <% @batch.pipeline.request_actions.each do |action| -%>
-                  <td class="7%">
+                <% request_actions.each do |action| -%>
+                  <td>
                     <label for="requested_<%= action.to_s %>_<%= request.id %>" style="display:none;"><%= action.to_s.capitalize %> request <%= index+1 %></label>
                     <input name='requested_<%= action.to_s %>[<%= request.id %>]' id="requested_<%= action.to_s %>_<%= request.id %>" type='checkbox' class='select_<%= action.to_s %> select_all_target' data-action='<%= action.to_s %>'>
                   </td>
                 <% end %>
               <% end -%>
             <% else -%>
-              <% @batch.pipeline.request_actions.each do |action| -%>
-                <td class="7%">&nbsp;</td>
-              <% end %>
+              <td colspan='<%=  request_actions.length %>'>
+                <%= badge('failed') %>
+              </td>
             <% end -%>
-            <td class="7%"><%= item_status(request) %></td>
           </tr>
         <% end -%>
       </tbody>

--- a/app/views/batches/fail.html.erb
+++ b/app/views/batches/fail.html.erb
@@ -3,35 +3,33 @@
 <% add :menu, "Edit batch" => edit_batch_path(@batch) -%>
 <% add :back_menu, "Back to batch" => batch_path(@batch) -%>
 
-<div class="page-header"><h1>FAIL ITEMS IN BATCH <%= @batch.id %></h1></div>
+<%= page_title "Fail batch requests", @batch.id %>
+
 <div class="info">
   Removing a request from a batch will result in it being returned to the inbox to be reprocessed. <br/ >
   Failing a request will result in an email being generated and sent to the project's PM.  This request will not be returned to the inbox. <br/>
   Batches will automatically be failed when all requests in them have been failed, cancelled or removed.
 </div>
+
 <%= form_tag(controller: :batches, action: :fail_items, id: @batch.id ) do -%>
 
 <%= render partial: "batch_fail", locals: { requests: @batch.ordered_requests, edit: false } %>
 
-<div class="page-header"><h1>FAILURE REASON</h1></div>
-<div class="info">
-  <table width="100%" cellspacing="0" cellpadding="0">
-    <tr>
-      <td width="35%" class="item"><%= label_tag(:failure_reason, 'Select failure reason') %>:</td>
-      <td width="65%"><%= select :failure, :reason, @fail_reasons, {prompt: 'Select Reason'} %></td>
-    </tr>
-    <tr>
-      <td width="35%" class="item">Comment:</td>
-      <td width="65%"><%= text_area :failure, :comment, size: "40x6" %></td>
-    </tr>
-    <tr>
-      <td width="35%" class="item"><%= label_tag('failure_fail_but_charge', 'Fail but charge')%></td>
-      <td width="65%"><%= check_box :failure, :fail_but_charge %></td>
-    </tr>
-    <tr>
-      <td width="35%" class="item">&nbsp;</td><td width="65%"><%= submit_tag 'Fail selected requests', value: 'Fail selected requests' %></td>
-    </tr>
-  </table>
+<div class="page-header"><h2>Failure Reason</h2></div>
+<div class="grid-form">
+  <%= label_tag(:failure_reason, 'Select failure reason') %>
+  <div class="field"><%= select :failure, :reason, @fail_reasons, {prompt: 'Select Reason'} %></div>
+</div>
+<div class="grid-form">
+   <%= label_tag(:failure_comment, 'Comment') %>
+   <div class="field"><%= text_area :failure, :comment, size: "40x6" %></div>
+</div>
+<div class="grid-form">
+  <%= label_tag('failure_fail_but_charge', 'Fail but charge')%>
+  <div class="field"><%= check_box :failure, :fail_but_charge %></div>
+</div>
+<div class="grid-form">
+  <%= submit_tag 'Fail selected requests', value: 'Fail selected requests' %>
 </div>
 <% end -%>
 <%= javascript_include_tag 'fail_batch.js' %>

--- a/spec/controllers/concerns/flash_truncation_spec.rb
+++ b/spec/controllers/concerns/flash_truncation_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe FlashTruncation do
+  let(:dummy_class) { Struct.new(:session) { include FlashTruncation } }
+
+  describe '#max_flash_size' do
+    subject { dummy_class.new(session).max_flash_size }
+
+    context 'when the session is 2 bytes' do
+      let(:session) { {} }
+      it { is_expected.to eq 2046 }
+    end
+
+    context 'when the session is 32 bytes' do
+      let(:session) { { user_name: 'Testy McTestface' } }
+      it { is_expected.to eq 2016 }
+    end
+  end
+
+  describe '#truncate_flash' do
+    subject { dummy_class.new({}).truncate_flash(flash, 16) }
+
+    context 'when the flash is a string smaller than the max_size' do
+      let(:flash) { 'A short string' }
+      it { is_expected.to eq flash }
+    end
+
+    context 'when the flash is a string larger than the max_size' do
+      let(:flash) { 'A longer st...' }
+      it { is_expected.to eq flash }
+    end
+
+    context 'when the flash is an array smaller than the max_size' do
+      let(:flash) { %w[shrt array] }
+      it { is_expected.to eq flash }
+    end
+
+    context 'when the flash is an array larger than the max_size' do
+      let(:flash) { ['longer', 'array', 'oh no'] }
+      it { is_expected.to eq ['longer', 'a...'] }
+    end
+  end
+end

--- a/spec/controllers/concerns/flash_truncation_spec.rb
+++ b/spec/controllers/concerns/flash_truncation_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe FlashTruncation do
 
     context 'when the session is 2 bytes' do
       let(:session) { {} }
+
       it { is_expected.to eq 2046 }
     end
 
     context 'when the session is 32 bytes' do
       let(:session) { { user_name: 'Testy McTestface' } }
+
       it { is_expected.to eq 2016 }
     end
   end
@@ -24,21 +26,25 @@ RSpec.describe FlashTruncation do
 
     context 'when the flash is a string smaller than the max_size' do
       let(:flash) { 'A short string' }
+
       it { is_expected.to eq flash }
     end
 
     context 'when the flash is a string larger than the max_size' do
       let(:flash) { 'A longer st...' }
+
       it { is_expected.to eq flash }
     end
 
     context 'when the flash is an array smaller than the max_size' do
       let(:flash) { %w[shrt array] }
+
       it { is_expected.to eq flash }
     end
 
     context 'when the flash is an array larger than the max_size' do
       let(:flash) { ['longer', 'array', 'oh no'] }
+
       it { is_expected.to eq ['longer', 'a...'] }
     end
   end


### PR DESCRIPTION
Fix user failure of large batches

fixes #2920

Large batches were generating 500s on failure as the resulting flash was too large.

- Add flash truncation library
- Truncate batch failure message
- Rephrase batch error messages
- Improve performance and appearance

Before:
![Screenshot 2020-09-30 at 15 35 19](https://user-images.githubusercontent.com/1283620/94699982-dca54980-0332-11eb-9039-2aac92c086c6.png)
After:
![Screenshot 2020-09-30 at 15 32 00](https://user-images.githubusercontent.com/1283620/94700016-ea5acf00-0332-11eb-9980-1e1e09e04447.png)
