### PR TITLE
Improve batch summary page for multiple events

### DIFF
--- a/app/assets/stylesheets/all/components.scss
+++ b/app/assets/stylesheets/all/components.scss
@@ -16,6 +16,12 @@ table.table-dense-information {
   @extend .table-sm;
 }
 
+table.table-batch-summary {
+  caption {
+    caption-side: top;
+  }
+}
+
 /* main-row encompasses the bulk of the application */
 .main-row {
   margin-bottom: 10px;

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -96,8 +96,9 @@ class Api::Messages::FlowcellIO < Api::Base
         end
 
         def detect_descriptor(name)
-          lab_events.each { |e| e.descriptor_value_for(name).tap { |bc| return bc if bc.present? } }
-          nil # We have no flowcell barcode
+          # Sort here goes by id. Which should
+          lab_events.sort.reverse_each { |e| e.descriptor_value_for(name).tap { |bc| return bc if bc.present? } }
+          nil # We have no matching descriptor
         end
       end
     end

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -96,7 +96,7 @@ class Api::Messages::FlowcellIO < Api::Base
         end
 
         def detect_descriptor(name)
-          # Sort here goes by id. Which should cover our needs
+          # Sort here goes by id ascending, so we use a reverse each, in order to find the most recent descriptor with the passed in 'name'
           lab_events.sort.reverse_each { |e| e.descriptor_value_for(name).tap { |bc| return bc if bc.present? } }
           nil # We have no matching descriptor
         end

--- a/app/models/api/messages/flowcell_io.rb
+++ b/app/models/api/messages/flowcell_io.rb
@@ -96,7 +96,7 @@ class Api::Messages::FlowcellIO < Api::Base
         end
 
         def detect_descriptor(name)
-          # Sort here goes by id. Which should
+          # Sort here goes by id. Which should cover our needs
           lab_events.sort.reverse_each { |e| e.descriptor_value_for(name).tap { |bc| return bc if bc.present? } }
           nil # We have no matching descriptor
         end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -106,10 +106,6 @@ class Asset < ApplicationRecord # rubocop:todo Metrics/ClassLength
     RequestType.where(asset_type: label)
   end
 
-  def external_identifier
-    "#{sti_type}#{id}"
-  end
-
   def details
     nil
   end

--- a/app/models/lab_event.rb
+++ b/app/models/lab_event.rb
@@ -1,6 +1,12 @@
 require_dependency 'broadcast_event/lab_event'
 
-class LabEvent < ApplicationRecord # rubocop:todo Style/Documentation
+# Lab events are created as part of the traditional Sequencescape based pipelines
+# the track the information supplied in each step, mostly in the form of descriptors:
+# key value pairs.
+# They can be associated with individual requests, or the batch as a whole.
+# The information is mainly displayed on the batch summary screen, but also acts
+# as a source of information for the FlowcellIO message
+class LabEvent < ApplicationRecord
   include ActsAsDescriptable
 
   CHIP_BARCODE_STEPS = ['Cluster generation', 'Add flowcell chip barcode', 'Loading'].freeze

--- a/app/models/lab_event.rb
+++ b/app/models/lab_event.rb
@@ -30,8 +30,7 @@ class LabEvent < ApplicationRecord # rubocop:todo Style/Documentation
   end
 
   def descriptor_value_for(name)
-    descriptors.each { |desc| return desc.value if desc.name.casecmp(name.to_s).zero? }
-    nil
+    descriptors.detect { |desc| desc.name.casecmp?(name.to_s) }&.value
   end
 
   def add_new_descriptor(name, value)

--- a/app/models/lab_event.rb
+++ b/app/models/lab_event.rb
@@ -9,8 +9,6 @@ class LabEvent < ApplicationRecord # rubocop:todo Style/Documentation
   belongs_to :user
   belongs_to :eventful, polymorphic: true
 
-  before_validation :unescape_for_descriptors
-
   scope :with_descriptor, ->(k, v) { where(['descriptors LIKE ?', "%#{k}: #{v}%"]) }
 
   scope :with_flowcell_barcode,
@@ -19,10 +17,6 @@ class LabEvent < ApplicationRecord # rubocop:todo Style/Documentation
   delegate :flowcell, :eventful_studies, :samples, to: :eventful
 
   after_create :generate_broadcast_event
-
-  def unescape_for_descriptors
-    self[:descriptors] = (self[:descriptors] || {}).to_h.transform_keys { |key| CGI.unescape(key) }
-  end
 
   def self.find_batch_id_by_barcode(barcode)
     batch_ids = with_flowcell_barcode(barcode).distinct.pluck(:batch_id)

--- a/app/models/lab_event.rb
+++ b/app/models/lab_event.rb
@@ -1,7 +1,7 @@
 require_dependency 'broadcast_event/lab_event'
 
 # Lab events are created as part of the traditional Sequencescape based pipelines
-# the track the information supplied in each step, mostly in the form of descriptors:
+# they track the information supplied in each step, mostly in the form of descriptors:
 # key value pairs.
 # They can be associated with individual requests, or the batch as a whole.
 # The information is mainly displayed on the batch summary screen, but also acts

--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -141,6 +141,10 @@ class Labware < Asset # rubocop:todo Metrics/ClassLength
 
   delegate :state_changer, to: :purpose, allow_nil: true
 
+  def external_identifier
+    "#{sti_type}#{id}"
+  end
+
   def ancestor_of_purpose(ancestor_purpose_id)
     return self if plate_purpose_id == ancestor_purpose_id
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -450,7 +450,11 @@ class Request < ApplicationRecord # rubocop:todo Metrics/ClassLength
   # @return [Array<LabEvent>,LabEvent::ActiveRecord_Associations_CollectionProxy] Events associated with `batch`
   #
   def lab_events_for_batch(batch)
-    lab_events.loaded? ? lab_events.select { |le| le.batch_id == batch.id } : lab_events.where(batch_id: batch.id)
+    if lab_events.loaded?
+      lab_events.select { |le| le.batch_id == batch.id }.sort_by(&:created_at)
+    else
+      lab_events.where(batch_id: batch.id).order(:created_at)
+    end
   end
 
   def next_requests

--- a/app/models/tasks/set_descriptors_handler.rb
+++ b/app/models/tasks/set_descriptors_handler.rb
@@ -72,7 +72,7 @@ module Tasks::SetDescriptorsHandler # rubocop:todo Style/Documentation
               # params[:fields] => <ActionController::Parameters {"1"=>"Operator", "2"=>"Workflow (Standard or Xp)", "3"=>"DPX1", "4"=>"DPX2", "5"=>"DPX3", "6"=>"NovaSeq Xp Mainfold", "7"=>"Pipette Carousel", "8"=>"PhiX lot #", "9"=>"PhiX %", "10"=>"Lane loading concentration (pM)", "11"=>"Comment"} permitted: true>
               # I believe that some of this complexity predates ordered hashes in ruby, and was an attempt to maintain field order.
               unless params[:descriptors].nil?
-                event.descriptors = params[:descriptors]
+                event.descriptors = params[:descriptors].to_unsafe_hash
                 event.descriptor_fields = ordered_fields(params[:fields])
 
                 # Cache values to populate the next request on the same stage

--- a/app/views/pipelines/_event.html.erb
+++ b/app/views/pipelines/_event.html.erb
@@ -1,7 +1,17 @@
-
-<li><%= event.description %></li>
-<ul>
-  <% event.descriptors.each do |descriptor|%>
-  <li><%= descriptor.name %>: <%= descriptor.value %></li>
-  <% end %>
-</ul>
+<table class="table table-dense-information table-batch-summary">
+  <caption><%= event.description %> on <%= time_tag(event.created_at) %> by <%= event.user&.name || 'Unknown' %></h4>
+  <thead>
+    <tr>
+      <% event.descriptors.each do |descriptor| %>
+        <th><%= descriptor.name %></th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <% event.descriptors.each do |descriptor| %>
+        <td><%= descriptor.value %></td>
+      <% end %>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/pipelines/_event_request.html.erb
+++ b/app/views/pipelines/_event_request.html.erb
@@ -1,5 +1,6 @@
-
-<li><strong><%= event_request.asset ? h(event_request.asset.display_name) : "<nil>" %></strong></li>
-<ul>
-<%= render partial: 'event', collection: event_request.lab_events_for_batch(@batch) %>
-</ul>
+<li>
+<%= panel do %>
+  <h3 class="card-title"><%= event_request.asset ? h(event_request.asset.display_name) : "<nil>" %></h3>
+  <%= render partial: 'event', collection: event_request.lab_events_for_batch(@batch) %>
+<% end %>
+</li>

--- a/app/views/pipelines/_event_requests.html.erb
+++ b/app/views/pipelines/_event_requests.html.erb
@@ -1,4 +1,4 @@
 
 <ol>
-  <%= render partial: 'event_request', collection: @batch.requests %>
+  <%= render partial: 'event_request', collection: batch.requests %>
 </ol>

--- a/app/views/pipelines/finish.html.erb
+++ b/app/views/pipelines/finish.html.erb
@@ -29,7 +29,7 @@
   <% if @pipeline.summary %>
     <div id="sample">
       <h4>Batch Summary</h4>
-      <%= render partial: 'event_requests'%>
+      <%= render partial: 'event_requests', locals: { batch: @batch }%>
     </div>
   <% end %>
 </div>

--- a/app/views/pipelines/summary.html.erb
+++ b/app/views/pipelines/summary.html.erb
@@ -1,16 +1,9 @@
 
-<% add :about, "Finished batch" -%>
+<% add :about, 'Displays information about a completed batch' -%>
 <% unless @batch.released? -%>
 <% add :menu, "Release this batch" => release_batch_url(@batch) -%>
 <% end -%>
 <% add :back_menu, "Back to pipeline" => pipeline_path(@batch.pipeline) -%>
 
 <%= page_title 'Batch', 'Summary' %>
-<div class="content">
-  <div class="info">
-  Summary of stored information for Batch <%= @batch.id %>.
-  </div>
-  <div id="sample">
-    <%= render partial: 'event_requests'%>
-  </div>
-</div>
+<%= render partial: 'event_requests', locals: { batch: @batch } %>

--- a/app/views/workflows/_descriptor.html.erb
+++ b/app/views/workflows/_descriptor.html.erb
@@ -16,7 +16,7 @@
     <% elsif descriptor.kind == 'File upload' %>
       <%= file_field_tag "requests[#{request.id}][upload][#{descriptor.name}" %>
     <% else %>
-      <%= text_field "requests[#{request.id}][descriptors]", u(descriptor.name), value: value %>
+      <%= text_field "requests[#{request.id}][descriptors]", descriptor.name, value: value %>
     <% end %>
     <%= hidden_field "requests[#{request.id}][fields]", @count, value: descriptor.name %>
   </td>
@@ -35,7 +35,7 @@
   <% elsif descriptor.kind == 'File upload' %>
     <%= file_field_tag "upload[#{descriptor.name}]" %>
   <% else %>
-    <%= text_field 'descriptors', u(descriptor.name), value: value %>
+    <%= text_field 'descriptors', descriptor.name, value: value %>
   <% end %>
   <%= hidden_field 'fields', @count, value: descriptor.name %>
 </td>

--- a/app/views/workflows/_descriptor.html.erb
+++ b/app/views/workflows/_descriptor.html.erb
@@ -2,42 +2,33 @@
 <% @count = 0 if @count.nil? %>
 <% @count += 1 %>
 <% prefix = '' %>
+<%# We generate our own ids, as there appears to be a discrepency between the
+    way label_tag and text_field handle spaces %>
+<% field_id = "descriptor_#{descriptor_counter}_#{request&.id}" %>
 <% if request %>
   <tr>
-  <td width='35%' class='request'><%= descriptor.name %>: <%= required_marker if descriptor.is_required? %></td>
+  <td width='35%' class='request'><%= label_tag field_id, descriptor.name %>: <%= required_marker if descriptor.is_required? %></td>
   <td width='65%'>
     <% value = descriptor_value descriptor %>
     <% if descriptor.kind == 'Selection' %>
-      <% if descriptor.key == "tag_number" %>
-        <%= select_tag "requests[#{request.id}][descriptors][#{descriptor.name}]", options_for_select(descriptor.selection.values.sort{|x, y| x.to_i <=> y.to_i}, value) %>
-      <% else %>
-        <%= select_tag "requests[#{request.id}][descriptors][#{descriptor.name}]", options_for_select(descriptor.selection.values, value) %>
-      <% end %>
-    <% elsif descriptor.kind == 'File upload' %>
-      <%= file_field_tag "requests[#{request.id}][upload][#{descriptor.name}" %>
+      <%= select_tag "requests[#{request.id}][descriptors][#{descriptor.name}]", options_for_select(descriptor.selection.values, value), id: field_id %>
     <% else %>
-      <%= text_field "requests[#{request.id}][descriptors]", descriptor.name, value: value %>
+      <%= text_field "requests[#{request.id}][descriptors]", descriptor.name, value: value, id: field_id %>
     <% end %>
-    <%= hidden_field "requests[#{request.id}][fields]", @count, value: descriptor.name %>
+    <%= hidden_field "requests[#{request.id}][fields]", @count, value: descriptor.name, id: field_id %>
   </td>
   </tr>
 <% else %>
 <tr>
-<td width='35%' class='request'><%= descriptor.name %>: <%= required_marker if descriptor.is_required? %></td>
+<td width='35%' class='request'><%= label_tag field_id, descriptor.name %>: <%= required_marker if descriptor.is_required? %></td>
 <td width='65%'>
   <% value = descriptor_value descriptor %>
   <% if descriptor.kind == 'Selection' %>
-    <% if descriptor.key == "tag_number" %>
-      <%= select_tag "descriptors[#{descriptor.name}]", options_for_select(descriptor.selection.values.sort{|x, y| x.to_i <=> y.to_i}, value) %>
-    <% else %>
-      <%= select_tag "descriptors[#{descriptor.name}]", options_for_select(descriptor.selection.values, value) %>
-    <% end %>
-  <% elsif descriptor.kind == 'File upload' %>
-    <%= file_field_tag "upload[#{descriptor.name}]" %>
+    <%= select_tag "descriptors[#{descriptor.name}]", options_for_select(descriptor.selection.values, value), id: field_id %>
   <% else %>
-    <%= text_field 'descriptors', descriptor.name, value: value %>
+    <%= text_field 'descriptors', descriptor.name, value: value, id: field_id %>
   <% end %>
-  <%= hidden_field 'fields', @count, value: descriptor.name %>
+  <%= hidden_field 'fields', @count, value: descriptor.name, id: field_id %>
 </td>
 </tr>
 <% end %>

--- a/db/migrate/20210813103500_back_up_lab_events.rb
+++ b/db/migrate/20210813103500_back_up_lab_events.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# We're about to make some major changes to lab events, so lets back it up for
+# disaster recovery reasons.
+# CAUTION: This table contains the data only, not the indexes.
+class BackUpLabEvents < ActiveRecord::Migration[5.2]
+  def up
+    ActiveRecord::Base.connection.execute(<<~SQL.squish)
+      CREATE TABLE bkp_lab_events AS SELECT * FROM lab_events
+    SQL
+  end
+
+  def down
+    drop_table :_bkp_lab_events
+  end
+end

--- a/db/migrate/20210813103531_migrate_descriptor_fields_into_descriptors.rb
+++ b/db/migrate/20210813103531_migrate_descriptor_fields_into_descriptors.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Descriptor fields is redundant now hashes are ordered. This migration
+# updates historical data to ensure:
+# - Hashes are sorted in the same order defined in order-fields
+# - Any keys present in the array, but absent from the hash are recorded
+# - Data missing a + in the hash key is repaired
+class MigrateDescriptorFieldsIntoDescriptors < ActiveRecord::Migration[5.2]
+  def up
+    say 'Updating lab_events...'
+    spinner = %w[🕛 🕐 🕑 🕒 🕓 🕔 🕕 🕖 🕗 🕘 🕙 🕚].cycle
+    data =
+      transaction do
+        LabEvent.find_each.filter_map do |event|
+          print "\r#{spinner.next} #{event.id}" # rubocop:disable Rails/Output
+          simplify_event(event)
+        end
+      end
+    backup_data(data)
+  end
+
+  def simplify_event(event)
+    return nil if event.descriptor_fields == event.descriptor_hash.keys
+
+    say ' - Repairing'
+
+    backup = [event.id, event.descriptors_before_type_cast.dup, event.descriptor_fields_before_type_cast.dup]
+    merged_descriptors = merge_descriptors(event.descriptor_fields, event.descriptor_hash)
+
+    fix_keys!(merged_descriptors)
+
+    event.write_attribute(:descriptors, merged_descriptors)
+    event.save!
+    backup
+  end
+
+  def merge_descriptors(fields, descriptors_hash)
+    fields.select(&:present?).map { |k| [k, nil] }.to_h.merge!(descriptors_hash)
+  end
+
+  def fix_keys!(merged_descriptors)
+    # A historical bug resulted in the attributes beginning in a plus eg.
+    # '+4 Temp. Sequencing Kit Lot #'
+    # being incorrectly stores in the descriptors as ' 4 Temp. Sequencing Kit Lot #'
+    # We'll fix that here to avoid duplicate field names
+    # If both keys are present, we won't merge them
+    good_keys = merged_descriptors.keys.select { |k| k.include?('+') }
+    good_keys.each do |good_key|
+      bad_key = good_key.tr('+', ' ')
+      merged_descriptors[good_key] ||= merged_descriptors.delete(bad_key) if merged_descriptors[bad_key]
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'Cannot be rolled-back automatically. Check ~/MigrateDescriptorFieldsIntoDescriptors-*.csv'
+  end
+
+  def backup_data(data)
+    timestamp = Time.zone.now.strftime('%Y%m%d%H%M%S')
+    filename = Pathname(Dir.home).join("MigrateDescriptorFieldsIntoDescriptors-#{timestamp}.csv")
+
+    CSV.open(filename, 'w') do |csv|
+      csv << %w[event_id descriptors descriptor_fields]
+      data.each { |row| csv << row }
+    end
+
+    say "Backed up to #{filename}", true
+  end
+end

--- a/db/migrate/20210817144508_drop_unused_columns.rb
+++ b/db/migrate/20210817144508_drop_unused_columns.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# In order to simplify things, we'll be removing the unused or redundant columns
+class DropUnusedColumns < ActiveRecord::Migration[5.2]
+  def up
+    change_column :lab_events, :description, :string
+    remove_column :lab_events, :descriptor_fields, type: :text, limit: 16_777_215
+    remove_column :lab_events, :filename, type: :string
+    remove_column :lab_events, :data, type: :binary
+  end
+
+  def down
+    change_column :lab_events, :description, :text, limit: 16_777_215
+    add_column :lab_events, :descriptor_fields, :text, limit: 16_777_215
+    add_column :lab_events, :filename, :string
+    add_column :lab_events, :data, :binary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_13_103531) do
+ActiveRecord::Schema.define(version: 2021_08_17_144508) do
 
   create_table "aker_containers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "barcode"
@@ -274,6 +274,22 @@ ActiveRecord::Schema.define(version: 2021_08_13_103531) do
     t.index ["updated_at"], name: "index_batches_on_updated_at"
   end
 
+  create_table "bkp_lab_events", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "id", default: 0, null: false
+    t.text "description", limit: 16777215, collation: "utf8mb4_unicode_ci"
+    t.text "descriptors", limit: 16777215, collation: "utf8mb4_unicode_ci"
+    t.text "descriptor_fields", limit: 16777215, collation: "utf8mb4_unicode_ci"
+    t.integer "eventful_id"
+    t.string "eventful_type", limit: 50, collation: "utf8mb4_unicode_ci"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "filename", collation: "utf8mb4_unicode_ci"
+    t.binary "data"
+    t.text "message", limit: 16777215, collation: "utf8mb4_unicode_ci"
+    t.integer "user_id"
+    t.integer "batch_id"
+  end
+
   create_table "broadcast_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "sti_type"
     t.string "seed_type"
@@ -511,15 +527,12 @@ ActiveRecord::Schema.define(version: 2021_08_13_103531) do
   end
 
   create_table "lab_events", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
-    t.text "description", limit: 16777215
+    t.string "description"
     t.text "descriptors", limit: 16777215
-    t.text "descriptor_fields", limit: 16777215
     t.integer "eventful_id"
     t.string "eventful_type", limit: 50
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "filename"
-    t.binary "data"
     t.text "message", limit: 16777215
     t.integer "user_id"
     t.integer "batch_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_09_140308) do
+ActiveRecord::Schema.define(version: 2021_08_13_103531) do
 
   create_table "aker_containers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "barcode"

--- a/lib/acts_as_descriptable.rb
+++ b/lib/acts_as_descriptable.rb
@@ -30,18 +30,11 @@
 
 module ActsAsDescriptable # :nodoc:
   def self.included(base)
-    base.class_eval do
-      serialize :descriptors
-      serialize :descriptor_fields, Array
-    end
+    base.class_eval { serialize :descriptors }
   end
 
   def descriptors
-    descriptor_fields.filter_map do |field|
-      next if field.blank?
-
-      Descriptor.new(name: field, value: descriptor_value(field))
-    end
+    descriptor_hash.map { |field, value| Descriptor.new(name: field, value: value) }
   end
 
   def descriptor_value(key)
@@ -50,10 +43,13 @@ module ActsAsDescriptable # :nodoc:
 
   def add_descriptor(descriptor)
     write_attribute(:descriptors, descriptor_hash.merge(descriptor.name => descriptor.value))
-    write_attribute(:descriptor_fields, descriptor_fields.push(descriptor.name))
   end
 
   def descriptor_hash
     read_attribute(:descriptors) || {}
+  end
+
+  def descriptor_fields=(fields)
+    # Ignore for now while we remove this
   end
 end

