### PR TITLE
gemfile.lock got out of date somehow

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,6 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-oci8 (2.2.9)
-    ruby-ole (1.2.12.2)
     ruby-plsql (0.7.1)
     ruby-prof (1.4.2)
     ruby-progressbar (1.11.0)
@@ -458,8 +457,6 @@ GEM
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
     slack-notifier (2.3.2)
-    spreadsheet (1.2.7)
-      ruby-ole
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -605,7 +602,6 @@ DEPENDENCIES
   simplecov
   sinatra
   slack-notifier
-  spreadsheet
   test-prof
   timecop
   traceroute


### PR DESCRIPTION
- was causing deployment issue
- You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
