### PR TITLE
Simplify and restrict stock plate behaviour

### DIFF
--- a/app/api/model_extensions/plate.rb
+++ b/app/api/model_extensions/plate.rb
@@ -27,14 +27,6 @@ module ModelExtensions::Plate
     end
   end
 
-  def source_plate
-    plate_purpose.source_plate(self)
-  end
-
-  def source_plates
-    plate_purpose.source_plates(self)
-  end
-
   def library_source_plate
     plate_purpose.library_source_plate(self)
   end

--- a/app/controllers/labware_controller.rb
+++ b/app/controllers/labware_controller.rb
@@ -29,7 +29,7 @@ class LabwareController < ApplicationController
   end
 
   def show
-    @source_plate = @asset.source_plate
+    @source_plates = @asset.source_plates
     respond_to do |format|
       format.html
       format.xml

--- a/app/controllers/plate_summaries_controller.rb
+++ b/app/controllers/plate_summaries_controller.rb
@@ -15,10 +15,15 @@ class PlateSummariesController < ApplicationController # rubocop:todo Style/Docu
 
   def search
     candidate_plate = Plate.find_from_any_barcode(params[:plate_barcode])
-    if candidate_plate.nil? || candidate_plate.source_plate.nil?
+    @barcode = params[:plate_barcode]
+    @plates = candidate_plate&.source_plates
+
+    if @plates.blank?
       redirect_back fallback_location: root_path, flash: { error: "No suitable plates found for barcode #{params[:plate_barcode]}" }
+    elsif @plates.one?
+      redirect_to plate_summary_path(@plates.first.human_barcode)
     else
-      redirect_to plate_summary_path(candidate_plate.source_plate.human_barcode)
+      render :search
     end
   end
 end

--- a/app/controllers/receptacles_controller.rb
+++ b/app/controllers/receptacles_controller.rb
@@ -28,7 +28,7 @@ class ReceptaclesController < ApplicationController
   end
 
   def show
-    @source_plate = @asset.source_plate
+    @source_plates = @asset.source_plates
     respond_to do |format|
       format.html
       format.xml

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -111,10 +111,6 @@ class Asset < ApplicationRecord
     RequestType.where(asset_type: label)
   end
 
-  def role
-    stock_plate&.stock_role
-  end
-
   def external_identifier
     "#{sti_type}#{id}"
   end
@@ -172,10 +168,6 @@ class Asset < ApplicationRecord
 
   def contained_samples
     Sample.none
-  end
-
-  def source_plate
-    nil
   end
 
   def printable?

--- a/app/models/illumina_b/mx_tube_purpose.rb
+++ b/app/models/illumina_b/mx_tube_purpose.rb
@@ -6,8 +6,26 @@
 #       - Delete this file
 #       - Check tests and update as appropriate. Check code coverage if removing tests.
 class IlluminaB::MxTubePurpose < IlluminaHtp::MxTubePurpose
+  #
+  # Attempts to find the 'stock_plate' for a given tube. However this is a fairly
+  # nebulous concept. Often it means the plate that first entered a pipeline,
+  # but in other cases it can be the XP plate part way through the process. Further
+  # complication comes from tubes which pool across multiple plates, where identifying
+  # a single stock plate is meaningless. In other scenarios, you split plates out again
+  # and the asset link graph is insufficient.
+  #
+  # JG: 2021-02-11: In this case we attempt to jump back through the requests. In most
+  # limber pipelines this will actually return the plate on which you charge and pass.
+  # See https://github.com/sanger/sequencescape/issues/3040 for more information
+  #
+  # @deprecate Do not use this for new behaviour.
+  #
+  # @param tube [Tube] The tube for which to find the stock_plate
+  #
+  # @return [Plate, nil] The stock plate if found
+  #
   def stock_plate(tube)
     tube.requests_as_target.where_is_a(IlluminaB::Requests::StdLibraryRequest).first.asset.plate
   end
-  deprecate :stock_plate
+  deprecate stock_plate: 'Stock plate is nebulous and can easily lead to unexpected behaviour'
 end

--- a/app/models/illumina_c/mx_tube_purpose.rb
+++ b/app/models/illumina_c/mx_tube_purpose.rb
@@ -10,12 +10,31 @@
 #       - Delete this file
 #       - Any failing tests are probably safe to remove
 class IlluminaC::MxTubePurpose < IlluminaHtp::MxTubePurpose
