### PR TITLE
Make code cov conditional

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -201,6 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rake_tests, rspec_tests, cucumber_tests]
     continue-on-error: true
+    if: ${{ github.secrets.CC_TEST_REPORTER_ID }}
     steps:
     - uses: actions/checkout@v2
     - name: Fetch coverage results


### PR DESCRIPTION
Ugh...

So github actions is apparently not treating the continue-on-error flag as expected, and still fails the build.
Here we make the code-coverage step conditional on the secret, at least I hope so, the documentation wasn't great covering what is truthy, or what the value of a missing secret is.