### PR TITLE
DPL-091 / DPL-134 PhiX tweaks

### DIFF
--- a/app/controllers/phi_x/spiked_buffers_controller.rb
+++ b/app/controllers/phi_x/spiked_buffers_controller.rb
@@ -9,7 +9,6 @@ class PhiX::SpikedBuffersController < ApplicationController
       @spiked_buffers = @spiked_buffer.created_spiked_buffers
       render :show
     else
-      @study_names = PhiX.studies.for_select_association
       render :new
     end
   end
@@ -17,8 +16,6 @@ class PhiX::SpikedBuffersController < ApplicationController
   private
 
   def phi_x_spiked_buffers_params
-    params
-      .require(:phi_x_spiked_buffer)
-      .permit(:name, :parent_barcode, :concentration, :buffer, :number, :volume, :study_id)
+    params.require(:phi_x_spiked_buffer).permit(:name, :parent_barcode, :concentration, :buffer, :number, :volume)
   end
 end

--- a/app/models/phi_x/spiked_buffer.rb
+++ b/app/models/phi_x/spiked_buffer.rb
@@ -85,6 +85,9 @@ class PhiX::SpikedBuffer
     @phi_x_sample ||= PhiX.sample
   end
 
+  # Setting the study for a SpikedBuffer tube is not currently exposed as an option through the /phi_x page
+  # due to concerns that it will be set accidentally
+  # But the option is here in the model to set it via study_id if needed in future
   def aliquot_attributes
     study_id.present? ? { study_id: study_id } : {}
   end

--- a/app/views/phi_xes/_spiked_buffer.html.erb
+++ b/app/views/phi_xes/_spiked_buffer.html.erb
@@ -21,16 +21,6 @@
     </div>
   </div>
   <div class='phi-x-form'>
-    <%= form.label :study_id, 'Study' %>
-    <div class="field">
-      <%= form.select :study_id, @study_names , {prompt: "Same a stock"} %>
-      <div class="form-help">
-        The study with which the PhiX will be associated.
-        Leave as is to use same study as parent
-      </div>
-    </div>
-  </div>
-  <div class='phi-x-form'>
     <%= form.label :concentration %>
     <div class="field">
     <div class="input-group">

--- a/spec/models/phi_x/spiked_buffer_spec.rb
+++ b/spec/models/phi_x/spiked_buffer_spec.rb
@@ -120,6 +120,9 @@ RSpec.describe PhiX::SpikedBuffer, type: :model, phi_x: true do
         end
       end
 
+      # Setting the study for a SpikedBuffer tube is not currently exposed as an option through the /phi_x page
+      # due to concerns that it will be set accidentally
+      # But the option is here in the model to set it via study_id if needed in future
       context 'when study_id is provided' do
         let(:study_id) { create(:study).id }
 


### PR DESCRIPTION
remove choice of study from SpikedBuffer tube creation
- just set it to the same as parent
- this is how they are currently using the tubes, and it reduces the risk of tubes accidentally being put in the wrong study