+  #
+  # Attempts to find the 'stock_plate' for a given tube. However this is a fairly
+  # nebulous concept. Often it means the plate that first entered a pipeline,
+  # but in other cases it can be the XP plate part way through the process. Further
+  # complication comes from tubes which pool across multiple plates, where identifying
+  # a single stock plate is meaningless. In other scenarios, you split plates out again
+  # and the asset link graph is insufficient.
+  #
+  # JG: 2021-02-11: In this case we attempt to jump back through the requests. In most
+  # limber pipelines this will actually return the plate on which you charge and pass.
+  # See https://github.com/sanger/sequencescape/issues/3040 for more information
+  #
+  # @deprecate Do not use this for new behaviour.
+  #
+  # @param tube [Tube] The tube for which to find the stock_plate
+  #
+  # @return [Plate, nil] The stock plate if found
+  #
   def stock_plate(tube)
     lt = library_request(tube)
     return lt.asset.plate if lt.present?
 
     nil
   end
+  deprecate stock_plate: 'Stock plate is nebulous and can easily lead to unexpected behaviour'
 
   def library_request(tube)
     tube.requests_as_target.where_is_a(IlluminaC::Requests::LibraryRequest).first ||

--- a/app/models/illumina_htp/mx_tube_purpose.rb
+++ b/app/models/illumina_htp/mx_tube_purpose.rb
@@ -37,12 +37,35 @@ class IlluminaHtp::MxTubePurpose < Tube::Purpose
     tube.requests_as_target.for_billing.where(state: Request::Statemachine::OPENED_STATE)
   end
 
+  #
+  # Attempts to find the 'stock_plate' for a given tube. However this is a fairly
+  # nebulous concept. Often it means the plate that first entered a pipeline,
+  # but in other cases it can be the XP plate part way through the process. Further
+  # complication comes from tubes which pool across multiple plates, where identifying
+  # a single stock plate is meaningless. In other scenarios, you split plates out again
+  # and the asset link graph is insufficient.
+  #
+  # JG: 2021-02-11: In this case we attempt to jump back through the requests. In most
+  # limber pipelines this will actually return the plate on which you charge and pass.
+  # See https://github.com/sanger/sequencescape/issues/3040 for more information
+  #
+  # @deprecate Do not use this for new behaviour.
+  #
+  # @param tube [Tube] The tube for which to find the stock_plate
+  #
+  # @return [Plate, nil] The stock plate if found
+  #
   def stock_plate(tube)
     tube.requests_as_target.where.not(requests: { asset_id: nil }).first&.asset&.plate
   end
+  deprecate stock_plate: 'Stock plate is nebulous and can easily lead to unexpected behaviour'
 
   def source_plate(tube)
     super || source_plate_scope(tube).first
+  end
+
+  def source_plates(tube)
+    super.presence || source_plate_scope(tube)
   end
 
   def library_source_plates(tube)

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -108,8 +108,22 @@ class Labware < Asset
     end
   }
 
+  scope :stock_plates, -> { where(plate_purpose_id: PlatePurpose.considered_stock_plate) }
+
   def human_barcode
     'UNKNOWN'
+  end
+
+  def role
+    (requests_as_source.first || in_progress_requests.first)&.role
+  end
+
+  def source_plate
+    @source_plate ||= purpose&.source_plate(self)
+  end
+
+  def source_plates
+    @source_plates ||= purpose&.source_plates(self)
   end
 
   # Assigns name

--- a/app/models/plate_purpose.rb
+++ b/app/models/plate_purpose.rb
@@ -42,14 +42,7 @@ class PlatePurpose < Purpose
     super || AssetShape.default
   end
 
-  def source_plate(plate)
-    source_purpose_id.present? ? plate.ancestor_of_purpose(source_purpose_id) : plate.stock_plate
-  end
   alias library_source_plate source_plate
-
-  def source_plates(plate)
-    source_purpose_id.present? ? plate.ancestors_of_purpose(source_purpose_id) : [plate.stock_plate]
-  end
   alias library_source_plates source_plates
 
   def cherrypick_completed(plate)

