### PR TITLE
DPL-931 BUG - Sample view page introducing incorrect sample_metadada data

### DIFF
--- a/app/views/shared/metadata/edit/_sample.html.erb
+++ b/app/views/shared/metadata/edit/_sample.html.erb
@@ -11,7 +11,7 @@
     <%= metadata_fields.text_field(:country_of_origin) %>
     <%= metadata_fields.text_field(:geographical_region) %>
     <%= metadata_fields.text_field(:ethnicity) %>
-    <%= metadata_fields.select(:dna_source, Sample::DNA_SOURCES) %>
+    <%= metadata_fields.select(:dna_source, Sample::DNA_SOURCES,include_blank: true) %>
     <%= metadata_fields.text_field(:volume) %>
     <%= metadata_fields.text_field(:mother) %>
     <%= metadata_fields.text_field(:father) %>
@@ -19,7 +19,7 @@
 
     <%# Fields for 'Next-gen sequencing' %>
     <%= metadata_fields.text_field(:organism) %>
-    <%= metadata_fields.select(:gc_content, Sample::GC_CONTENTS) %>
+    <%= metadata_fields.select(:gc_content, Sample::GC_CONTENTS,include_blank: true) %>
 
     <%# Fields for the SLF pipeline, by the looks of it %>
     <%= metadata_fields.text_field(:sibling) %>
@@ -40,7 +40,7 @@
 
     <!-- ENA requirement -->
     <% metadata_fields.with_options(grouping: 'ENA requirement') do |group| %>
-      <%= group.select(:sample_sra_hold, Sample::SRA_HOLD_VALUES) %>
+      <%= group.select(:sample_sra_hold, Sample::SRA_HOLD_VALUES,include_blank: true) %>
       <%= group.text_field(:sample_common_name, 'data-organism' => 'common_name') %>
       <input class='btn btn-default validate_organism' type='button' value='Lookup'/>
       <%= group.text_field(:sample_taxon_id,    'data-organism' => 'taxon_id') %>


### PR DESCRIPTION
include blank options on these sample metadata fields
- to avoid the first in the list from getting set by accident if you edit and then save a sample

Closes #3104 