### PR TITLE
Issue3228/dpl 043 manifest upload causing duplications in ega

### DIFF
--- a/app/controllers/admin/studies_controller.rb
+++ b/app/controllers/admin/studies_controller.rb
@@ -78,7 +78,8 @@ class Admin::StudiesController < ApplicationController # rubocop:todo Style/Docu
       redirect_to controller: 'admin/studies', action: 'update', id: @study.id
     end
   rescue ActiveRecord::RecordInvalid => e
-    logger.warn "Failed to update attributes: #{@study.errors.map(&:to_s)}}"
+    errors = @study.errors.full_messages
+    logger.warn "Failed to update attributes: #{errors}}"
     flash[:error] = 'Failed to update attributes for study!'
     render action: :show, id: @study.id and return
   end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -20,6 +20,11 @@ require 'rexml/text'
 # - Heron: Heron samples get registered via the Api::V2::Heron::PlatesController
 # - Special samples: Samples such as {PhiX} are generated internally
 class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
+  # See https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :processing_manifest
+  end
+
   GC_CONTENTS = ['Neutral', 'High AT', 'High GC'].freeze
   GENDERS = ['Male', 'Female', 'Mixed', 'Hermaphrodite', 'Unknown', 'Not Applicable'].freeze
   DNA_SOURCES = [
@@ -354,7 +359,11 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
   validates_associated(:ena_study, allow_blank: true, on: :accession)
 
   before_destroy :safe_to_destroy
-  after_save :accession
+
+  # processing_manifest is true if we're currently processing a manifest. We
+  # disable accessioning, as we'll perform it explicitly later. This avoids
+  # accidental calls to save triggering duplicate accessions
+  after_save :accession, unless: -> { Sample::Current.processing_manifest }
 
   # NOTE: Samples don't tend to get released through Sequencescape
   # so in reality these methods are usually misleading.

--- a/app/sample_manifest_excel/sample_manifest_excel/worksheet/test_worksheet.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/worksheet/test_worksheet.rb
@@ -13,7 +13,6 @@ module SampleManifestExcel
 
       attr_accessor :data,
                     :no_of_rows,
-                    :study,
                     :supplier,
                     :count,
                     :type,
@@ -23,7 +22,7 @@ module SampleManifestExcel
                     :cgap,
                     :num_plates,
                     :num_samples_per_plate
-      attr_reader :dynamic_attributes, :tags
+      attr_reader :dynamic_attributes, :tags, :study
       attr_writer :manifest_type
 
       def initialize(attributes = {}) # rubocop:todo Metrics/MethodLength
@@ -40,9 +39,19 @@ module SampleManifestExcel
           create_tube_requests
         end
         create_styles
-        add_title_and_description(study, supplier, count)
+        add_title_and_description(study.name, supplier, count)
         add_headers
         add_data
+      end
+
+      def study=(new_study)
+        @study =
+          case new_study
+          when String
+            Study.find_by(name: new_study) || FactoryBot.create(:study, name: new_study)
+          else
+            new_study
+          end
       end
 
       def last_row
@@ -74,20 +83,22 @@ module SampleManifestExcel
       end
 
       def create_sample_manifest # rubocop:todo Metrics/MethodLength
-        if %w[plate_default plate_full plate_rnachip].include? manifest_type
+        case manifest_type
+        when /plate/
           FactoryBot.create(
             :pending_plate_sample_manifest,
             num_plates: num_plates,
-            num_samples_per_plate: num_samples_per_plate
+            num_samples_per_plate: num_samples_per_plate,
+            study: study
           )
-        elsif %w[tube_library_with_tag_sequences].include? manifest_type
-          FactoryBot.create(:sample_manifest, asset_type: 'library')
-        elsif %w[tube_multiplexed_library tube_multiplexed_library_with_tag_sequences].include? manifest_type
-          FactoryBot.create(:sample_manifest, asset_type: 'multiplexed_library')
-        elsif %w[tube_rack_default].include? manifest_type
-          FactoryBot.create(:tube_rack_manifest, asset_type: 'tube_rack')
+        when /tube_library/
+          FactoryBot.create(:sample_manifest, asset_type: 'library', study: study)
+        when /tube_multiplexed_library/
+          FactoryBot.create(:sample_manifest, asset_type: 'multiplexed_library', study: study)
+        when /tube_rack/
+          FactoryBot.create(:tube_rack_manifest, asset_type: 'tube_rack', study: study)
         else
-          FactoryBot.create(:sample_manifest, asset_type: '1dtube')
+          FactoryBot.create(:sample_manifest, asset_type: '1dtube', study: study)
         end
       end
 

--- a/app/sequencescape_excel/sequencescape_excel/specialised_field/control_type.rb
+++ b/app/sequencescape_excel/sequencescape_excel/specialised_field/control_type.rb
@@ -19,7 +19,6 @@ module SequencescapeExcel
           sample.control = false
           sample.control_type = nil
         end
-        sample.save
       end
 
       def check_control_type_matches_enum

--- a/app/sequencescape_excel/sequencescape_excel/specialised_field/priority.rb
+++ b/app/sequencescape_excel/sequencescape_excel/specialised_field/priority.rb
@@ -13,7 +13,6 @@ module SequencescapeExcel
         return unless valid?
 
         sample.priority = value if value.present?
-        sample.save
       end
 
       private

--- a/spec/models/sample_manifest/uploader_spec.rb
+++ b/spec/models/sample_manifest/uploader_spec.rb
@@ -162,16 +162,20 @@ RSpec.describe SampleManifest::Uploader, type: :model, sample_manifest_excel: tr
     end
 
     it 'will generate sample accessions', accessioning_enabled: true do
+      number_of_plates = 2
+      samples_per_plate = 2
       download =
         build(
           :test_download_plates,
+          num_plates: number_of_plates,
+          num_samples_per_plate: samples_per_plate,
           manifest_type: 'plate_full',
           columns: SampleManifestExcel.configuration.columns.plate_full.dup,
           study: create(:open_study, accession_number: 'acc')
         )
       download.save(test_file_name)
       uploader = described_class.new(test_file, SampleManifestExcel.configuration, user, false)
-      expect { uploader.run! }.to change(Delayed::Job, :count).by(4)
+      expect { uploader.run! }.to change(Delayed::Job, :count).by(number_of_plates * samples_per_plate)
     end
 
     it 'will not upload an invalid 1d tube sample manifest' do

--- a/spec/models/sample_manifest_spec.rb
+++ b/spec/models/sample_manifest_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SampleManifest, type: :model, sample_manifest: true do
 
       teardown { Delayed::Worker.delay_jobs = true }
 
-      # rubocop:todo Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength
       [1, 2].each do |count|
         context "count: #{count}" do
           let(:count) { count }
@@ -162,7 +162,7 @@ RSpec.describe SampleManifest, type: :model, sample_manifest: true do
     context 'when asset_type: multiplexed_library' do
       let(:asset_type) { 'multiplexed_library' }
 
-      # rubocop:todo Metrics/BlockLength
+      # rubocop:disable Metrics/BlockLength
       [2, 3].each do |count|
         context "#{count} libraries(s)" do
           let(:count) { count }

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -134,17 +134,15 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
     context '1dtube' do
       let!(:columns) { SampleManifestExcel.configuration.columns.tube_full.dup }
       let!(:download) { build(:test_download_tubes, columns: columns) }
+      let(:upload) { SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9) }
 
       before { download.save(test_file_name) }
 
       it 'has the correct processor' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9)
