### PR TITLE
Cherrypick pipelines will set batch to nil

### DIFF
--- a/app/models/cherrypick_for_pulldown_pipeline.rb
+++ b/app/models/cherrypick_for_pulldown_pipeline.rb
@@ -14,12 +14,6 @@ class CherrypickForPulldownPipeline < CherrypickingPipeline
     batch.release_pending_requests
   end
 
-  def update_detached_request(batch, request)
-    # We do not need to do any of the default behaviour:
-    # 1. The requests should just be detached, not blocked
-    # 2. The assets are not removed because they are not considered unused
-  end
-
   def all_requests_from_submissions_selected?(requests)
     request_types, submissions = request_types_and_submissions_for(requests)
     matching_requests = Request.where(request_type_id: request_types, submission_id: submissions).order(:id).pluck(:id)

--- a/app/models/cherrypick_pipeline.rb
+++ b/app/models/cherrypick_pipeline.rb
@@ -31,10 +31,4 @@ class CherrypickPipeline < CherrypickingPipeline
     batch.release_pending_requests
     batch.output_plates.each(&:cherrypick_completed)
   end
-
-  def update_detached_request(batch, request)
-    # We do not need to do any of the default behaviour:
-    # 1. The requests should just be detached, not blocked
-    # 2. The assets are not removed because they are not considered unused
-  end
 end

--- a/app/models/cherrypicking_pipeline.rb
+++ b/app/models/cherrypicking_pipeline.rb
@@ -16,4 +16,8 @@ class CherrypickingPipeline < GenotypingPipeline
   def pick_information?(batch)
     PICKED_STATES.include?(batch.state)
   end
+
+  def update_detached_request(batch, request)
+    batch.remove_link(request)
+  end
 end

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -100,8 +100,7 @@ class Pipeline < ApplicationRecord
     request.save!
   end
 
-  def update_detached_request(_batch, request)
-  end
+  def update_detached_request(_batch, _request); end
 
   # Overridden in group-by parent pipelines to display input plates
   def input_labware(_requests)
@@ -113,8 +112,7 @@ class Pipeline < ApplicationRecord
     Labware.none
   end
 
-  def post_finish_batch(batch, user)
-  end
+  def post_finish_batch(batch, user); end
 
   def completed_request_as_part_of_release_batch(request)
     if library_creation?


### PR DESCRIPTION
Cherrypick pipelines were not removing the requests
from the batch. This restores the functionality.

Fixes #3105
