### PR TITLE
Bug destination plate event no user

### DIFF
--- a/app/models/broadcast_event/plate_cherrypicked.rb
+++ b/app/models/broadcast_event/plate_cherrypicked.rb
@@ -34,9 +34,7 @@ class BroadcastEvent::PlateCherrypicked < BroadcastEvent
 
   def user_identifier
     # allows for user identifiers that aren't in the SS db
-    return properties[:user_identifier] if properties[:user_identifier]
-
-    super
+    properties[:user_identifier].presence || super
   end
 
   def robot_present

--- a/app/models/broadcast_event/plate_cherrypicked.rb
+++ b/app/models/broadcast_event/plate_cherrypicked.rb
@@ -32,6 +32,13 @@ class BroadcastEvent::PlateCherrypicked < BroadcastEvent
     _add_destination_plate
   end
 
+  def user_identifier
+    # allows for user identifiers that aren't in the SS db
+    return properties[:user_identifier] if properties[:user_identifier]
+
+    super
+  end
+
   def robot_present
     check_subject_role_type(:robot, ROBOT_ROLE_TYPE)
   end

--- a/spec/models/broadcast_events/plate_cherrypicked_spec.rb
+++ b/spec/models/broadcast_events/plate_cherrypicked_spec.rb
@@ -31,15 +31,6 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
     subject_record('plate', BroadcastEvent::PlateCherrypicked::DESTINATION_PLATE_ROLE_TYPE, '000003', uuids[5])
   end
 
-  def subject_record(subject_type, role_type, friendly_name, uuid)
-    {
-      "role_type": role_type,
-      "subject_type": subject_type,
-      "friendly_name": friendly_name,
-      "uuid": uuid
-    }
-  end
-
   it 'is not directly instantiated' do
     expect(described_class.new).not_to be_valid
   end
@@ -91,6 +82,8 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
 
   context 'with the right contents in properties and seed' do
     let(:props) {  { subjects: [plate1, plate2, sample1, sample2, robot] } }
+    # let(:props) {  user_identifier: 'jimmy', subjects: [plate1, plate2, sample1, sample2, robot] }
+
     let(:instance) { described_class.new(seed: destination_plate, properties: props) }
 
     it 'can be created when all required subjects are defined' do
@@ -110,6 +103,12 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
                                                        event_type: 'lh_beckman_cp_destination_created'
                                                      }
                                                    })
+        end
+
+        it 'includes a user identifier' do
+          event_info = JSON.parse(instance.to_json)
+          expect(event_info['event']).to have_key('user_identifier')
+          expect(event_info['event']['user_identifier']).to eq('jimmy')
         end
 
         it 'has right size of subjects' do

--- a/spec/models/broadcast_events/plate_cherrypicked_spec.rb
+++ b/spec/models/broadcast_events/plate_cherrypicked_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
           end
         end
 
+        context 'when user identifier is an empty string' do
+          let(:props) { { user_identifier: '', subjects: [plate1, plate2, sample1, sample2, robot] } }
+
+          it 'includes the unknown user identifier' do
+            event_info = JSON.parse(instance.to_json)
+            expect(event_info['event']).to have_key('user_identifier')
+            expect(event_info['event']['user_identifier']).to eq('UNKNOWN')
+          end
+        end
+
         it 'has right size of subjects' do
           event_info = JSON.parse(instance.to_json)
           expect(event_info['event']).to have_key('subjects')

--- a/spec/models/broadcast_events/plate_cherrypicked_spec.rb
+++ b/spec/models/broadcast_events/plate_cherrypicked_spec.rb
@@ -81,8 +81,7 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
   end
 
   context 'with the right contents in properties and seed' do
-    let(:props) {  { subjects: [plate1, plate2, sample1, sample2, robot] } }
-    # let(:props) {  user_identifier: 'jimmy', subjects: [plate1, plate2, sample1, sample2, robot] }
+    let(:props) {  { user_identifier: 'jimmy', subjects: [plate1, plate2, sample1, sample2, robot] } }
 
     let(:instance) { described_class.new(seed: destination_plate, properties: props) }
 
@@ -109,6 +108,16 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
           event_info = JSON.parse(instance.to_json)
           expect(event_info['event']).to have_key('user_identifier')
           expect(event_info['event']['user_identifier']).to eq('jimmy')
+        end
+
+        context 'where user identifier is missing' do
+          let(:props) {  { subjects: [plate1, plate2, sample1, sample2, robot] } }
+
+          it 'includes the unknown user identifier if one is not provided' do
+            event_info = JSON.parse(instance.to_json)
+            expect(event_info['event']).to have_key('user_identifier')
+            expect(event_info['event']['user_identifier']).to eq('UNKNOWN')
+          end
         end
 
         it 'has right size of subjects' do

--- a/spec/models/broadcast_events/plate_cherrypicked_spec.rb
+++ b/spec/models/broadcast_events/plate_cherrypicked_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
   end
 
   context 'with the right contents in properties and seed' do
-    let(:props) {  { user_identifier: 'jimmy', subjects: [plate1, plate2, sample1, sample2, robot] } }
+    let(:props) { { user_identifier: 'jimmy', subjects: [plate1, plate2, sample1, sample2, robot] } }
 
     let(:instance) { described_class.new(seed: destination_plate, properties: props) }
 
@@ -110,10 +110,10 @@ RSpec.describe BroadcastEvent::PlateCherrypicked, type: :model, broadcast_event:
           expect(event_info['event']['user_identifier']).to eq('jimmy')
         end
 
-        context 'where user identifier is missing' do
-          let(:props) {  { subjects: [plate1, plate2, sample1, sample2, robot] } }
+        context 'when user identifier is missing' do
+          let(:props) { { subjects: [plate1, plate2, sample1, sample2, robot] } }
 
-          it 'includes the unknown user identifier if one is not provided' do
+          it 'includes the unknown user identifier' do
             event_info = JSON.parse(instance.to_json)
             expect(event_info['event']).to have_key('user_identifier')
             expect(event_info['event']['user_identifier']).to eq('UNKNOWN')


### PR DESCRIPTION
- Allow user_identifier to be set by a value in the properties hash, rather than using a user id
- So that calls from lighthouse from Beckman destination plate creation endpoint work
- Delete a duplicated method