### PR TITLE
Rewrite the submission template creation for Cardinal

### DIFF
--- a/lib/limber/helper.rb
+++ b/lib/limber/helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Helper templates and methods used in limber.rake
 module Limber::Helper
   PIPELINE = 'Limber-Htp'
   PIPELINE_REGEX = /Illumina-[A-z]+ /.freeze
@@ -287,6 +288,15 @@ module Limber::Helper
       ids << [cherrypick_request_type.id] if cherrypick
       ids << [library_request_type.id]
       ids << [multiplexing_request_type.id] unless library_request_type.for_multiplexing?
+    end
+  end
+
+  def self.find_project(name)
+    if Rails.env.production?
+      Project.find_by!(name: name)
+    else
+      # In development mode or UAT we don't care so much
+      Project.find_by(name: name) || UatActions::StaticRecords.project
     end
   end
 end


### PR DESCRIPTION
- driver is that I needed it to specify the project_id, so it could be used in an 'automated' way from Limber
- refactored the project querying code that is also used by heron into the helper class
- renamed a task to 'create_purposes' - makes more sense
- got rid of all the extra submission templates as the plan is for the sequencing submissions to be manual, after library prep (due to custom / multiple pooling steps)

- added in things for cardinal cell banking pipeline