### PR TITLE
Rt707158 missing poolings new relationships

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -73,7 +73,9 @@ class Asset < ApplicationRecord
 
   scope :recent_first, -> { order(id: :desc) }
 
-  scope :include_for_show, -> { includes({ requests_as_source: %i[request_type request_metadata] }, requests_as_target: %i[request_type request_metadata]) }
+  # Includes are mostly handled in the views themselves, which allows us to be
+  # a bit more smart about what we load if necessary (Ie. different stuff for plates)
+  scope :include_for_show, -> { includes(:studies) }
 
   # The use of a sub-query here is a performance optimization. If we join onto the asset_links
   # table instead, rails is unable to paginate the results efficiently, as it needs to use DISTINCT

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -155,16 +155,6 @@ class Plate < Labware
   delegate :asset_shape, to: :plate_purpose, allow_nil: true
   delegate :dilution_factor, :dilution_factor=, to: :plate_metadata
 
-  scope :include_for_show, -> {
-    includes(
-      requests: :request_metadata,
-      wells: [
-        :map_id,
-        { aliquots: %i[samples tag tag2] }
-      ]
-    )
-  }
-
   # Submissions on requests out of the plate
   # May not have been started yet
   has_many :waiting_submissions, -> { distinct }, through: :well_requests_as_source, source: :submission

--- a/app/models/pooling.rb
+++ b/app/models/pooling.rb
@@ -26,7 +26,11 @@ class Pooling
 
   def transfer
     each_transfer do |source_asset, target_asset|
-      TransferRequest.create!(asset: source_asset, target_asset: target_asset)
+      # These transfers are not being performed to fulfil a specific request, so we explicitly
+      # pass in a Request Null object. This will disable the attempt to detect an outer request.
+      # We don't use nil as its *far* to easy to end up with nil by accident, so basing key behaviour
+      # off it is risky.
+      TransferRequest.create!(asset: source_asset, target_asset: target_asset, outer_request: Request::None.new)
     end
     message[:notice] = message[:notice] + success
   end

--- a/app/models/pooling.rb
+++ b/app/models/pooling.rb
@@ -61,7 +61,7 @@ class Pooling
   end
 
   def print_job_required?
-    barcode_printer.present?
+    barcode_printer.present? && count&.positive?
   end
 
   def print_job

--- a/app/models/request/none.rb
+++ b/app/models/request/none.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Null object for situations where you wish to explicitly indicate you have no
+# request. (In contrast to nil, which could too easily result from a bug)
+# Added to allow {Pooling} to indicate there should ne no outer request,
+# without risking incorrect behaviour if we pass in nil unintentionally.
+#
+class Request::None
+  def submission_id
+    nil
+  end
+
+  def id
+    nil
+  end
+
+  # Normal requests can inject attributes into aliquots created by transfer
+  # requests associated with the request.
+  # In the case of Request::None we return an empty hash, which ensures that no
+  # additional attributes are injected
+  def aliquot_attributes
+    {}
+  end
+end

--- a/app/models/transfer_request.rb
+++ b/app/models/transfer_request.rb
@@ -113,9 +113,9 @@ class TransferRequest < ApplicationRecord
   # Set the outer request associated with this transfer request
   # the outer request is the {Request} which is currently being processed,
   # such as a {LibraryCreationRequest}. Setting this ensures that the
-  # transfered {Aliquots} are associated with the correct request, and that
+  # transferred {Aliquots} are associated with the correct request, and that
   # submission_id on transfer request is recorded correctly.
-  # @note This is particularly important when transfering out of the initial
+  # @note This is particularly important when transferring out of the initial
   # {Receptacle} when there may be multiple active {Receptacle#requests_as_source}
   # @param request [Request] The request which is being processed
   def outer_request=(request)

--- a/app/views/labware/_relations.html.erb
+++ b/app/views/labware/_relations.html.erb
@@ -1,9 +1,12 @@
 <section id="relations-table-container" class='info-panel'>
   <header>
     <a href='#relations-table-collapser' role="button" data-toggle='collapse'>
+    <% t = Time.now; p 'START' %>
     <h3>Relations
       <%= counter_badge asset.parents.size, 'parent' %>
       <%= counter_badge asset.children.size, 'child' %>
+      <%= counter_badge asset.links_as_descendant.indirect.size, 'ancestors' %>
+      <%= counter_badge asset.links_as_ancestor.indirect.size, 'descendants' %>
       <small class='show-hide'>Click to toggle</small>
     </h3>
     </a>
@@ -14,34 +17,35 @@
         <tr>
           <th>Asset</th>
           <th>Relationship type</th>
-          <th>Map</th>
         </tr>
       </thead>
       <tbody>
-        <% asset.parents.each do |parent| %>
-        <tr>
-          <td><%= link_to "#{(parent.label or "").titleize}: #{parent.display_name}", labware_path(parent) %></td>
-          <td>Parent</td>
-          <td>
-            <% if parent.is_a?(Well) && parent.map %>
-              <%= parent.map.description %>
-            <% end %>
-          </td>
-        </tr>
+        <% asset.parents.find_each do |parent| %>
+          <tr>
+            <td><%= link_to "#{(parent.label or "").titleize}: #{parent.display_name}", labware_path(parent) %></td>
+            <td>Parent</td>
+          </tr>
         <% end %>
