### PR TITLE
Issue3362/dpl 140 we recently started making citeseq libraries from scratch

### DIFF
--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -355,7 +355,9 @@ namespace :limber do
           'TraDIS',
           'Chromium Visium',
           'Hi-C',
-          'Haplotagging'
+          'Haplotagging',
+          'Chromium single cell HTO',
+          'Chromium single cell surface protein'
         ],
         product_line: 'Bespoke',
         default_purposes: ['LBB Cherrypick'] # It requires default_purpose to accept an array.
@@ -370,9 +372,7 @@ namespace :limber do
         'Chromium single cell 3 prime v3',
         'Chromium single cell 5 prime',
         'Chromium single cell TCR',
-        'Chromium single cell BCR',
-        'Chromium single cell HTO',
-        'Chromium single cell surface protein'
+        'Chromium single cell BCR'
       ]
 
       Limber::Helper::RequestTypeConstructor.new(


### PR DESCRIPTION
Can also be merged straight to master

Closes #3362

Changes proposed in this pull request:

* Move library types from chromium to pcr_free request types

Note: This will not remove the existing library type associations. This can probably be removed easily enough via the rails console.


