### PR TITLE
Dpl 033 add phix during library prep

### DIFF
--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -21,7 +21,7 @@ class Api::Messages::FlowcellIO < Api::Base
     ]
   }
 
-  # Included in SequencingRequest
+  # Included in SequencingRequest model
   module LaneExtensions
     # rubocop:todo Metrics/MethodLength
     def self.included(base) # rubocop:todo Metrics/AbcSize
@@ -104,7 +104,8 @@ class Api::Messages::FlowcellIO < Api::Base
     # rubocop:enable Metrics/MethodLength
   end
 
-  module ControlLaneExtensions # rubocop:todo Style/Documentation
+  # Included in ControlRequest model
+  module ControlLaneExtensions
     def self.included(base) # rubocop:todo Metrics/MethodLength
       base.class_eval do
         def mx_library
@@ -158,7 +159,8 @@ class Api::Messages::FlowcellIO < Api::Base
     end
   end
 
-  module AliquotExtensions # rubocop:todo Style/Documentation
+  # Included in Aliquot model
+  module AliquotExtensions
     def aliquot_type
       tags? ? 'library_indexed' : 'library'
     end
@@ -168,13 +170,15 @@ class Api::Messages::FlowcellIO < Api::Base
     end
   end
 
-  module ProjectExtensions # rubocop:todo Style/Documentation
+  # Included in Project model
+  module ProjectExtensions
     def project_cost_code_for_uwh
       project_cost_code.length > 20 ? 'Custom' : project_cost_code
     end
   end
 
-  module Extensions # rubocop:todo Style/Documentation
+  # Included in Batch model
+  module Extensions
     module ClassMethods # rubocop:todo Style/Documentation
     end
 

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -21,6 +21,10 @@ class Api::Messages::FlowcellIO < Api::Base
     ]
   }
 
+  #
+  # The following modules add methods onto the relevant models, which are used below in generation of the flowcell MLWH message.
+  #
+
   # Included in SequencingRequest model
   module LaneExtensions
     # rubocop:todo Metrics/MethodLength
@@ -200,8 +204,14 @@ class Api::Messages::FlowcellIO < Api::Base
     end
   end
 
+  # Batch is the main / top-level model that contributes to the message sent to the MLWH.
   renders_model(::Batch)
 
+  #
+  # The following section maps attributes on Sequencescape models to attributes in the json message that is passed to the MLWH.
+  #
+
+  # The following methods come from the Batch model or the relevant module above.
   map_attribute_to_json_attribute(:flowcell_barcode)
   map_attribute_to_json_attribute(:id, 'flowcell_id')
   map_attribute_to_json_attribute(:read_length, 'forward_read_length')
@@ -209,8 +219,9 @@ class Api::Messages::FlowcellIO < Api::Base
 
   map_attribute_to_json_attribute(:updated_at)
 
+  # The following methods come from the Request model or the relevant module above.
+  # They are included in the MLWH message under 'lanes'.
   with_nested_has_many_association(:requests, as: :lanes) do
-    # actually requests
     map_attribute_to_json_attribute(:manual_qc)
     map_attribute_to_json_attribute(:position)
     map_attribute_to_json_attribute(:priority)
@@ -224,8 +235,9 @@ class Api::Messages::FlowcellIO < Api::Base
     map_attribute_to_json_attribute(:workflow)
     map_attribute_to_json_attribute(:loading_concentration)
 
+    # The following methods come from the Aliquot model or the relevant module above.
+    # They are included in the MLWH message under 'samples'.
     with_nested_has_many_association(:lane_samples, as: :samples) do
-      # actually aliquots
       map_attribute_to_json_attribute(:aliquot_index_value, 'tag_index')
       map_attribute_to_json_attribute(:suboptimal, 'suboptimal')
 
@@ -257,6 +269,8 @@ class Api::Messages::FlowcellIO < Api::Base
       map_attribute_to_json_attribute(:aliquot_type, 'entity_type')
     end
 
+    # The following methods come from the Aliquot model or the relevant module above.
+    # They are included in the MLWH message under 'controls'.
     with_nested_has_many_association(:controls) do
       with_association(:tag) do
         map_attribute_to_json_attribute(:map_id, 'tag_index')

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -71,8 +71,6 @@ class Labware < Asset # rubocop:todo Metrics/ClassLength
 
   belongs_to :purpose, foreign_key: :plate_purpose_id, optional: true, inverse_of: :labware
 
