### PR TITLE
Fix knapsack coverage in queue mode

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -15,4 +15,10 @@ SimpleCov.start 'rails' do
   enable_coverage :branch
 
   # You can add_filter here to add anything else you don't want to cover
+
+  at_exit do
+    result = SimpleCov.result
+    result.command_name =  "#{result.command_name}.#{$PID}"
+    result.format!
+  end
 end

--- a/.simplecov
+++ b/.simplecov
@@ -18,7 +18,7 @@ SimpleCov.start 'rails' do
 
   at_exit do
     result = SimpleCov.result
-    result.command_name =  "#{result.command_name}.#{$PID}"
+    result.command_name = "#{result.command_name}.#{$PID}"
     result.format!
   end
 end

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/setup
+++ b/bin/setup
@@ -47,7 +47,7 @@ chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
-  system 'bin/rails db:setup'
+  system! 'bin/rails db:setup'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,6 +2,13 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
+if ENV['RAILS_ENV'] == 'test' || ENV['RAILS_ENV'] == 'cucumber'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
+
+
 # Bootsnap does not purge its cache, which can cause boot-times to increase
 # over time. This change will purge the cache every 30 days. In development
 # I saw a reduction in boot time from 44 seconds, to 17.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,8 +4,6 @@ require 'bundler/setup' # Set up gems listed in the Gemfile.
 
 if ENV['RAILS_ENV'] == 'test' || ENV['RAILS_ENV'] == 'cucumber'
   require 'simplecov'
-  SimpleCov.start 'rails'
-  puts "required simplecov"
 end
 
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,10 +2,7 @@ ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 
-if ENV['RAILS_ENV'] == 'test' || ENV['RAILS_ENV'] == 'cucumber'
-  require 'simplecov'
-end
-
+require 'simplecov' if ENV['RAILS_ENV'] == 'test' || ENV['RAILS_ENV'] == 'cucumber'
 
 # Bootsnap does not purge its cache, which can cause boot-times to increase
 # over time. This change will purge the cache every 30 days. In development

--- a/features/support/knapsack.rb
+++ b/features/support/knapsack.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require 'knapsack_pro'
+
 # https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
   run_id = "#{queue_id}_#{Time.now.to_i}"
+  puts "Simple cov command: cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}_#{run_id}"
   SimpleCov.command_name("cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}_#{run_id}")
 end
 KnapsackPro::Adapters::CucumberAdapter.bind


### PR DESCRIPTION
So the previous attempt at solving this wasn't quite working, and seems to be due to forked processes exiting and clobbering the coverage.

This change ensures we get a new coverage file per process, and also ensures that the sever processes spun up by capybara et al, get their coverage recorded.