--- a/lib/acts_as_descriptable.rb
+++ b/lib/acts_as_descriptable.rb
@@ -37,7 +37,11 @@ module ActsAsDescriptable # :nodoc:
   end
 
   def descriptors
-    [].tap { |response| each_descriptor { |field, value| response.push(Descriptor.new(name: field, value: value)) } }
+    descriptor_fields.filter_map do |field|
+      next if field.blank?
+
+      Descriptor.new(name: field, value: descriptor_value(field))
+    end
   end
 
   def descriptor_value(key)
@@ -51,15 +55,5 @@ module ActsAsDescriptable # :nodoc:
 
   def descriptor_hash
     read_attribute(:descriptors) || {}
-  end
-
-  private
-
-  def each_descriptor
-    descriptor_fields.each do |field|
-      next if field.blank?
-
-      yield(field, descriptor_hash[field])
-    end
   end
 end

--- a/spec/factories/pipelines_factories.rb
+++ b/spec/factories/pipelines_factories.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
   end
 
   factory :lab_event do
+    descriptors { {} }
     descriptor_fields { descriptors.keys }
 
     factory :flowcell_event do

--- a/spec/factories/pipelines_factories.rb
+++ b/spec/factories/pipelines_factories.rb
@@ -41,7 +41,6 @@ FactoryBot.define do
 
   factory :lab_event do
     descriptors { {} }
-    descriptor_fields { descriptors.keys }
 
     factory :flowcell_event do
       descriptors { { 'Chip Barcode' => 'fcb' } }

--- a/spec/factories/pipelines_factories.rb
+++ b/spec/factories/pipelines_factories.rb
@@ -40,9 +40,10 @@ FactoryBot.define do
   end
 
   factory :lab_event do
+    descriptor_fields { descriptors.keys }
+
     factory :flowcell_event do
       descriptors { { 'Chip Barcode' => 'fcb' } }
-      descriptor_fields { descriptors.keys }
     end
   end
 
@@ -171,15 +172,6 @@ FactoryBot.define do
       request.request_metadata.fragment_size_required_to = 500
       request.request_metadata.library_type = create(:library_type)
     end
-  end
-
-  factory :task do
-    name { 'New task' }
-    association(:workflow, factory: :lab_workflow)
-    sorted { nil }
-    batched { nil }
-    location { '' }
-    interactive { nil }
   end
 
   factory :pipeline_admin, class: 'User' do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :task do
+    name { 'New task' }
+    association(:workflow, factory: :lab_workflow)
+    sorted { nil }
+    batched { nil }
+    location { '' }
+    interactive { nil }
+  end
+
   factory :plate_template_task do
     name { 'Select Plate Template' }
     association(:workflow, factory: :cherrypick_pipeline_workflow)
