### PR TITLE
Aggregate comments show if request has no comments

### DIFF
--- a/app/views/requests/comments/_list.html.erb
+++ b/app/views/requests/comments/_list.html.erb
@@ -1,10 +1,10 @@
 
 <ul id="request_annotations_<%= @request.id %>" class="list-group">
-  <% if @request.comments.size > 0 %>
+  <% if @comments.present? %>
     <% @comments.each do |comment| %>
       <li class="list-group-item">
         <%= render partial: "shared/comment" ,
-                   locals: { comment: comment, commentable: @request.becomes(Request), update_target: "request_annotations_#{@request.id}" }%>
+                   locals: { comment: comment, update_target: "request_annotations_#{@request.id}" }%>
       </li>
     <% end %>
   <% else %>

--- a/app/views/shared/_comment.html.erb
+++ b/app/views/shared/_comment.html.erb
@@ -1,7 +1,7 @@
-<% commentable ||= comment.commentable %>
+<% commentable ||= comment.commentable.becomes(comment.commentable.class.base_class) %>
 <div class="comment-box">
   <div class="comment">
-    <h5 class="comment-title"><%= comment.title %></h5>
+    <h5 class="comment-title"><%= comment.title %> <%= badge(commentable.class.name, style: 'info') %></h5>
     <div class="comment-description"><%= comment.description %></div>
   </div>
   <div  class="comment-metadata">


### PR DESCRIPTION
Fixes #3115

- Use the @comments variable, not the association
- Convert the commentable to the base class in the shared view
- Add the commentable class name to the comment to better distinguish
  the source
