### PR TITLE
Fix coverage in knapsack queue mode

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,4 @@
-SimpleCov.configure do
+SimpleCov.start 'rails' do
   add_filter '/test/'
   add_filter '/config/'
   add_filter '/coverage/'
@@ -12,7 +12,7 @@ SimpleCov.configure do
   add_filter '/vendor/'
   add_filter '/tmp/'
 
+  enable_coverage :branch
+
   # You can add_filter here to add anything else you don't want to cover
 end
-
-SimpleCov.start 'rails'

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -11,6 +11,6 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
     KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
     bundle exec rake knapsack_pro:rspec # use Regular Mode here always
 else
-    export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES = true
+    export KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES=true
     bundle exec rake knapsack_pro:queue:rspec
 fi

--- a/features/support/knapsack.rb
+++ b/features/support/knapsack.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 require 'knapsack_pro'
+# https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode
+KnapsackPro::Hooks::Queue.before_queue do |_queue_id|
+  SimpleCov.command_name("cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
+end
 KnapsackPro::Adapters::CucumberAdapter.bind

--- a/features/support/knapsack.rb
+++ b/features/support/knapsack.rb
@@ -2,7 +2,8 @@
 
 require 'knapsack_pro'
 # https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode
-KnapsackPro::Hooks::Queue.before_queue do |_queue_id|
-  SimpleCov.command_name("cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
+KnapsackPro::Hooks::Queue.before_queue do |queue_id|
+  run_id = "#{queue_id}_#{Time.now.to_i}"
+  SimpleCov.command_name("cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}_#{run_id}")
 end
 KnapsackPro::Adapters::CucumberAdapter.bind

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,9 +18,15 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'simplecov' # Simple cov should be loaded as early as possible
 
 require 'knapsack_pro'
+require 'simplecov'
+
+# https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode
+KnapsackPro::Hooks::Queue.before_queue do |_queue_id|
+  SimpleCov.command_name("rspec_ci_node_#{KnapsackPro::Config::Env.ci_node_index}")
+end
+
 KnapsackPro::Adapters::RSpecAdapter.bind
 
 require 'webdrivers/chromedriver'


### PR DESCRIPTION
I noticed our test coverage dropped, likely a result of the knapsack pro queue. Followed the instructions here:
# https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode