### PR TITLE
Rename intergration to integration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -613,7 +613,7 @@ RSpec/ContextWording:
     - 'spec/sequencescape_excel/conditional_formatting_default_spec.rb'
     - 'spec/sequencescape_excel/worksheet_spec.rb'
     - 'spec/shared_contexts/limber_shared_context.rb'
-    - 'spec/uat_actions/intergration_suite_tools_spec.rb'
+    - 'spec/uat_actions/integration_suite_tools_spec.rb'
     - 'spec/uat_actions/test_submission_spec.rb'
 
 # Offense count: 4

--- a/app/uat_actions/uat_actions/integration_suite_tools.rb
+++ b/app/uat_actions/uat_actions/integration_suite_tools.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Will construct plates with well_count wells filled with samples
-class UatActions::IntergrationSuiteTools < UatActions
-  self.title = 'Intergration suite tools'
+class UatActions::IntegrationSuiteTools < UatActions
+  self.title = 'Integration suite tools'
 
   # The description displays on the list of UAT actions to provide additional information
   self.description =

--- a/knapsack_rspec_report.json
+++ b/knapsack_rspec_report.json
@@ -254,7 +254,7 @@
   "spec/resources/api/v2/user_resource_spec.rb": 0.007020235061645508,
   "spec/requests/api/v2/lots_spec.rb": 0.6619267463684082,
   "spec/requests/api/v2/tubes_spec.rb": 0.3098578453063965,
-  "spec/uat_actions/intergration_suite_tools_spec.rb": 0.00563812255859375,
+  "spec/uat_actions/integration_suite_tools_spec.rb": 0.00563812255859375,
   "spec/sequencescape_excel/formula_spec.rb": 0.0018832683563232422,
   "spec/features/studies/view_study_request_links_spec.rb": 3.947901487350464,
   "spec/features/billing_report_spec.rb": 5.762065887451172,

--- a/spec/uat_actions/integration_suite_tools_spec.rb
+++ b/spec/uat_actions/integration_suite_tools_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe UatActions::IntergrationSuiteTools do
+describe UatActions::IntegrationSuiteTools do
   context 'valid options' do
     let(:parameters) { {} }
     let(:uat_action) { described_class.new(parameters) }


### PR DESCRIPTION
Noticed this while updating integration-suite.  I'm fixing the typos there too so these line up.