### PR TITLE
Fix stripping and encoding of labwhere URLS

### DIFF
--- a/app/models/location_report/location_report_form.rb
+++ b/app/models/location_report/location_report_form.rb
@@ -10,17 +10,10 @@ class LocationReport::LocationReportForm
   include ActiveModel::AttributeMethods
 
   # Attributes
-  attr_accessor :user,
-                :report_type,
-                :location_barcode,
-                :faculty_sponsor_ids,
-                :study_id,
-                :start_date,
-                :end_date,
-                :plate_purpose_ids
+  attr_accessor :user, :report_type, :faculty_sponsor_ids, :study_id, :start_date, :end_date, :plate_purpose_ids
 
   attr_accessor :barcodes_text
-  attr_reader :name
+  attr_reader :name, :location_barcode
   attr_writer :location_report, :barcodes
 
   # validations
@@ -32,6 +25,10 @@ class LocationReport::LocationReportForm
   def name=(input_name)
     @name = input_name.gsub(/[^A-Za-z0-9_\-.\s]/, '').squish.gsub(/\s/, '_') if input_name.present?
     @name = Time.current.to_formatted_s(:number) if input_name.blank?
+  end
+
+  def location_barcode=(location_barcode)
+    @location_barcode = location_barcode&.strip
   end
 
   def location_report # rubocop:todo Metrics/MethodLength

--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -11,7 +11,8 @@ module LabWhereClient
     def path_to(instance, target)
       raise LabwhereException, 'LabWhere service URL not set' if base_url.nil?
 
-      [base_url, instance.endpoint, target].compact.join('/')
+      encoded_target = ERB::Util.url_encode(target)
+      [base_url, instance.endpoint, encoded_target].compact.join('/')
     end
 
     def parse_json(str)

--- a/spec/models/location_report_form_spec.rb
+++ b/spec/models/location_report_form_spec.rb
@@ -188,11 +188,10 @@ RSpec.describe LocationReport::LocationReportForm, type: :model do
       end
 
       it 'creates a valid location report' do
-        # rubocop:todo RSpec/AggregateExamples
         expect(location_report_form.location_report).to be_valid
       end
 
-      it 'correctly records the form object information in the location report' do
+      it 'correctly records the form object information in the location report', aggregate_failures: true do
         expect(location_report_form.location_report.name).to eq('Test_name')
         expect(location_report_form.location_report.report_type).to eq('type_selection')
         expect(location_report_form.location_report.faculty_sponsor_ids).to eq([study_1_sponsor.id])
@@ -224,6 +223,14 @@ RSpec.describe LocationReport::LocationReportForm, type: :model do
         end
       end
 
+      context 'when barcode is whitespace padded' do
+        let(:location_barcode) { ' 1001 ' }
+
+        it 'the model is valid' do
+          expect(location_report_form).to be_valid
+        end
+      end
+
       context 'for an invalid location' do
         let(:location_barcode) { '9999' }
 
@@ -249,12 +256,10 @@ RSpec.describe LocationReport::LocationReportForm, type: :model do
       end
 
       it 'creates a valid location report' do
-        # rubocop:todo RSpec/AggregateExamples
         expect(location_report_form.location_report).to be_valid
       end
 
-      it 'correctly records the form object information in the location report' do
-        # rubocop:todo RSpec/AggregateExamples
+      it 'correctly records the form object information in the location report', aggregate_failures: true do
         expect(location_report_form.location_report.name).to eq('Test_name')
         expect(location_report_form.location_report.report_type).to eq('type_labwhere')
         expect(location_report_form.location_report.location_barcode).to eq('1001')


### PR DESCRIPTION
Fixes #3218

- Strip whitespace from the location report forms
- Escape any generated labwhere URLs
