### PR TITLE
Update .simplecov (#66)

### DIFF
--- a/features/support/knapsack.rb
+++ b/features/support/knapsack.rb
@@ -3,7 +3,13 @@
 require 'knapsack_pro'
 # https://knapsackpro.com/faq/question/how-to-use-simplecov-in-queue-mode
 KnapsackPro::Hooks::Queue.before_queue do |queue_id|
-  run_id = "#{queue_id}_#{Time.now.to_i}"
-  SimpleCov.command_name("cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}_#{run_id}")
+  command = "cucumber_ci_node_#{KnapsackPro::Config::Env.ci_node_index}_#{queue_id}"
+  SimpleCov.command_name(command)
 end
+
 KnapsackPro::Adapters::CucumberAdapter.bind
+# So the instructions above are actually insufficient, as Knpasack Pro spins up
+# a seperate cucumber process for each subset of the queue. This results in Simplecov
+# clobbering the coverage. Before queue runs only the once, whereas this will run
+# on each invokation
+SimpleCov.command_name("#{SimpleCov.command_name}_#{ENV['KNAPSACK_PRO_SUBSET_QUEUE_ID']}")


### PR DESCRIPTION
Fix coverage reports for cucumber

Cucumber coverage was drastically under-reporting as knapsack was spinning up a new cucumber-process per chunk of the queue. Before the simplecov command was being set in before queue only.

This change ensures we set the command name on each iteration of the queue, and appends the iteration id. This allows simple-cov to correctly sum the coverage for all runs of the cukes.