### PR TITLE
GPL-278 Get rid of 'new project registered' emails

### DIFF
--- a/lib/event_factory.rb
+++ b/lib/event_factory.rb
@@ -3,7 +3,9 @@ class EventFactory # rubocop:todo Style/Documentation
   #################################
   # project related notifications #
   #################################
-  # Creates an event and sends an email when a new project is created
+
+  # Creates an event when a new project is created
+  # This used to send a notification using EventfulMailer, but it is no longer required
   def self.new_project(project, user)
     content = "Project registered by #{user.login}"
 
@@ -18,7 +20,8 @@ class EventFactory # rubocop:todo Style/Documentation
     event.save
   end
 
-  # Creates an event and sends an email or emails when a project is approved
+  # Creates an event or emails when a project is approved
+  # This used to send a notification using EventfulMailer, but it is no longer required
   def self.project_approved(project, user)
     content = "Project approved by #{user.login}"
 
@@ -31,22 +34,6 @@ class EventFactory # rubocop:todo Style/Documentation
       of_interest_to: 'administrators'
     )
     event.save
-
-    recipients_email = []
-    project_manager_email = ''
-    if project.manager.present?
-      project_manager_email = (project.manager.email).to_s
-      recipients_email << project_manager_email
-    end
-    if user.is_administrator?
-      administrators_email = User.all_administrators_emails
-      administrators_email.each do |email|
-        recipients_email << email unless email == project_manager_email
-      end
-    end
-
-    EventfulMailer.confirm_event(recipients_email, event.eventful, event.message, event.content,
-                                 'No Milestone').deliver_now
   end
 
   def self.project_refund_request(project, user, reference)

--- a/lib/event_factory.rb
+++ b/lib/event_factory.rb
@@ -16,16 +16,6 @@ class EventFactory # rubocop:todo Style/Documentation
       of_interest_to: 'administrators'
     )
     event.save
-
-    admin_emails = User.all_administrators_emails.reject(&:blank?)
-
-    EventfulMailer.confirm_event(
-      admin_emails,
-      event.eventful,
-      event.message,
-      event.content,
-      'No Milestone'
-    ).deliver_now unless admin_emails.empty?
   end
 
   # Creates an event and sends an email or emails when a project is approved

--- a/test/controllers/admin_projects_controller_test.rb
+++ b/test/controllers/admin_projects_controller_test.rb
@@ -53,16 +53,10 @@ module Admin
             assert_equal 1, Event.count - @event_count, 'Expected Event.count to change by 1'
           end
 
-          should 'send an email' do
-            assert_equal 1, emails.count
-            assert_match "Project #{@project.id}: Project approved\n\nProject approved by #{@user.login}", emails.first.parts.first.body.to_s
-          end
-
-          should 'Have sent an email' do
-            last_mail = ActionMailer::Base.deliveries.last
-            assert_match(/[TEST].*Project/, last_mail.subject)
-            assert last_mail.bcc.include? 'project.owner@example.com'
-            assert_match(/Project approved by/, last_mail.text_part.body.to_s)
+          # History: Projects had to be approved post creation. Now approval is done pre generation.
+          # Therefore function not required
+          should 'not send email any more' do
+            assert_equal 0, emails.count
           end
         end
       end

--- a/test/unit/event_factory_test.rb
+++ b/test/unit/event_factory_test.rb
@@ -31,20 +31,10 @@ class EventFactoryTest < ActiveSupport::TestCase
         assert_equal 1, Event.count - @event_count, 'Expected Event.count to change by 1'
       end
 
-      context 'send 1 email to 1 recipient' do
-        should 'send email' do
-          assert_equal 1, emails.count
-          assert_match "Project #{@project.id}: Project registered\n\nProject registered by south", emails.first.parts.first.body.to_s
-        end
-
-        should 'Have sent an email' do
-          assert_equal 1, emails.count
-          last_mail = ActionMailer::Base.deliveries.last
-          assert_match(/Project/, last_mail.subject)
-          assert last_mail.bcc.include?('abc123@example.com')
-          assert_match(/Project registered/, last_mail.text_part.body.to_s)
-          assert_equal 1, last_mail.bcc.size
-        end
+      # History: Projects had to be approved post creation. Now approval is done pre generation.
+      # Therefore function not required
+      should 'not send email any more' do
+        assert_equal 0, emails.count
       end
     end
 