@@ -38,5 +47,23 @@ FactoryBot.define do
     pipeline_workflow_id { |workflow| workflow.association(:lab_workflow) }
     location { '' }
     sorted { 2 }
+  end
+
+  factory :add_spiked_in_control_task do
+    name { 'Add Spiked in control' }
+    sorted { 0 }
+    lab_activity { true }
+    workflow
+  end
+
+  factory :set_descriptors_task do
+    name { 'Set descriptors' }
+    sorted { 1 }
+    lab_activity { true }
+    workflow
+
+    transient { descriptor_attributes { [{ kind: 'Text', sorter: 2, name: 'Operator' }] } }
+
+    descriptors { instance.descriptors.build(descriptor_attributes) }
   end
 end

--- a/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
+++ b/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Following a Sequencing Pipeline', type: :feature, js: true do
                 submission: create(:submission)
   end
 
-  it 'can be processed-' do
+  it 'can be processed' do
     login_user(user)
     visit pipeline_path(pipeline)
     within('#available-requests') { all('input[type=checkbox]', count: 2).each(&:check) }
@@ -53,17 +53,10 @@ RSpec.describe 'Following a Sequencing Pipeline', type: :feature, js: true do
     click_on 'Next step'
 
     # We don't currently have labels, so this doesn't work
