### PR TITLE
Fix undefined method `sti_type' for nil:NilClass

### DIFF
--- a/app/api/model_extensions/well.rb
+++ b/app/api/model_extensions/well.rb
@@ -18,6 +18,6 @@ module ModelExtensions::Well
 
   # Compatibility for v1 API maintains legacy 'type' for assets
   def legacy_asset_type
-    labware.sti_type
+    sti_type
   end
 end


### PR DESCRIPTION
Mistake was made when updating this with the asset split.
Well should return 'Well'
This code either returns 'Plate' or throws a 500 if the well is not on a plate.

I wasn't aware we actually had people pulling back the xml files for wells.

Closes #

Changes proposed in this pull request:

*
*
* ...
