### PR TITLE
Bug - Unhandled error when tube rack scan file missing

### DIFF
--- a/lib/csv_parser_client.rb
+++ b/lib/csv_parser_client.rb
@@ -9,6 +9,14 @@ module CsvParserClient
     endpoint = configatron.tube_rack_scans_microservice_url
     response = Net::HTTP.get_response(URI(endpoint + tube_rack_barcode))
 
+    if response.body.nil?
+      error_message =
+        "Scan could not be retrieved for tube rack with barcode #{tube_rack_barcode}. Service responded with status code #{response.code}"
+      error_message += " and message #{response.message}."
+      object_to_add_errors_to.errors.add(:base, error_message)
+      return nil
+    end
+
     begin
       scan_results = JSON.parse(response.body)
     rescue JSON::JSONError => e


### PR DESCRIPTION
Tube rack manifest upload was not handling the situation where Wrangler responded with no body

- this happens when there is no csv found for the tube rack scan
- changed to handle this error more gracefully
- found during testing of DPL-024

Closes #3239 
