### PR TITLE
Hotfix template naming format

### DIFF
--- a/lib/tasks/generate_primer_panel_templates.rake
+++ b/lib/tasks/generate_primer_panel_templates.rake
@@ -19,7 +19,7 @@ namespace :primer_panel_templates do
       end
       varieties.each do |variety|
         existing_template.dup.tap do |new_template|
-          new_template.name = "#{existing_template_name} - #{primer_panel_suffix} - #{variety}"
+          new_template.name = "#{existing_template_name}-#{variety}-#{primer_panel_suffix}"
           next if TagLayoutTemplate.find_by(name: new_template.name)
 
           new_template.save!


### PR DESCRIPTION
The previous naming format generated long names, where important
information was pushed off the labels.

This change:
1) Front-loads important information
2) Shortens the text printed on the label

I'll rename the existing templates manually with:
```
[
  ['TSsc384 - nCoV-2019/V3/B - PCR1', 'TSsc384-PCR1-nCoV-2019/V3/B'],
  ['TSsc384 - nCoV-2019/V3/B - PCR1', 'TSsc384-PCR1-nCoV-2019/V3/B']
].each do |from, to|
  TagLayoutTemplate.find_by!(name: from).update!(name: to)
end
```
This allows us to apply the changes along with the validation changes in limber and avoid the need for multiple releases.