--- a/test/unit/event_factory_test.rb
+++ b/test/unit/event_factory_test.rb
@@ -49,92 +49,14 @@ class EventFactoryTest < ActiveSupport::TestCase
         EventFactory.project_approved(@project, @user)
       end
 
-      should 'send email' do
-        assert_equal 1, emails.count
-        assert_match "Project approved\n\nProject approved by south", emails.first.parts.first.body.to_s
+      # History: Projects had to be approved post creation. Now approval is done pre generation.
+      # Therefore function not required
+      should 'not send email any more' do
+        assert_equal 0, emails.count
       end
 
       should 'change Event.count by 1' do
         assert_equal 1, Event.count - @event_count, 'Expected Event.count to change by 1'
-      end
-
-      context 'send email to project manager' do
-        should 'Have sent an email' do
-          last_mail = ActionMailer::Base.deliveries.last
-          assert_match(/Project approved/, last_mail.subject)
-          assert last_mail.bcc.include?('south@example.com')
-          assert_not last_mail.bcc.include?('')
-          assert_match(/Project approved/, last_mail.text_part.body.to_s)
-        end
-      end
-    end
-
-    context '#project_approved by administrator' do
-      setup do
-        @event_count = Event.count
-        ::ActionMailer::Base.deliveries = [] # reset the queue
-        admin = create :role, name: 'administrator'
-        @user1 = create :user, login: 'west'
-        @user1.roles << admin
-        @user2 = create :user, login: 'north'
-        @user2.roles << admin
-        role = create :manager_role, authorizable: @project
-        role.users << @user
-        EventFactory.project_approved(@project, @user2)
-      end
-
-      should 'change Event.count by 1' do
-        assert_equal 1, Event.count - @event_count, 'Expected Event.count to change by 1'
-      end
-
-      context ': send emails to everyone administrators' do
-        should 'Have sent an email' do
-          last_mail = ActionMailer::Base.deliveries.last
-          assert_match(/Project approved/, last_mail.subject)
-          assert last_mail.bcc.include?('north@example.com')
-          assert last_mail.bcc.include?('south@example.com')
-          assert last_mail.bcc.include?('west@example.com')
-          assert_not last_mail.bcc.include?('')
-          assert_match(/Project approved/, last_mail.text_part.body.to_s)
-        end
-      end
-    end
-
-    context '#project_approved but not by administrator' do
-      setup do
-        @event_count = Event.count
-        ActionMailer::Base.deliveries.clear
-        admin = create :role, name: 'administrator'
-        @user1 = create :user, login: 'west'
-        @user1.roles << admin
-        follower = create :role, name: 'follower'
-        @user2 = create :user, login: 'north'
-        @user2.roles << follower
-        role = create :manager_role, authorizable: @project
-        role.users << @user
-        EventFactory.project_approved(@project, @user2)
-      end
-
-      should 'change Event.count by 1' do
-        assert_equal 1, Event.count - @event_count, 'Expected Event.count to change by 1'
-      end
-
-      context ': send email to project manager' do
-        should 'Have sent an email' do
-          last_mail = ActionMailer::Base.deliveries.last
-          assert_match(/Project approved/, last_mail.subject)
-          assert last_mail.bcc.include?('south@example.com')
-          assert_not last_mail.bcc.include?('')
-          assert_match(/Project approved/, last_mail.text_part.body.to_s)
-        end
-      end
-
-      context 'send no email to adminstrator nor to approver' do
-        ActionMailer::Base.deliveries.each do |d|
-          assert_not d.bcc.include?('west@example.com')
-          assert_not d.bcc.include?('north@example.com')
-          assert_not d.bcc.include?('')
-        end
       end
     end
 


### PR DESCRIPTION
Get rid of new project registered email
- History: Projects had to be approved post creation. Now approval is done pre generation.
- Therefore function not required and discussed this with SSRs and they would SOOO happy if it went away
- (from Neil on https://github.com/sanger/sequencescape/issues/2514)

Closes #2514 
