### PR TITLE
Issue3245/dpl 084 {bug} ss study users not updating to mlwh.study users

### DIFF
--- a/app/models/api/study_io.rb
+++ b/app/models/api/study_io.rb
@@ -46,13 +46,16 @@ class Api::StudyIO < Api::Base
     json_attributes['abbreviation'] = object.abbreviation
 
     object.roles.each do |role|
-      json_attributes[role.name.downcase.gsub(/\s+/, '_')] =
-        role.user_role_bindings.map do |user_role|
-          { login: user_role.user.login, email: user_role.user.email, name: user_role.user.name }.tap do
-            json_attributes['updated_at'] ||= user_role.updated_at
-            json_attributes['updated_at'] = user_role.updated_at if json_attributes['updated_at'] < user_role.updated_at
-          end
-        end
+      role_key = role.name.downcase.gsub(/\s+/, '_')
+      json_attributes[role_key] ||= []
+      role.user_role_bindings.each do |user_role|
+        json_attributes[role_key] << {
+          login: user_role.user.login,
+          email: user_role.user.email,
+          name: user_role.user.name
+        }
+        json_attributes['updated_at'] = [json_attributes['updated_at'], user_role.updated_at].compact.max
+      end
     end
   end
 

--- a/app/models/role/user_role_helper.rb
+++ b/app/models/role/user_role_helper.rb
@@ -18,7 +18,7 @@ module Role::UserRoleHelper
   # Grants a user the role_name,  in cases like
   # owner, authorizable should indicate the owned resource
   def grant_role(role_name, authorizable = nil)
-    roles.find_or_create_by!(name: role_name, authorizable: authorizable)
+    roles << Role.find_or_create_by!(name: role_name, authorizable: authorizable)
   end
 
   def remove_role(role_name, authorizable = nil)

--- a/spec/models/api/study_io_spec.rb
+++ b/spec/models/api/study_io_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Api::StudyIO, type: :model do
   let(:reference_genome) { create :reference_genome }
 
   let!(:manager) { create :manager, authorizable: subject }
+  let!(:manager2) { create :manager, authorizable: subject }
 
   let(:expected_json) do
     {
@@ -50,7 +51,10 @@ RSpec.describe Api::StudyIO, type: :model do
       'data_access_group' => 'something',
       's3_email_list' => 'aa1@sanger.ac.uk;aa2@sanger.ac.uk',
       'data_deletion_period' => '3 months',
-      'manager' => [{ login: manager.login, email: manager.email, name: manager.name }]
+      'manager' => [
+        { login: manager.login, email: manager.email, name: manager.name },
+        { login: manager2.login, email: manager2.email, name: manager2.name }
+      ]
     }
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -110,6 +110,14 @@ RSpec.describe User, type: :model do
       user.grant_role('owner', study)
       expect(user).to be_an_owner_of, study
     end
+
+    context 'when a role already exists' do
+      before { create(:user).grant_role('owner', study) }
+
+      it "doesn't create a new role" do
+        expect { user.grant_role('owner', study) }.not_to(change { study.roles.reload.count })
+      end
+    end
   end
 
   describe '#remove_role' do


### PR DESCRIPTION
Closes #3245

Changes proposed in this pull request:

* Handle duplicate role names when generating study messages
* Avoid adding additional roles unecessarily