-  # Gets the SpikedBuffer tube that is a direct parent of this labware, if it exists.
-  # The original implementation of spiked_in_buffer just supported direct parent tubes.
   has_one :spiked_in_buffer_links,
           # If we try to use the Rails 6 version, Rails 5 doesn't seem to perform the join
           -> { includes(:ancestor).references(:ancestor).where(labware: { sti_type: 'SpikedBuffer' }).direct },
@@ -80,8 +78,6 @@ class Labware < Asset # rubocop:todo Metrics/ClassLength
           foreign_key: :descendant_id,
           inverse_of: :descendant
 
-  # Gets the most recent SpikedBuffer tube ancestor, if it exists, to use if there is no direct parent SpikedBuffer tube.
-  # Added to support PhiX being added during library prep rather than at sequencing time (for Heron).
   has_one :spiked_in_buffer_most_recent_links,
           # If we try to use the Rails 6 version, Rails 5 doesn't seem to perform the join
           -> {
@@ -93,6 +89,14 @@ class Labware < Asset # rubocop:todo Metrics/ClassLength
           class_name: 'AssetLink',
           foreign_key: :descendant_id,
           inverse_of: :descendant
+
+  # Gets the SpikedBuffer tube that is a direct parent of this labware, if it exists.
+  # The original implementation of spiked_in_buffer only supported direct parent tubes.
+  has_one :direct_spiked_in_buffer, through: :spiked_in_buffer_links, source: :ancestor
+
+  # Gets the most recent SpikedBuffer tube ancestor, if it exists, to use if there is no direct parent SpikedBuffer tube.
+  # Added to support PhiX being added during library prep rather than at sequencing time (for Heron).
+  has_one :most_recent_spiked_in_buffer, through: :spiked_in_buffer_most_recent_links, source: :ancestor
 
   has_many :asset_audits, foreign_key: :asset_id, dependent: :destroy, inverse_of: :asset
   has_many :volume_updates, foreign_key: :target_id, dependent: :destroy, inverse_of: :target
@@ -173,8 +177,7 @@ class Labware < Asset # rubocop:todo Metrics/ClassLength
   # This was necessary to avoid affecting historical data, for which the direct parent should be used,
   # even though there is another ancestor that was created more recently.
   def spiked_in_buffer
-    asset_link = spiked_in_buffer_links || spiked_in_buffer_most_recent_links
-    asset_link.present? ? asset_link.ancestor : nil
+    direct_spiked_in_buffer || most_recent_spiked_in_buffer
   end
 
   def human_barcode

--- a/app/models/receptacle.rb
+++ b/app/models/receptacle.rb
@@ -70,7 +70,7 @@ class Receptacle < Asset # rubocop:todo Metrics/ClassLength
 
   has_many :messengers, as: :target, inverse_of: :target
   delegate :scanned_in_date, to: :labware
-  has_one :spiked_in_buffer, through: :labware
+  delegate :spiked_in_buffer, to: :labware
 
   has_many :transfer_requests_as_source, class_name: 'TransferRequest', foreign_key: :asset_id
   has_many :transfer_requests_as_target, class_name: 'TransferRequest', foreign_key: :target_asset_id

--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -13,12 +13,8 @@ xml.batch do
             {
               target_asset: {
                 labware: {
-                  spiked_in_buffer_links: {
-                    ancestor: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }]
-                  },
-                  spiked_in_buffer_most_recent_links: {
-                    ancestor: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }]
-                  }
+                  direct_spiked_in_buffer: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }],
+                  most_recent_spiked_in_buffer: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }]
                 },
                 aliquots: %i[library tag tag2 aliquot_index bait_library sample]
               }

--- a/app/views/batches/show.xml.builder
+++ b/app/views/batches/show.xml.builder
@@ -12,7 +12,14 @@ xml.batch do
           request: [
             {
               target_asset: {
-                spiked_in_buffer: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }],
+                labware: {
+                  spiked_in_buffer_links: {
+                    ancestor: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }]
+                  },
+                  spiked_in_buffer_most_recent_links: {
+                    ancestor: [:index, { aliquots: %i[library tag tag2 aliquot_index sample] }]
+                  }
+                },
                 aliquots: %i[library tag tag2 aliquot_index bait_library sample]
               }
             },

