### PR TITLE
Ensure flowcell broadcast by batch touch

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -592,7 +592,7 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   def rebroadcast
-    messengers.each(&:queue_for_broadcast)
+    messengers.each(&:resend)
   end
 
   def pick_information?

--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -17,11 +17,7 @@ class Messenger < ApplicationRecord
     { root => render_class.to_hash(target), 'lims' => configatron.amqp.lims_id! }
   end
 
-  def queue_for_broadcast
-    add_to_transaction
-  end
-
   def resend
-    broadcast
+    Warren.handler << Warren::Message::Short.new(self)
   end
 end

--- a/app/models/tag_substitution.rb
+++ b/app/models/tag_substitution.rb
@@ -97,8 +97,8 @@ class TagSubstitution # rubocop:todo Metrics/ClassLength
       @substitutions.each(&:nullify_tags)
       @substitutions.each(&:substitute_tags)
       apply_comments
+      rebroadcast_flowcells
     end
-    rebroadcast_flowcells
     true
   rescue ActiveRecord::RecordNotUnique => e
     # We'll specifically handle tag clashes here so that we can produce more informative messages

--- a/spec/factories/messengers.rb
+++ b/spec/factories/messengers.rb
@@ -11,5 +11,11 @@ FactoryBot.define do
     root { 'barcode' }
     association(:target, factory: :barcode)
     template { 'BarcodeIO' }
+
+    factory :flowcell_messenger do
+      root { 'flowcell' }
+      association(:target, factory: :sequencing_batch)
+      template { 'FlowcellIO' }
+    end
   end
 end

--- a/spec/models/tag_substitutions_spec.rb
+++ b/spec/models/tag_substitutions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe TagSubstitution do
+describe TagSubstitution, warren: true do
   # Works for: Library manifests, old tube pipelines
   # We have two samples, each with unique tags, which only exist
   # in aliquots identified by the library id. We don't need to consider:
@@ -23,27 +23,35 @@ describe TagSubstitution do
   let(:additional_parameters) { {} }
 
   shared_examples 'tag substitution' do
-    before { assert subject.save, "TagSubstitution did not save. #{subject.errors.full_messages}" }
+    describe '#save' do
+      before { assert subject.save, "TagSubstitution did not save. #{subject.errors.full_messages}" }
 
-    it 'perform the correct tag substitutions' do
-      expect(library_aliquot_a.reload.tag).to eq sample_a_new_tag
-      expect(library_aliquot_b.reload.tag).to eq sample_b_new_tag
-      expect(mx_aliquot_a.reload.tag).to eq sample_a_new_tag
-      expect(mx_aliquot_b.reload.tag).to eq sample_b_new_tag
+      it 'perform the correct tag substitutions' do
+        expect(library_aliquot_a.reload.tag).to eq sample_a_new_tag
+        expect(library_aliquot_b.reload.tag).to eq sample_b_new_tag
+        expect(mx_aliquot_a.reload.tag).to eq sample_a_new_tag
+        expect(mx_aliquot_b.reload.tag).to eq sample_b_new_tag
+      end
+
+      it 'perform the correct tag2 substitutions' do
+        expect(library_aliquot_a.reload.tag2).to eq sample_a_new_tag2
+        expect(library_aliquot_b.reload.tag2).to eq sample_b_new_tag2
+        expect(mx_aliquot_a.reload.tag2).to eq sample_a_new_tag2
+        expect(mx_aliquot_b.reload.tag2).to eq sample_b_new_tag2
+      end
+
+      it 'assigns comments to the lanes and tubes' do
+        expect(library_tube_a.receptacle.comments.map(&:description)).to eq [comment]
+        expect(library_tube_b.receptacle.comments.map(&:description)).to eq [comment]
+        expect(mx_library_tube.receptacle.comments.map(&:description)).to eq [comment]
+        expect(lane.comments.map(&:description)).to eq [comment]
+      end
     end
 
-    it 'perform the correct tag2 substitutions' do
-      expect(library_aliquot_a.reload.tag2).to eq sample_a_new_tag2
-      expect(library_aliquot_b.reload.tag2).to eq sample_b_new_tag2
-      expect(mx_aliquot_a.reload.tag2).to eq sample_a_new_tag2
-      expect(mx_aliquot_b.reload.tag2).to eq sample_b_new_tag2
-    end
-
-    it 'assigns comments to the lanes and tubes' do
-      expect(library_tube_a.receptacle.comments.map(&:description)).to eq [comment]
-      expect(library_tube_b.receptacle.comments.map(&:description)).to eq [comment]
-      expect(mx_library_tube.receptacle.comments.map(&:description)).to eq [comment]
-      expect(lane.comments.map(&:description)).to eq [comment]
+    it 'rebroadcasts the flowcell' do
+      expect { subject.save }.to change {
+        Warren.handler.messages_matching("queue_broadcast.messenger.#{flowcell_message.id}")
+      }.by(1)
     end
   end
 
@@ -98,6 +106,11 @@ describe TagSubstitution do
              tag2: sample_a_orig_tag2,
              library: library_tube_a,
              receptacle: lane
+    end
+
+    let!(:flowcell_message) do
+      batch = create(:sequencing_batch, request_attributes: [{ target_asset: lane }])
+      create :flowcell_messenger, target: batch
     end
 
     context 'with only tag 1' do


### PR DESCRIPTION
Fixes  #3248

- Add test for flowcell message creation
- After commit callback on batch triggers immediate broadcast
- Move batch callback inside transaction
