### PR TITLE
Add removal date for sample registration

### DIFF
--- a/app/views/studies/sample_registration/index.html.erb
+++ b/app/views/studies/sample_registration/index.html.erb
@@ -5,6 +5,7 @@
 <div class="page-header"><h1>Sample registration</h1></div>
 
 <%= deprecate_section(
+   date: Date.parse('2021-02-01'),
    message:'<p class="lead">The preferred method of registering samples is sample manifests.</p>
   <ul>
     <li>Sample manifests support both plates and tubes</li>
@@ -14,7 +15,7 @@
     in filling out the spreadsheet.</li>
   </ul>
   <p>If there is functionality you need that is not provided by sample manifests
-  then please let us know. The intent is to remove this page in future.</p>'.html_safe,
+  then please let us know. This page will be automatically removed at the end of January 2021.</p>'.html_safe,
    replaced_by: sample_manifests_study_path(@study)) do %>
    <h2><%= link_to "1. Manual entry", new_study_sample_registration_path %></h2>
    <p>Type your samples in online using the manual entry form.</p>
@@ -22,4 +23,3 @@
    <h2><%= link_to "2. Spreadsheet load", upload_study_sample_registration_index_path %></h2>
    <p>Pre-populate the manual entry form with values from an Excel spreadsheet.</p>
 <% end %>
-

--- a/app/views/studies/sample_registration/new.html.erb
+++ b/app/views/studies/sample_registration/new.html.erb
@@ -6,6 +6,7 @@
 <div class="page-header"><h1>Sample registration</h1></div>
 
 <%= deprecate_section(
+   date: Date.parse('2021-02-01'),
    message:'<p class="lead">The preferred method of registering samples is sample manifests.</p>
   <ul>
     <li>Sample manifests support both plates and tubes</li>
@@ -15,8 +16,7 @@
     in filling out the spreadsheet.</li>
   </ul>
   <p>If there is functionality you need that is not provided by sample manifests
-  then please let us know. The intent is to remove this page in future.</p>'.html_safe,
+  then please let us know. This page will be automatically removed at the end of January 2021.</p>'.html_safe,
    replaced_by: sample_manifests_study_path(@study)) do %>
    <%= render partial: "sample_registrar" %>
 <% end %>
-

--- a/app/views/studies/sample_registration/upload.html.erb
+++ b/app/views/studies/sample_registration/upload.html.erb
@@ -9,6 +9,7 @@
     The Reference Genome list is <%= link_to "here", reference_genomes_path %>
 </div>
 <%= deprecate_section(
+   date: Date.parse('2021-02-01'),
    message:'<p class="lead">The preferred method of registering samples is sample manifests.</p>
   <ul>
     <li>Sample manifests support both plates and tubes</li>
@@ -18,7 +19,7 @@
     in filling out the spreadsheet.</li>
   </ul>
   <p>If there is functionality you need that is not provided by sample manifests
-  then please let us know. The intent is to remove this page in future.</p>'.html_safe,
+  then please let us know. This page will be automatically removed at the end of January 2021.</p>'.html_safe,
    replaced_by: sample_manifests_study_path(@study)) do %>
     <%= form_tag spreadsheet_study_sample_registration_index_path, multipart: true do -%>
     <h2>1. Please select a spreadsheet to upload:</h2>


### PR DESCRIPTION
As discused on Slack, this page had the initial warning added in July/August
2019, and no one has contacted us to say they use it. This commit establishes
a removal date of 01/02/2021, at which point the form will automatically
disappear. I am preparing another branch that removes the associated code,
which can be merged in after this date.