-        expect(upload.processor).not_to be_nil
         expect(upload.processor).to be_one_d_tube
       end
 
       it 'updates all of the data' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9)
         upload.process(tag_group)
         expect(upload).to be_processed
       end
@@ -332,20 +330,37 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
 
     context 'plate' do
       let!(:plate_columns) { SampleManifestExcel.configuration.columns.plate_full.dup }
-      let!(:download) { build(:test_download_plates, columns: plate_columns) }
+      let(:download) { build(:test_download_plates, columns: plate_columns, study: study) }
+      let(:study) { create(:open_study, accession_number: 'acc') }
+      let(:upload) { SampleManifestExcel::Upload::Base.new(file: test_file, column_list: plate_columns, start_row: 9) }
 
       before { download.save(test_file_name) }
 
       it 'has the correct processor' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: plate_columns, start_row: 9)
-        expect(upload.processor).not_to be_nil
         expect(upload.processor).to be_plate
       end
 
       it 'updates all of the data' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: plate_columns, start_row: 9)
         upload.process(nil)
         expect(upload).to be_processed
+      end
+
+      context 'when accessioning is enabled' do
+        before do
+          @cache_configatron = configatron.accession_samples
+          configatron.accession_samples = true
+          Accession.configure do |config|
+            config.folder = File.join('spec', 'data', 'accession')
+            config.load!
+          end
+        end
+
+        after { configatron.accession_samples = @cache_configatron } # rubocop:disable RSpec/InstanceVariable
+
+        it 'only generates one acccession job' do
+          sample_count = 4
+          expect { upload.process(nil) }.to change(Delayed::Job, :count).by(sample_count)
+        end
       end
     end
   end

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -345,21 +345,9 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
         expect(upload).to be_processed
       end
 