-    # fill_in('Operator', with: 'James')
-    # select('XP', from: 'workflow')
-    # fill_in('Lane loading concentration (pM)', with: 23)
-    # fill_in('+4 field of weirdness', with: 'Check stored')
-    within('.content') do
-      fields = all('input[type=text]')
-      fields[0].fill_in(with: 'James')
-      fields[1].fill_in(with: 23)
-      fields[2].fill_in(with: 'Check stored')
-      select('XP')
-    end
+    fill_in('Operator', with: 'James')
+    select('XP', from: 'Workflow (Standard or Xp)')
+    fill_in('Lane loading concentration (pM)', with: 23)
+    fill_in('+4 field of weirdness', with: 'Check stored')
 
     click_on 'Next step'
 

--- a/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
+++ b/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
@@ -72,15 +72,13 @@ RSpec.describe 'Following a Sequencing Pipeline', type: :feature, js: true do
         expect(page).to have_text('James')
         expect(page).to have_text('XP')
         expect(page).to have_text('23')
-        # Currently failing
-        # expect(page).to have_text('Check stored')
+        expect(page).to have_text('Check stored')
       end
       within(all('li').last) do
         expect(page).to have_text('James')
         expect(page).to have_text('XP')
         expect(page).to have_text('23')
-        # Currently failing
-        # expect(page).to have_text('Check stored')
+        expect(page).to have_text('Check stored')
       end
     end
     click_on 'Release this batch'

--- a/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
+++ b/spec/features/pipelines/sequencing/following_a_sequencing_pipeline_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Following a Sequencing Pipeline', type: :feature, js: true do
+  let(:user) { create :user }
+  let(:pipeline) do
+    create(:sequencing_pipeline).tap do |pipeline|
+      workflow = pipeline.workflow
+      create(:add_spiked_in_control_task, workflow: workflow)
+      create(
+        :set_descriptors_task,
+        workflow: workflow,
+        descriptor_attributes: [
+          { kind: 'Text', sorter: 2, name: 'Operator' },
+          {
+            kind: 'Selection',
+            sorter: 3,
+            name: 'Workflow (Standard or Xp)',
+            selection: {
+              'Standard' => 'Standard',
+              'XP' => 'XP'
+            },
+            value: 'Standard'
+          },
+          { kind: 'Text', sorter: 4, name: 'Lane loading concentration (pM)' },
+          # We had a bug where the + was being stripped from the beginning of field names
+          { kind: 'Text', sorter: 5, name: '+4 field of weirdness' }
+        ]
+      )
+    end
+  end
+
+  let(:spiked_buffer) { create :spiked_buffer, :tube_barcode }
+
+  before do
+    asset = create :multiplexed_library_tube, :scanned_into_lab, sample_count: 2
+    create_list :sequencing_request_with_assets,
+                2,
+                request_type: pipeline.request_types.first,
+                asset: asset,
+                target_asset: nil,
+                submission: create(:submission)
+  end
+
+  it 'can be processed-' do
+    login_user(user)
+    visit pipeline_path(pipeline)
+    within('#available-requests') { all('input[type=checkbox]', count: 2).each(&:check) }
+    first(:button, 'Submit').click
+    click_on('Add Spiked in control')
+    fill_in('Barcode', with: spiked_buffer.machine_barcode)
+    click_on 'Next step'
+
+    # We don't currently have labels, so this doesn't work
+    # fill_in('Operator', with: 'James')
+    # select('XP', from: 'workflow')
+    # fill_in('Lane loading concentration (pM)', with: 23)
+    # fill_in('+4 field of weirdness', with: 'Check stored')
+    within('.content') do
+      fields = all('input[type=text]')
+      fields[0].fill_in(with: 'James')
+      fields[1].fill_in(with: 23)
+      fields[2].fill_in(with: 'Check stored')
+      select('XP')
+    end
+
+    click_on 'Next step'
+
+    within '#sample' do
+      within(first('li')) do
+        expect(page).to have_text('James')
+        expect(page).to have_text('XP')
+        expect(page).to have_text('23')
+        # Currently failing
+        # expect(page).to have_text('Check stored')
+      end
+      within(all('li').last) do
+        expect(page).to have_text('James')
+        expect(page).to have_text('XP')
+        expect(page).to have_text('23')
+        # Currently failing
+        # expect(page).to have_text('Check stored')
+      end
+    end
+    click_on 'Release this batch'
+    expect(page).to have_content('Batch released')
+  end
+end

