### PR TITLE
Document event edge case

### DIFF
--- a/app/models/broadcast_event/order_made.rb
+++ b/app/models/broadcast_event/order_made.rb
@@ -7,6 +7,35 @@ class BroadcastEvent::OrderMade < BroadcastEvent
 
   # The seed itself can be a subject
   seed_subject :order
+
+  # !CAUTION!
+  # Be careful before changing this behaviour, as it could impact
+  # on users of the events warehouse.
+  # Discussion with jgrg 29/10/2020:
+  # > jgrg: I guess the reason removing "event_types.key = 'order_made'" pulls in
+  # > samples from other projects is that some events involve samples from
+  # > multiple projects, such as when samples from multiple projects are
+  # > loaded on the same flowcell. Will "order_made" always be confined to
+  # > samples in our project
+  #
+  # This assumption is currently *true* for all order_made events, however it
+  # will be potentially impacted if we change the behaviour of cross-study
+  # or cross-project orders.
+  #
+  # A cross-study/cross-project order is currently generated if sequencing
+  # is requested *directly* on multiplexed library containing samples from
+  # different studies/projects. This mostly occurs with re-sequencing, but
+  # can also happen during GBS, custom-pooling, or situations in which the
+  # sequencing request creation is deferred until after multiplexing.
+  #
+  # Currently these orders are not explicitly associated with *any* study/project
+  # (ie. study_id and project_id on order are nil), and this event uses this
+  # explicit link. As a result, these orders have no projects/studies associated
+  # as subjects.
+  #
+  # If this behaviour changes in future to reference the *implicit* studies,
+  # then please try to generate multiple Events per order. (Note you'll want
+  # to filter the samples associated with the event as well)
   has_subject(:study, :study)
   has_subject(:project, :project)
   has_subject(:submission, :submission)

--- a/app/models/broadcast_event/order_made.rb
+++ b/app/models/broadcast_event/order_made.rb
@@ -35,7 +35,7 @@ class BroadcastEvent::OrderMade < BroadcastEvent
   #
   # If this behaviour changes in future to reference the *implicit* studies,
   # (those associated with the aliquots in the tube) then please try to generate
-  # multiple Events per order. (Note you'll want to filter the samples associated 
+  # multiple Events per order. (Note you'll want to filter the samples associated
   # with the event as well)
   has_subject(:study, :study)
   has_subject(:project, :project)

--- a/app/models/broadcast_event/order_made.rb
+++ b/app/models/broadcast_event/order_made.rb
@@ -23,7 +23,7 @@ class BroadcastEvent::OrderMade < BroadcastEvent
   # or cross-project orders.
   #
   # A cross-study/cross-project order is currently generated if sequencing
-  # is requested *directly* on multiplexed library containing samples from
+  # is requested *directly* on multiplexed library tubes containing samples from
   # different studies/projects. This mostly occurs with re-sequencing, but
   # can also happen during GBS, custom-pooling, or situations in which the
   # sequencing request creation is deferred until after multiplexing.

--- a/app/models/broadcast_event/order_made.rb
+++ b/app/models/broadcast_event/order_made.rb
@@ -29,9 +29,9 @@ class BroadcastEvent::OrderMade < BroadcastEvent
   # sequencing request creation is deferred until after multiplexing.
   #
   # Currently these orders are not explicitly associated with *any* study/project
-  # (ie. study_id and project_id on order are nil), and this event uses this
-  # explicit link. As a result, these orders have no projects/studies associated
-  # as subjects.
+  # (ie. study_id and project_id on order are nil)
+  # The order_made event links projects/studies as subjects only if this explicit link is present.
+  # As a result, these orders have no projects/studies associated as subjects.
   #
   # If this behaviour changes in future to reference the *implicit* studies,
   # then please try to generate multiple Events per order. (Note you'll want

--- a/app/models/broadcast_event/order_made.rb
+++ b/app/models/broadcast_event/order_made.rb
@@ -34,8 +34,9 @@ class BroadcastEvent::OrderMade < BroadcastEvent
   # As a result, these orders have no projects/studies associated as subjects.
   #
   # If this behaviour changes in future to reference the *implicit* studies,
-  # then please try to generate multiple Events per order. (Note you'll want
-  # to filter the samples associated with the event as well)
+  # (those associated with the aliquots in the tube) then please try to generate
+  # multiple Events per order. (Note you'll want to filter the samples associated 
+  # with the event as well)
   has_subject(:study, :study)
   has_subject(:project, :project)
   has_subject(:submission, :submission)


### PR DESCRIPTION
Following a discussion with jgrg today it became apparant that we have
a potential future risk should we change our handling of cross-study or
cross-project orders. While it would not be *incorrect* to associate
multiple studyes with an order event, it would reduce utility for users
of the event warehouse.