### PR TITLE
Allow coverage to continue on error

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -200,6 +200,7 @@ jobs:
   end_coverage:
     runs-on: ubuntu-latest
     needs: [rake_tests, rspec_tests, cucumber_tests]
+    continue-on-error: true
     steps:
     - uses: actions/checkout@v2
     - name: Fetch coverage results


### PR DESCRIPTION
It would be nice to get coverage on PRs, but currently issues with secret accessibility. Also, if code-climate is down, we don't want to block releases.
Adding continue-on-error:

Closes #

Changes proposed in this pull request:

*
*
* ...