--- a/app/models/purpose.rb
+++ b/app/models/purpose.rb
@@ -48,8 +48,24 @@ class Purpose < ApplicationRecord
 
   delegate :prefix, to: :barcode_prefix, allow_nil: true
 
-  def source_plate(asset)
-    source_purpose_id.present? ? asset.ancestor_of_purpose(source_purpose_id) : asset.stock_plate
+  def source_plate(labware)
+    # Stock_plate is deprecated, but we still have some tubes with special behaviour
+    # We'll allow its usage here to support existing code.
+    ActiveSupport::Deprecation.silence do
+      # Rails 6 lets us do this:
+      # ActiveSupport::Deprecation.allow(:stock_plate) do
+      source_purpose_id.present? ? labware.ancestor_of_purpose(source_purpose_id) : labware.stock_plate
+    end
+  end
+
+  def source_plates(labware)
+    # Stock_plate is deprecated, but we still have some tubes with special behaviour
+    # We'll allow its usage here
+    ActiveSupport::Deprecation.silence do
+      # Rails 6 lets us do this:
+      # ActiveSupport::Deprecation.allow(:stock_plate) do
+      source_purpose_id.present? ? labware.ancestors_of_purpose(source_purpose_id) : [labware.stock_plate].compact
+    end
   end
 
   def barcode_type

--- a/app/models/receptacle.rb
+++ b/app/models/receptacle.rb
@@ -33,6 +33,7 @@ class Receptacle < Asset
   delegate :has_stock_asset?, to: :labware, allow_nil: true
   delegate :children, to: :labware, allow_nil: true
   delegate :sequenceable?, to: :labware, allow_nil: true
+  delegate :source_plate, :source_plates, to: :labware, allow_nil: true
   # Keeps event behaviour consistent
   delegate :subject_type, to: :labware
   delegate :public_name, to: :labware
@@ -92,6 +93,7 @@ class Receptacle < Asset
   has_many :samples, through: :aliquots
   has_many :studies, ->() { distinct }, through: :aliquots
   has_many :projects, ->() { distinct }, through: :aliquots
+  has_many :aliquot_requests, through: :aliquots, source: :request
   has_one :primary_aliquot, ->() { order(:created_at).readonly }, class_name: 'Aliquot'
   has_one :primary_sample, through: :primary_aliquot, source: :sample
 
@@ -288,6 +290,10 @@ class Receptacle < Asset
   # within the context of any tube-rack it may be contained within
   def absolute_position_name
     racked_tube&.coordinate
+  end
+
+  def role
+    (requests_as_source.first || aliquot_requests.first).role
   end
 
   private

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -40,12 +40,6 @@ class Tube < Labware
     submissions.ids.first
   end
 
-  def source_plate
-    return nil if purpose.nil?
-
-    @source_plate ||= purpose.source_plate(self)
-  end
-
   def ancestor_of_purpose(ancestor_purpose_id)
     return self if plate_purpose_id == ancestor_purpose_id
 

--- a/app/views/labware/_asset_summary.html.erb
+++ b/app/views/labware/_asset_summary.html.erb
@@ -58,10 +58,12 @@
         tube_rack_summary_path(asset.human_barcode) %></td>
     </tr>
   <% end %>
-  <% if  @source_plate&.human_barcode %>
+  <% if  @source_plates.present? %>
     <tr>
       <th>Summary page</th>
-      <td><%= link_to "Summary for #{@source_plate.human_barcode}", plate_summary_path(@source_plate.human_barcode) %></td>
+      <% @source_plates.each do |source_plate| %>
+        <td><%= link_to "Summary for #{source_plate.human_barcode}", plate_summary_path(source_plate.human_barcode) %></td>
+      <% end %>
     </tr>
   <% end %>
 

--- a/app/views/plate_summaries/search.html.erb
+++ b/app/views/plate_summaries/search.html.erb
@@ -1,0 +1,15 @@
+<%= page_title("plate summary", "results") %>
+<%= form_tag(search_plate_summaries_path, method: :get) do %>
+  <%= label_tag :plate_barcode, "Plate barcode" %>
+  <%= search_field_tag :plate_barcode, nil, class: "form-control" %>
+<% end %>
+
+<h2>Multiple Plates</h2>
+<p><%= @barcode %> has multiple source plates</p>
+<ul class="list-group">
+<% @plates.each do |plate| %>
+  <li class="list_group-item">
+    <%= link_to plate.human_barcode, plate_summary_path(plate.human_barcode) %>
+  </li>
+<% end %>
+</ul>

