### PR TITLE
Move ancestor of purpose onto labware

### DIFF
--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -134,6 +134,18 @@ class Labware < Asset
 
   delegate :state_changer, to: :purpose, allow_nil: true
 
+  def ancestor_of_purpose(ancestor_purpose_id)
+    return self if plate_purpose_id == ancestor_purpose_id
+
+    ancestors.order(id: :desc).find_by(plate_purpose_id: ancestor_purpose_id)
+  end
+
+  def ancestors_of_purpose(ancestor_purpose_id)
+    return [self] if plate_purpose_id == ancestor_purpose_id
+
+    ancestors.order(id: :desc).where(plate_purpose_id: ancestor_purpose_id)
+  end
+
   def human_barcode
     'UNKNOWN'
   end

--- a/app/models/plate.rb
+++ b/app/models/plate.rb
@@ -336,18 +336,6 @@ class Plate < Labware
   end
   deprecate stock_plate: 'Stock plate is nebulous and can easily lead to unexpected behaviour'
 
-  def ancestor_of_purpose(ancestor_purpose_id)
-    return self if plate_purpose_id == ancestor_purpose_id
-
-    ancestors.order(id: :desc).find_by(plate_purpose_id: ancestor_purpose_id)
-  end
-
-  def ancestors_of_purpose(ancestor_purpose_id)
-    return [self] if plate_purpose_id == ancestor_purpose_id
-
-    ancestors.order(id: :desc).where(plate_purpose_id: ancestor_purpose_id)
-  end
-
   def self.create_with_barcode!(*args, &block)
     attributes = args.extract_options!
     attributes[:sanger_barcode] = safe_sanger_barcode(attributes[:sanger_barcode] || {})

--- a/app/models/tube.rb
+++ b/app/models/tube.rb
@@ -40,12 +40,6 @@ class Tube < Labware
     submissions.ids.first
   end
 
-  def ancestor_of_purpose(ancestor_purpose_id)
-    return self if plate_purpose_id == ancestor_purpose_id
-
-    ancestors.order(created_at: :desc).find_by(plate_purpose_id: ancestor_purpose_id)
-  end
-
   def name_for_label
     primary_sample&.shorten_sanger_sample_id.presence || name
   end


### PR DESCRIPTION
Ancestor of purpose was getting called on tubes, but was failing.
The logic holds for all labware, so should be defined on the base class.

Fixes #3153
