### PR TITLE
Improver performance of small substitutions

### DIFF
--- a/app/models/tag_substitution.rb
+++ b/app/models/tag_substitution.rb
@@ -87,6 +87,10 @@ class TagSubstitution # rubocop:todo Metrics/ClassLength
     @substitutions = substitutions.map { |attrs| Substitution.new(attrs.dup, self) }
   end
 
+  def updated_substitutions
+    @updated_substitutions ||= @substitutions.select(&:updated?)
+  end
+
   # Perform the substitution, add comments to all tubes and lanes and rebroadcast all flowcells
   # @return [Boolean] returns true if the operation was successful, false otherwise
   def save # rubocop:todo Metrics/MethodLength
@@ -94,8 +98,8 @@ class TagSubstitution # rubocop:todo Metrics/ClassLength
 
     # First set all tags to null to avoid the issue of tag clashes
     ActiveRecord::Base.transaction do
-      @substitutions.each(&:nullify_tags)
-      @substitutions.each(&:substitute_tags)
+      updated_substitutions.each(&:nullify_tags)
+      updated_substitutions.each(&:substitute_tags)
       apply_comments
     end
     rebroadcast_flowcells
@@ -150,7 +154,7 @@ class TagSubstitution # rubocop:todo Metrics/ClassLength
 
   def comment_text
     @comment_text ||=
-      @substitutions.each_with_object(comment_header) do |substitution, comment|
+      updated_substitutions.each_with_object(comment_header) do |substitution, comment|
         substitution_comment = substitution.comment(oligo_index)
         comment << substitution_comment << "\n" if substitution_comment.present?
       end

--- a/app/models/tag_substitution/substitution.rb
+++ b/app/models/tag_substitution/substitution.rb
@@ -157,11 +157,11 @@ class TagSubstitution::Substitution # rubocop:todo Metrics/ClassLength
     original_tag_id || original_tag2_id
   end
 
-  private
-
   def updated?
     substitute_tag? || substitute_tag2? || @other_attributes.present?
   end
+
+  private
 
   def substitute_tag?
     original_tag_id && original_tag_id != substitute_tag_id
@@ -175,6 +175,6 @@ class TagSubstitution::Substitution # rubocop:todo Metrics/ClassLength
     attributes = { sample_id: sample_id, library_id: library_id }
     attributes[:tag_id] = original_tag_id if original_tag_id
     attributes[:tag2_id] = original_tag2_id if original_tag2_id
-    Aliquot.where(attributes).pluck(:id)
+    Aliquot.where(attributes).ids
   end
 end


### PR DESCRIPTION
- Only bother updating tags that have actually changed.

When testing the flowcell message stuff I realised we were updating all aliquots, even those that hadn't changed.