-      context 'when accessioning is enabled' do
-        before do
-          @cache_configatron = configatron.accession_samples
-          configatron.accession_samples = true
-          Accession.configure do |config|
-            config.folder = File.join('spec', 'data', 'accession')
-            config.load!
-          end
-        end
-
-        after { configatron.accession_samples = @cache_configatron } # rubocop:disable RSpec/InstanceVariable
-
-        it 'only generates one acccession job' do
-          sample_count = 4
-          expect { upload.process(nil) }.to change(Delayed::Job, :count).by(sample_count)
+      context 'when accessioning is enabled', accessioning_enabled: true do
+        it 'surpresses accessioning' do
+          expect { upload.process(nil) }.not_to change(Delayed::Job, :count)
         end
       end
     end

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
       end
 
       context 'when accessioning is enabled', accessioning_enabled: true do
-        it 'suppresses accessioning' do
+        it 'suppresses accessioning to allow explicit triggering after upload' do
           expect { upload.process(nil) }.not_to change(Delayed::Job, :count)
         end
       end

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
       end
 
       context 'when accessioning is enabled', accessioning_enabled: true do
-        it 'surpresses accessioning' do
+        it 'suppresses accessioning' do
           expect { upload.process(nil) }.not_to change(Delayed::Job, :count)
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,6 +151,17 @@ RSpec.configure do |config|
     Warren.handler.disable!
   end
 
+  config.around(:each, accessioning_enabled: true) do |ex|
+    original_value = configatron.accession_samples
+    Accession.configure do |accession|
+      accession.folder = File.join('spec', 'data', 'accession')
+      accession.load!
+    end
+    configatron.accession_samples = true
+    ex.run
+    configatron.accession_samples = original_value
+  end
+
   config.before do
     # Reset the all sequences at the beginning of each
     # test to reduce the impact test order has on test execution

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,8 +151,20 @@ RSpec.configure do |config|
     Warren.handler.disable!
   end
 
+  # Add accessioning_enabled to a spec to automatically:
+  # - Set accession_samples to true before the test, and roll it back afterward
+  # - Configure Accession service with the config defined in spec/data/assession
+  # - Ensure accession service configuration is rolled back afterward
+  #
+  # @example
+  #   context 'when accessioning is enabled', accessioning_enabled: true do
+  #     it 'suppresses accessioning to allow explicit triggering after upload' do
+  #       expect { upload.process(nil) }.not_to change(Delayed::Job, :count)
+  #     end
+  #   end
   config.around(:each, accessioning_enabled: true) do |ex|
     original_value = configatron.accession_samples
+    original_config = Accession.configuration
     Accession.configure do |accession|
       accession.folder = File.join('spec', 'data', 'accession')
       accession.load!
@@ -160,6 +172,7 @@ RSpec.configure do |config|
     configatron.accession_samples = true
     ex.run
     configatron.accession_samples = original_value
+    Accession.configuration = original_config
   end
 
   config.before do


### PR DESCRIPTION
Closes #3228 

- Prevents saves in the middle of manifest processing
- Deliberately disable accessioning while processing to avoid risking similar issues in future

