### PR TITLE
Update yanked Mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)


### PR DESCRIPTION
*All* versions of mimemagic below 0.3.6 were janked due to
a GPL license violation.

https://github.com/minad/mimemagic/issues/97
