### PR TITLE
Update carrierwave

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,7 @@ group :default do
   gem 'mysql2', platforms: :mri
   gem 'will_paginate'
 
-  # CarrierWave 2.0.0-2.0.1 causes test/controllers/qc_files_controller_test.rb
-  # to fail due to mime-type detection failing due to the newly introduces
-  # mime-magic. Pinning to 1.3.1 for the time being.
-  # https://github.com/sanger/sequencescape/issues/2349
-  gem 'carrierwave', '~>1.3.1'
+  gem 'carrierwave'
   gem 'net-ldap'
   # Will paginate clashes awkwardly with bootstrap
   gem 'will_paginate-bootstrap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,10 +130,13 @@ GEM
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
-    carrierwave (1.3.2)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
+    carrierwave (2.2.1)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     childprocess (3.0.0)
     choice (0.2.0)
@@ -234,6 +237,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -263,6 +269,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
+    mini_magick (4.11.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.0)
     mini_racer (0.3.1)
@@ -426,6 +433,8 @@ GEM
     ruby-prof (1.4.3)
     ruby-progressbar (1.11.0)
     ruby-units (2.3.2)
+    ruby-vips (2.1.0)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.4)
     ruby_parser (3.15.1)
       sexp_processor (~> 4.9)
@@ -541,7 +550,7 @@ DEPENDENCIES
   cancancan
   capybara
   capybara-selenium
-  carrierwave (~> 1.3.1)
+  carrierwave
   configatron
   connection_pool
   cucumber


### PR DESCRIPTION
Carrierwave was pinned as mimemagic in later versions
was incorrectly detecting the file format of excel spreadsheets.

Carrierwave has now switched to marcel, so hopefully shouldn't
show the same behaviour.

Fixes #2349