### PR TITLE
Add qc result uat action

### DIFF
--- a/app/uat_actions/uat_actions/generate_qc_results.rb
+++ b/app/uat_actions/uat_actions/generate_qc_results.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Will generate qc results for a given plate
+class UatActions::GenerateQcResults < UatActions
+  self.title = 'Generate qc results for a plate or tube'
+  self.description = 'Generate a set of randomised qc result values for a plate or tube.'
+
+  ATTRIBUTE_UNITS = {
+    'molarity' => 'nM',
+    'volume' => 'ul',
+    'concentration' => 'ng/ul',
+    'gender_markers' => 'bases',
+    'loci_passed' => 'bases',
+    'RIN' => 'RIN',
+    'primer_panel' => 'panels',
+    'loci_tested' => 'bases',
+    'gel_pass' => 'status',
+    'live_cell_count' => 'cells/ml',
+    'viability' => '%'
+  }.freeze
+
+  form_field :labware_barcode,
+             :text_field,
+             label: 'Labware barcode',
+             help:
+               'Enter the barcode of the plate or tube for which you want to add qc results. ' \
+                 'NB. only wells/tubes containing aliquots will have qc results set.'
+  form_field :measured_attribute,
+             :select,
+             label: 'Measured attribute',
+             help: 'Select your choice of qc result to record',
+             select_options: ATTRIBUTE_UNITS.keys,
+             options: {
+               include_blank: 'Select a type...'
+             }
+
+  form_field :units, :text_field, label: 'Units', help: 'Leave blank to select a sensible default for the attribute'
+
+  form_field :minimum_value,
+             :number_field,
+             label: 'Minimum value',
+             help: 'The minimum value the results should have.',
+             options: {
+               minimum: 0
+             }
+  form_field :maximum_value,
+             :number_field,
+             label: 'Maximum value',
+             help: 'The maximum value the results should have.',
+             options: {
+               minimum: 0
+             }
+
+  #
+  # Returns a default copy of the UatAction which will be used to fill in the form, with values
+  # for the units, and min and max concentrations.
+  #
+  # @return [UatActions::GeneratePlateConcentrations] A default object for rendering a form
+  def self.default
+    new(measured_attribute: 'concentration', minimum_value: 0, maximum_value: 100)
+  end
+
+  validates :labware, presence: { message: 'could not be found' }
+  validates :measured_attribute, presence: { message: 'needs a choice' }
+  validates :minimum_value, numericality: { only_integer: false }
+  validates :maximum_value, numericality: { greater_than: 0, only_integer: false }
+  validate :maximum_greater_than_minimum
+
+  def perform
+    construct_qc_assay
+  end
+
+  private
+
+  def maximum_greater_than_minimum
+    return true if max_conc > min_conc
+
+    errors.add(:maximum_value, 'needs to be greater than minimum value')
+    false
+  end
+
+  def labware
+    @labware ||= Labware.find_by_barcode(labware_barcode.strip)
+  end
+
+  def resolved_units
+    units.presence || ATTRIBUTE_UNITS[measured_attribute]
+  end
+
+  def min_conc
+    @min_conc ||= minimum_value.to_f
+  end
+
+  def max_conc
+    @max_conc ||= maximum_value.to_f
+  end
+
+  def create_random_concentration
+    value = (rand * (max_conc - min_conc)) + min_conc
+    format('%.3f', value)
+  end
+
+  def construct_qc_assay
+    qc_assay = QcAssay.new
+
+    labware.receptacles.each do |receptacle|
+      next if receptacle.aliquots.empty?
+
+      qc_assay.qc_results.build(
+        asset: receptacle,
+        key: measured_attribute,
+        value: create_random_concentration,
+        units: resolved_units,
+        assay_type: 'UAT_Testing',
+        assay_version: 'Binning',
+        qc_assay: qc_assay
+      )
+    end
+    report['number_results_written'] = qc_assay.qc_results.length
+    qc_assay.save
+  end
+end

--- a/spec/uat_actions/generate_qc_results_spec.rb
+++ b/spec/uat_actions/generate_qc_results_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UatActions::GenerateQcResults do
+  context 'with valid options' do
+    let(:plate) { create :plate_with_untagged_wells, sample_count: 3, barcode: '1' }
+    let(:tube) { create :sample_tube, barcode: '1' }
+
+    let(:uat_action) { described_class.new(parameters) }
+    let(:report) do
+      # A report is a hash of key value pairs which get returned to the user.
+      # It should include information such as barcodes and identifiers
+      { 'number_results_written' => 3 }
+    end
+
+    context 'when concentration' do
+      let(:parameters) do
+        {
+          labware_barcode: plate.human_barcode,
+          measured_attribute: 'concentration',
+          minimum_value: 0,
+          maximum_value: 30
+        }
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report).to eq report
+        expect(plate.wells.flat_map(&:qc_results).size).to eq 3
+        expect(plate.wells.first.qc_results.first.assay_type).to eq 'UAT_Testing'
+      end
+    end
+
+    context 'when a tube' do
+      let(:parameters) do
+        {
+          labware_barcode: tube.human_barcode,
+          measured_attribute: 'concentration',
+          minimum_value: 0,
+          maximum_value: 30
+        }
+      end
+      let(:report) do
+        # A report is a hash of key value pairs which get returned to the user.
+        # It should include information such as barcodes and identifiers
+        { 'number_results_written' => 1 }
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report).to eq report
+        expect(tube.receptacles.flat_map(&:qc_results).size).to eq 1
+        expect(tube.receptacles.first.qc_results.first.assay_type).to eq 'UAT_Testing'
+      end
+    end
+
+    context 'when molarity' do
+      let(:parameters) do
+        { labware_barcode: plate.human_barcode, measured_attribute: 'molarity', minimum_value: 0, maximum_value: 30 }
+      end
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report).to eq report
+        expect(plate.wells.map(&:qc_results).size).to eq 3
+        expect(plate.wells.first.qc_results.first.assay_type).to eq 'UAT_Testing'
+      end
+    end
+  end
+
+  it 'returns a default' do
+    expect(described_class.default).to be_a described_class
+  end
+end


### PR DESCRIPTION
I wanted to test with the actual qc-attributes we'd be expecting for this step, but the existing uat action only allowed for molarity and concentrations, something that was also implied by its name.

We probably want to get rid of the more specific one soon, but I left it there until we can update the UAT actions.