### PR TITLE
Improve performance of aliquot validation

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -73,8 +73,8 @@ class Aliquot < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   convert_labware_to_receptacle_for :library, :receptacle
 
-  before_validation { |record| record.tag_id ||= UNASSIGNED_TAG unless tag }
-  before_validation { |record| record.tag2_id ||= UNASSIGNED_TAG unless tag2 }
+  before_validation { |aliquot| aliquot.tag_id ||= UNASSIGNED_TAG unless aliquot.tag_id? || tag }
+  before_validation { |aliquot| aliquot.tag2_id ||= UNASSIGNED_TAG unless aliquot.tag2_id? || tag2 }
 
   broadcast_with_warren
 

--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -126,7 +126,7 @@ class Aliquot < ApplicationRecord # rubocop:todo Metrics/ClassLength
   # This essentially meant that tag clashes would result in sample dropouts.
   # (presumably because << triggers save not save!)
   def no_tag1?
-    tag_id == UNASSIGNED_TAG || tag.nil?
+    tag_id == UNASSIGNED_TAG || tag_id.nil? && tag.nil?
   end
 
   def tag1?
@@ -134,7 +134,7 @@ class Aliquot < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   def no_tag2?
-    tag2_id == UNASSIGNED_TAG || tag2.nil?
+    tag2_id == UNASSIGNED_TAG || tag2_id.nil? && tag2.nil?
   end
 
   def tag2?


### PR DESCRIPTION
The original statement was:
```ruby
before_validation { |record| record.tag_id ||= UNASSIGNED_TAG unless tag }
```

However, ruby evaluated the right hand side of this statement first.

```ruby
irb(main):001:0> def evaluate(position); puts position; true; end
=> :evaluate
irb(main):002:0> test = nil
=> nil
irb(main):003:0> test ||= evaluate('left') unless evaluate('right')
right
=> nil
irb(main):004:0> test = true
=> true
irb(main):005:0> test ||= evaluate('left') unless evaluate('right')
right
=> nil
```

This was causing the before validation code to fetch the tag each time.

The change:

```
before_validation { |aliquot| aliquot.tag_id ||= UNASSIGNED_TAG unless aliquot.tag_id? || tag }
```

Ensures that we only do so when tag_id is null. We unfortunately still need
to check the presence of a tag in this case to cover situations where the
tag has yet to be persisted. (Mostly only seen in testing)

Impact:
I noticed the issue with tag substitutions, but its likely to impact elsewhere. Still, the performance change I saw was:

Before: Completed 302 Found in 6157ms (ActiveRecord: 3349.9ms)
After: Completed 302 Found in 2170ms (ActiveRecord: 1566.8ms)

Production impact is generally less significant for database query optimisations, as query logging is disabled.

*
*
* ...
