### PR TITLE
Add CC_TEST_REPORTER_ID to repo

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -1,7 +1,7 @@
 name: Ruby Test
 env:
   TZ: Europe/London
-  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID || '9c624e5d90c5b319d678e06d66c7671f1661fda826436d475f9679b54be63e26' }}
 
 on:
   - push
@@ -201,7 +201,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rake_tests, rspec_tests, cucumber_tests]
     continue-on-error: true
-    if: ${{ github.secrets.CC_TEST_REPORTER_ID }}
     steps:
     - uses: actions/checkout@v2
     - name: Fetch coverage results


### PR DESCRIPTION
This introduces a slight risk that a malicious actor could send invalid code coverage statistics. However has the advantage that we get coverage reports on pull requests.

Closes #

Changes proposed in this pull request:

*
*
* ...
