### PR TITLE
GPL560 - Extend samples api

### DIFF
--- a/app/resources/api/v2/labware_resource.rb
+++ b/app/resources/api/v2/labware_resource.rb
@@ -15,6 +15,8 @@ module Api
         records.joins(:purpose).where(plate_purposes: { name: value })
       end)
       filter :purpose_id, apply: ->(records, value, _options) { records.where(plate_purpose_id: value) }
+      filter :barcode, apply: ->(records, value, _options) { records.with_barcode(value) }
+      filter :uuid, apply: ->(records, value, _options) { records.with_uuid(value) }
     end
   end
 end

--- a/app/resources/api/v2/sample_resource.rb
+++ b/app/resources/api/v2/sample_resource.rb
@@ -14,6 +14,10 @@ module Api
       attribute :uuid
       attribute :control
       attribute :control_type
+
+      filter :uuid
+      filter :sanger_sample_id
+      filter :name
     end
   end
 end

--- a/app/resources/api/v2/tube_rack_resource.rb
+++ b/app/resources/api/v2/tube_rack_resource.rb
@@ -11,7 +11,7 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
+      default_includes :uuid_object, :barcodes
 
       # Associations:
       has_many :racked_tubes


### PR DESCRIPTION
Adds:

- uuid, sanger_sample_id and sample_name filters to sample API (required for backfill of samples_extraction data)
- barcode, uuid filters to labware - To make this endpoint actually useful
- barcodes to TubeRack default includes. Avoids N+1 issue on retrieving tube racks