--- a/app/views/receptacles/_asset_summary.html.erb
+++ b/app/views/receptacles/_asset_summary.html.erb
@@ -41,10 +41,12 @@
       <td><%= @asset.labware.human_barcode %></td>
     </tr>
   <% end %>
-  <% if  @source_plate&.human_barcode %>
+  <% if  @source_plates.present? %>
     <tr>
       <th>Summary page</th>
-      <td><%= link_to "Summary for #{@source_plate.human_barcode}", plate_summary_path(@source_plate.human_barcode) %></td>
+      <% @source_plates.each do |source_plate| %>
+        <td><%= link_to "Summary for #{source_plate.human_barcode}", plate_summary_path(source_plate.human_barcode) %></td>
+      <% end %>
     </tr>
   <% end %>
   <% if asset.respond_to?(:plate) %>

--- a/spec/models/broadcast_event/qc_assay_spec.rb
+++ b/spec/models/broadcast_event/qc_assay_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe BroadcastEvent::QcAssay, type: :model, broadcast_event: true do
             'friendly_name' => sample2.name },
           { 'role_type' => 'assayed_labware', 'subject_type' => 'plate', 'uuid' => plate.uuid,
             'friendly_name' => plate.human_barcode },
-          { 'role_type' => 'stock_plate', 'subject_type' => 'plate', 'uuid' => plate.stock_plate.uuid,
-            'friendly_name' => plate.stock_plate.human_barcode }
+          { 'role_type' => 'stock_plate', 'subject_type' => 'plate', 'uuid' => stock_plate.uuid,
+            'friendly_name' => stock_plate.human_barcode }
         ])
       end
     end
@@ -103,8 +103,8 @@ RSpec.describe BroadcastEvent::QcAssay, type: :model, broadcast_event: true do
             'friendly_name' => sample1.name },
           { 'role_type' => 'assayed_labware', 'subject_type' => 'plate', 'uuid' => plate.uuid,
             'friendly_name' => plate.human_barcode },
-          { 'role_type' => 'stock_plate', 'subject_type' => 'plate', 'uuid' => plate.stock_plate.uuid,
-            'friendly_name' => plate.stock_plate.human_barcode }
+          { 'role_type' => 'stock_plate', 'subject_type' => 'plate', 'uuid' => stock_plate.uuid,
+            'friendly_name' => stock_plate.human_barcode }
         ])
       end
     end

--- a/test/controllers/plate_summaries_controller_test.rb
+++ b/test/controllers/plate_summaries_controller_test.rb
@@ -14,8 +14,9 @@ class PlateSummariesControllerTest < ActionController::TestCase
 
     context 'with some plates' do
       setup do
-        @source_plate_a = create :source_plate
-        @source_plate_b = create :source_plate
+        purpose = create :source_plate_purpose
+        @source_plate_a = create :source_plate, purpose: purpose
+        @source_plate_b = create :source_plate, purpose: purpose
         @child_plate_a  = create :child_plate, parent: @source_plate_a
         @child_plate_b  = create :child_plate, parent: @source_plate_b
       end
@@ -64,6 +65,20 @@ class PlateSummariesControllerTest < ActionController::TestCase
 
           should redirect_to 'back'
           should set_flash.to 'No suitable plates found for barcode abcd'
+        end
+
+        context 'render the search page with a list of plates if multiple found' do
+          setup do
+            @child_plate_a.parents << @source_plate_b
+            get :search, params: { plate_barcode: @child_plate_a.human_barcode }
+          end
+
+          should render_template 'search'
+
+          should 'list the possible plates' do
+            assert_includes assigns(:plates), @source_plate_a
+            assert_includes assigns(:plates), @source_plate_b
+          end
         end
       end
 


### PR DESCRIPTION
Fixes  #3040

- This method failed to handle cases where a tube
was made from a plate, but didn't have a stock-plate ancestor
- It also would walk the request graph, which means multiple queries
- Fortunately, the code is little used, so we make it
'work' and deprecate it
- Update role just to go directly via requests
- Update the summaries page to show all potential
source plates.

Closes #

Changes proposed in this pull request:

*
*
* ...
