### PR TITLE
Improve performance of cherrpick specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -161,3 +161,7 @@ Metrics/ClassLength:
   Exclude:
     - "spec/**/*"
     - "test/**/*"
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - "spec/features/**/*"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -861,7 +861,7 @@ RSpec/MultipleDescribes:
 
 # Offense count: 736
 RSpec/MultipleExpectations:
-  Max: 21
+  Max: 18
 
 # Offense count: 787
 # Configuration parameters: AllowSubject.

--- a/spec/features/pipelines/cherrypick/cherrypick_pipeline_spec.rb
+++ b/spec/features/pipelines/cherrypick/cherrypick_pipeline_spec.rb
@@ -42,7 +42,7 @@ describe 'Cherrypicking pipeline', type: :feature, cherrypicking: true, js: true
   let(:custom_destination_type) { nil }
   let(:custom_destination_type_name) { custom_destination_type.name || nil }
   let(:expected_pick_files_by_destination_plate) { nil }
-  let!(:plates) { create_list(:plate_with_untagged_wells_and_custom_name, 3, sample_count: 2) }
+  let(:plates) { create_list(:plate_with_untagged_wells_and_custom_name, 3, sample_count: 2) }
 
   # rubocop:todo Metrics/AbcSize
   # rubocop:todo Metrics/MethodLength

--- a/spec/features/shared_examples/cherrypicking.rb
+++ b/spec/features/shared_examples/cherrypicking.rb
@@ -4,7 +4,7 @@ shared_examples 'a cherrypicking procedure' do
   attr_reader :batch_id
   attr_reader :batch_barcode
 
-  it 'can run the cherrypicking pipeline' do
+  scenario 'running the cherrypicking pipeline' do
     step 'Setting up the batch' do
       step 'Access the Cherrypicking pipeline' do
         login_user(user)
@@ -108,15 +108,18 @@ shared_examples 'a cherrypicking procedure' do
           end
 
           step 'check the worksheets' do
-            visit batch_path(batch_id)
-
-            within('#output_assets table tbody') do
-              row = page.all('tr', text: /#{destination_barcode}/).first
-              within(row) { click_link 'Print worksheet' }
+            step 'visit the page' do
+              visit batch_path(batch_id)
             end
 
-            expect(page).to have_content('This worksheet was generated')
+            step 'get the file' do
+              within('#output_assets table tbody') do
+                row = page.all('tr', text: /#{destination_barcode}/).first
+                within(row) { click_link 'Print worksheet' }
+              end
 
+              expect(page).to have_content('This worksheet was generated')
+            end
             (1..expected_plates.size).each do |pick_number_index|
               within("#worksheet_plate_#{destination_barcode}_pick_#{pick_number_index}") do
                 within('#source_plates') do
@@ -127,7 +130,6 @@ shared_examples 'a cherrypicking procedure' do
 
                 control_plate = expected_plates[pick_number_index][:control]
                 within('#control_plates') { expect(page).to have_content(control_plate.human_barcode) } if control_plate
-
                 within('#destination_plate') { expect(page).to have_content(destination_barcode) }
 
                 # check barcode
@@ -137,13 +139,14 @@ shared_examples 'a cherrypicking procedure' do
 
                 # check wells
                 within('#plate_layouts') do
-                  cells_with_content = page.all('td', text: /.+v13.0 b0.0/)
+                  cells_with_content = page.all('td', text: /.+v[\d.]+ b[\d.]+/, wait: 0)
+                  expect(cells_with_content).not_to be_empty
+                  barcode_numbers = expected_plates[pick_number_index][:sources].map(&:barcode_number)
+                  barcode_numbers << control_plate.barcode_number if control_plate
 
                   # check that the number each cell contains is in the expected list of plate barcodes
                   # N.B. this doesn't actually check the correct picks are going to correct wells at sample level
                   cells_with_content.each do |cell|
-                    barcode_numbers = expected_plates[pick_number_index][:sources].map(&:barcode_number)
-                    barcode_numbers << control_plate.barcode_number if control_plate
                     number_in_cell = cell.text.split(' ')[1]
 
                     expect(barcode_numbers).to include(number_in_cell)


### PR DESCRIPTION
page.all('td', text: /.+v13.0 b0.0/) waits for 10 seconds
if no cells match the regexp, and will then return an empty array.

However:
1) We have some tests for different volumes,
so we increase the permissiveness of the regexp
2) We know the page is already rendered, so don't wait.
3) If we *don't* find anything, that's probably a bug. Lets fail.

This also moves the barcode array generation out of the loop.
Its a minor saving, but one I made while tracking down the
bottle-neck.

These tests are still pretty slow, but this change knoxk about 10 seconds
off each pass through, saving a minute or so over all.

Closes #

Changes proposed in this pull request:

*
*
* ...
