### PR TITLE
Issue3312/dpl 122 import cardinal samples via manifest

### DIFF
--- a/app/views/shared/_manifests.html.erb
+++ b/app/views/shared/_manifests.html.erb
@@ -1,5 +1,5 @@
 
-<table id="study_list" class="sortable">
+<table id="study_list" class="sortable table">
   <thead>
   <tr>
     <th>Name</th>
@@ -22,8 +22,8 @@
       <td><%= pluralize(manifest.count, manifest.asset_type || "plate") %></td>
       <td><%= link_to manifest.study.name, study_path(manifest.study) %></td>
       <td><%= link_to manifest.supplier.name, supplier_path(manifest.supplier) %></td>
-      <td class="strong faint"><span style="display:none"><%= manifest.created_at %></span><%= manifest.created_at.to_formatted_s(:sortable) %></td>
-      <td class="strong faint"><span style="display:none"><%= manifest.updated_at %></span><%= manifest.updated_at.to_formatted_s(:sortable) %></td>
+      <td><%= time_tag(manifest.created_at, format: :sortable) %></td>
+      <td><%= time_tag(manifest.updated_at, format: :sortable) %></td>
       <td>
         <% if manifest.user %>
           <%= link_to manifest.user.login, profile_path(manifest.user) %>

--- a/config/default_records/tube_purposes/005_cardinal_tube_purposes.yml
+++ b/config/default_records/tube_purposes/005_cardinal_tube_purposes.yml
@@ -1,0 +1,7 @@
+# Note: Tubes in the cardinal pipeline are under control of Limber. These are
+# the initial tubes that enter via manifest
+---
+LCA Blood Tube:
+  type: Tube::Purpose
+  target_type: SampleTube
+  stock_plate: false

--- a/config/default_records/tube_purposes/005_cardinal_tube_purposes.yml
+++ b/config/default_records/tube_purposes/005_cardinal_tube_purposes.yml
@@ -1,7 +1,7 @@
 # Note: Tubes in the cardinal pipeline are under control of Limber. These are
 # the initial tubes that enter via manifest
 ---
-LCA Blood Tube:
+LCA Blood Vac:
   type: Tube::Purpose
   target_type: SampleTube
   stock_plate: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
       default: "%a, %d %b %Y %H:%M:%S %z"
       short: "%d %b %H:%M"
       long: "%B %d, %Y %H:%M"
+      sortable: "%Y-%m-%d"
     am: "am"
     pm: "pm"
 

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -678,3 +678,11 @@ heron:
     - :donor_id2
     - :control_type
     - :priority
+cardinal:
+  heading: "Cardinal"
+  asset_type: "1dtube"
+  columns:
+    - :sanger_tube_id
+    - :sanger_sample_id
+    - :supplier_name
+    - :volume


### PR DESCRIPTION
Closes #3312

Changes proposed in this pull request:

* Add minimal cardinal manifest template (We need Sanger sample ids in there as that's how samples get linked behind the scenes) 
* Add cardinal tube purpose
* Minor tweaks to manifest page to add basic table formatting
* Minor tweaks to manifest page to remove hidden span and use time tags.