--- a/spec/models/api/messages/flowcell_io_spec.rb
+++ b/spec/models/api/messages/flowcell_io_spec.rb
@@ -46,6 +46,98 @@ RSpec.describe Api::Messages::FlowcellIO, type: :model do
       )
     end
 
+    context 'with updated events' do
+      before do
+        create :lab_event,
+               eventful: request_1,
+               descriptors: {
+                 'Chip Barcode' => 'new_fcb',
+                 'PhiX %' => '1',
+                 'Workflow (Standard or Xp)' => 'xp',
+                 'Lane loading concentration (pM)' => '30'
+               }
+      end
+
+      let(:request_data) do
+        {
+          'Chip Barcode' => 'fcb',
+          'PhiX %' => '12',
+          'Workflow (Standard or Xp)' => 'standard',
+          'Lane loading concentration (pM)' => '20'
+        }
+      end
+
+      let(:expected_json) do
+        {
+          'flowcell_barcode' => 'new_fcb',
+          'flowcell_id' => sequencing_batch.id,
+          'forward_read_length' => 76,
+          'reverse_read_length' => 76,
+          'lanes' => [
+            {
+              'manual_qc' => nil,
+              'position' => 1,
+              'priority' => 0,
+              'id_pool_lims' => mx_tube1.human_barcode,
+              'external_release' => nil,
+              'entity_id_lims' => lane1.id,
+              'team' => team.name,
+              'purpose' => 'standard',
+              'spiked_phix_barcode' => phix.human_barcode,
+              'spiked_phix_percentage' => 1.0,
+              'workflow' => 'xp',
+              'loading_concentration' => 30.0,
+              'samples' => [
+                {
+                  'tag_index' => 1,
+                  'suboptimal' => false,
+                  'tag_sequence' => tags[0].oligo,
+                  'tag_set_id_lims' => tags[0].tag_group_id,
+                  'tag_set_name' => tags[0].tag_group.name,
+                  'tag_identifier' => tags[0].map_id,
+                  'tag2_sequence' => tag2s[0].oligo,
+                  'tag2_set_id_lims' => tag2s[0].tag_group_id,
+                  'tag2_set_name' => tag2s[0].tag_group.name,
+                  'tag2_identifier' => tag2s[0].map_id,
+                  'pipeline_id_lims' => 'Standard',
+                  'bait_name' => aliquots[0].bait_library.name,
+                  'requested_insert_size_from' => 100,
+                  'requested_insert_size_to' => 200,
+                  'sample_uuid' => aliquots[0].sample.uuid,
+                  'study_uuid' => aliquots[0].study.uuid,
+                  'cost_code' => 'Some Cost Code',
+                  'is_r_and_d' => false,
+                  'primer_panel' => aliquots[0].primer_panel.name,
+                  'id_library_lims' => aliquots[0].library.human_barcode,
+                  'legacy_library_id' => aliquots[0].library_id,
+                  'entity_type' => 'library_indexed'
+                }
+              ],
+              'controls' => [
+                {
+                  'tag_index' => 888,
+                  'tag_sequence' => 'TGTGCAGC',
+                  'tag_set_id_lims' => phix.aliquots[0].tag.tag_group_id,
+                  'tag_set_name' => 'Control Tag Group 888',
+                  'tag2_sequence' => 'ACTGATGT',
+                  'tag2_set_id_lims' => phix.aliquots[0].tag.tag_group_id,
+                  'tag2_set_name' => 'Control Tag Group 888',
+                  'sample_uuid' => phix.aliquots[0].sample.uuid,
+                  'id_library_lims' => phix.human_barcode,
+                  'legacy_library_id' => phix.receptacle.id,
+                  'entity_type' => 'library_indexed_spike'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'generates valid json' do
+        expect(subject.as_json).to include_json(expected_json)
+      end
+    end
+
     context 'with full request data' do
       let(:request_data) do
         {

--- a/spec/models/broadcast_event/lab_event_spec.rb
+++ b/spec/models/broadcast_event/lab_event_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe BroadcastEvent::LabEvent, type: :model, broadcast_event: true do
              'key_a' => 'value a',
              'key_b' => 'value b'
            },
-           descriptor_fields: %w[key_a key_b],
            eventful: eventful
   end
   let(:user) { create :user }


### PR DESCRIPTION
- Use tables for more compact display
- Add timestamps to event information
- Ensure events are sorted in chronological order

