### PR TITLE
Change release.tar.gz name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,5 +44,5 @@ jobs:
       with:
         upload_url: ${{ github.event.release.upload_url }} # Pull the URL from the event
         asset_path: ./release.tar.gz
-        asset_name: gh-release.tar.gz
+        asset_name: release.tar.gz
         asset_content_type: application/gzip


### PR DESCRIPTION
change release name to how it was named by previous (Travis) builds, so that psd-deployment doesn't have to change what it's looking for
