### PR TITLE
Add documentation about test failure

### DIFF
--- a/app/helpers/deprecation_helper.rb
+++ b/app/helpers/deprecation_helper.rb
@@ -30,7 +30,7 @@ module DeprecationHelper
   #       once the removal date has been hit. While on one level this acts as a nice reminder,
   #       it also unexpectedly breaks the build. Please make sure the tests also get disabled
   #       on the target date. But feel free to spit out a load of warnings to make sure the next
-  #       steps actually happen.
+  #       code-removal steps actually happen.
   #
   # @example sample_registration.html.erb
   #  <%= deprecate_section(

--- a/app/helpers/deprecation_helper.rb
+++ b/app/helpers/deprecation_helper.rb
@@ -26,6 +26,12 @@ module DeprecationHelper
   # Once date has been reached, the section will be automatically hidden. It will also log
   # every-time it gets hit to allow for removal.
   #
+  # @note When using this feature, tests relying on the deprecated behaviour will begin failing
+  #       once the removal date has been hit. While on one level this acts as a nice reminder,
+  #       it also unexpectedly breaks the build. Please make sure the tests also get disabled
+  #       on the target date. But feel free to spit out a load of warnings to make sure the next
+  #       steps actually happen.
+  #
   # @example sample_registration.html.erb
   #  <%= deprecate_section(
   #     date: Date.parse('20190708'),


### PR DESCRIPTION
When I added the deprecation for the sample reception, I didn't consider
that tests would begin failing once the target date was reached. This
caused some unexpected failures with an unrelated update, and delayed
an important release. Added a note to the deprecation card library to
reduce the risk of a similar error being made in future.

