### PR TITLE
Don't auto-require rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -133,8 +133,8 @@ end
 group :development, :linting do
   # Enforces coding styles and detects some bad practices
   gem 'rubocop', require: false
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'yard-activerecord', '~> 0.0.16'
 end


### PR DESCRIPTION
We don't need to load rubocop automatically, only when explicitly
invoked. This should:

- Prevent the parser warning when loading a server/console
- Theoretically speed up sever/console loading in development