--- a/spec/factories/tube_factories.rb
+++ b/spec/factories/tube_factories.rb
@@ -195,6 +195,12 @@ FactoryBot.define do
     after(:build) do |tube, evaluator|
       tube.receptacle.aliquots << build(:phi_x_aliquot, evaluator.aliquot_attributes.merge(library: tube))
     end
+
+    factory :spiked_buffer_with_parent do
+      transient { parent { create :spiked_buffer, :tube_barcode } }
+
+      after(:build) { |tube, evaluator| tube.parents << evaluator.parent }
+    end
   end
 
   factory :phi_x_stock_tube, class: 'LibraryTube', traits: [:tube_barcode] do

--- a/spec/models/labware_spec.rb
+++ b/spec/models/labware_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe Labware, type: :model do
         expect(labware.spiked_in_buffer).to eq(spiked_buffer_child)
       end
     end
+
+    context 'when there is no SpikedBuffer ancestor at all' do
+      it 'returns nil' do
+        expect(labware.spiked_in_buffer).to be_nil
+      end
+    end
   end
 
   context 'when checking scopes' do

--- a/spec/models/labware_spec.rb
+++ b/spec/models/labware_spec.rb
@@ -95,8 +95,7 @@ RSpec.describe Labware, type: :model do
 
     context 'when there are no direct parent SpikedBuffer tubes, and multiple indirect ancestors' do
       before do
-        # Create the SpikedBuffer child after the parent
-        # Tests expected situation from now on
+        # Create the SpikedBuffer child after the parent (normal expected scenario)
         spiked_buffer_parent
         spiked_buffer_child
         spiked_buffer_child.parents << spiked_buffer_parent

--- a/test/controllers/batches_controller_test.rb
+++ b/test/controllers/batches_controller_test.rb
@@ -126,8 +126,6 @@ class BatchesControllerTest < ActionController::TestCase
 
             should 'have information about spiked in buffers' do
               # puts @response.body
-              # puts "phix library id: #{@phix_with_parent.aliquots.first.library_id}"
-              # puts "phix parent library id: #{@phix_with_parent.parents.first.aliquots.first.library_id}"
               assert_select 'hyb_buffer', 1
               assert_select "sample[library_id='#{@phix_with_parent.aliquots.first.library_id}']", 1
               assert_select "tag[tag_id='#{@phix_with_parent.aliquots.first.tag_id}']", 1

--- a/test/controllers/batches_controller_test.rb
+++ b/test/controllers/batches_controller_test.rb
@@ -125,7 +125,6 @@ class BatchesControllerTest < ActionController::TestCase
             end
 
             should 'have information about spiked in buffers' do
-              # puts @response.body
               assert_select 'hyb_buffer', 1
               assert_select "sample[library_id='#{@phix_with_parent.aliquots.first.library_id}']", 1
               assert_select "tag[tag_id='#{@phix_with_parent.aliquots.first.tag_id}']", 1


### PR DESCRIPTION
Changes proposed in this pull request:

* Previously, PhiX was included in Lanes at sequencing stage by making the SpikedBuffer tube (which contains the PhiX) a direct parent of the Lane Labware.
* Now, the SpikedBuffer tube can also be an indirect ancestor of the Lane Labware
  * When looking for the relevant SpikedBuffer tube, direct parents will be considered first. If there is no direct parent, the most recently created ancestor will be chosen.
    * This is because if we just considered the most recently created ancestor, it would find different tubes for some historical lanes (see this comment on story - https://github.com/sanger/limber/issues/740#issuecomment-893468497)
* This modification is necessary so that the PhiX can be added at an earlier stage for the Heron pipeline (as a parent of the multiplexed library tube).
* I had to change `spiked_in_buffer` on Labware from a `has_one` association to a method, to accommodate the need to check direct parent first, then ancestors.
* The two interfaces affected here are 
  * a) the message that goes to MLWH iseq_flowcell table (flowcell_io class), and 
  * b) the batch xml interface, which is used by NPG's front end and perl API (show.xml.builder)

I'm merging into an epic branch as the changes needed to the sequencing pipeline interface and Limber library prep pipeline are quite separate and will be done in separate pull requests.