-
-        <% asset.children.each do |child| %>
-        <tr>
-          <td><%= link_to "#{child.label&.titleize}: #{child.display_name}", labware_path(child) %></td>
-          <td>Child</td>
-          <td>
-          <% if child.is_a?(Well) && child.map %>
-            <%= child.map.description %>
-          <% end %>
-          </td>
-        </tr>
+        <% asset.children.find_each do |child| %>
+          <tr>
+            <td><%= link_to "#{child.label&.titleize}: #{child.display_name}", labware_path(child) %></td>
+            <td>Child</td>
+          </tr>
+        <% end %>
+        <% asset.links_as_descendant.indirect.includes(:ancestor).find_each do |link| %>
+          <tr>
+            <td><%= link_to "#{(link.ancestor.label or "").titleize}: #{link.ancestor.display_name}", labware_path(link.ancestor) %></td>
+            <td>Ancestor</td>
+          </tr>
+        <% end %>
+        <% asset.links_as_ancestor.indirect.includes(:descendant).find_each do |link| %>
+          <tr>
+            <td><%= link_to "#{link.descendant.label&.titleize}: #{link.descendant.display_name}", labware_path(link.descendant) %></td>
+            <td>Descendant</td>
+          </tr>
         <% end %>
       </tbody>
     </table>
   </div>
+  <% p "END #{Time.now-t}s" %>
 </section>

--- a/app/views/labware/_requests.html.erb
+++ b/app/views/labware/_requests.html.erb
@@ -4,7 +4,7 @@
   <header>
     <a href='#requests-table-collapser' role="button" data-toggle='collapse'>
     <h3>Requests
-      <%= counter_badge asset.requests_as_source.length %>
+      <%= counter_badge asset.requests_as_source.size %>
       <small class='show-hide'>Click to toggle</small>
     </h3>
     </a>
@@ -28,7 +28,12 @@
         </tr>
       </thead>
       <tbody>
-        <% @asset.requests_as_source.includes(:submission, :request_type, :batch, target_asset: :map).each do |request| %>
+        <% @asset.requests_as_source.includes(
+          :submission,
+          :request_type,
+          :batch,
+          target_asset: [:map, { labware: :barcodes }]
+          ).each do |request| %>
         <tr>
           <td><%= link_to(request.id, request_url(request), title: "#{ request.request_type.try(:name) || 'Unknown' } request") %></td>
           <td><%= request.request_type&.name %></td>
@@ -86,7 +91,7 @@
         </tr>
       </thead>
       <tbody>
-        <% @asset.requests_as_target.includes(:submission, :request_type, :batch, target_asset: :map).each do |request| %>
+        <% @asset.requests_as_target.includes(:request_type, :batch, asset: [:map, { labware: :barcodes }], submission: :orders).each do |request| %>
         <tr>
           <td><%= link_to(request.id, request_url(request), title: "#{ request.request_type.try(:name) || 'Unknown' } request") %></td>
           <td><%= request.request_type&.name  %></td>

--- a/spec/factories/request_factories.rb
+++ b/spec/factories/request_factories.rb
@@ -52,6 +52,10 @@ FactoryBot.define do
       sti_type { 'CustomerRequest' } # Oddly, this seems to be necessary!
       association(:request_type, factory: :customer_request_type)
     end
+
+    factory :create_asset_request do
+      sti_type { 'CreateAssetRequest' } # Oddly, this seems to be necessary!
+    end
   end
 
   factory :sequencing_request, class: 'SequencingRequest' do

--- a/spec/models/pooling_spec.rb
+++ b/spec/models/pooling_spec.rb
@@ -11,7 +11,14 @@ describe Pooling, type: :model, poolings: true do
   let(:mx_tube) { create :multiplexed_library_tube, barcode: 6 }
   let(:stock_mx_tube_required) { false }
   let(:barcode_printer_option) { nil }
-  let(:pooling) { described_class.new(barcodes: barcodes, stock_mx_tube_required: stock_mx_tube_required, barcode_printer: barcode_printer_option) }
+  let(:pooling) do
+    described_class.new(
+      barcodes: barcodes,
+      stock_mx_tube_required: stock_mx_tube_required,
+      barcode_printer: barcode_printer_option,
+      count: 1
+    )
+  end
 
   context 'without source assets' do
     let(:barcodes) { [] }

--- a/spec/models/pooling_spec.rb
+++ b/spec/models/pooling_spec.rb
@@ -76,6 +76,23 @@ describe Pooling, type: :model, poolings: true do
       end
     end
 
+    # LibraryTubes created as part of an MX library manifest have two associated requests,
+    # the CreateAssetRequest and the ExternalLibraryCreationRequest. When the TransferRequest
+    # is created, it was attempting to associate itself with one of these requests, and then
+    # failing to disambiguate between them.
+    context 'when the source tubes are from an mx library manifest' do
+      before do
+        create :create_asset_request, asset: tagged_lb_tube1.receptacle
+        create(:external_multiplexed_library_tube_creation_request, asset: tagged_lb_tube1.receptacle)
+      end
+
+      let(:stock_mx_tube_required) { true }
+
+      it 'creates stock and standard mx tube' do
+        expect(pooling.execute).to be true
+      end
+    end
+
     context 'when a barcode printer is provided' do
       let(:barcode_printer) { create :barcode_printer }
       let(:barcode_printer_option) { barcode_printer.name }


### PR DESCRIPTION
Picked up some minor tweaks for RT#707158

- Poolings new wasn't creating asset-links, which made finding child tubes a bit tricky
- We only show direct parents and children on asset pages, this adds all ancestors and decendants
- Noticed a few performance issues which I decided to fix up.