### PR TITLE
Update request history page message

### DIFF
--- a/app/views/requests/history.html.erb
+++ b/app/views/requests/history.html.erb
@@ -6,7 +6,7 @@
 
 <div>
   <%= alert(:warning) do %>
-    From October 2021, the Event History page will no longer receive and display new updates on the status of the run. If this will be a problem for you, please let team PSD know by emailing <%= help_email_link %>
+    As of October 2021, the Event History page no longer receives and displays new updates on the status of the run.
   <% end %>
 </div>
 


### PR DESCRIPTION
Update request history page message, because NPG have stopped sending these updates

For context, see email thread "Sequencescape 'Batch xml'" , first message 4 August 2021 at 11:03, including me, James, Rich, David J and Marina. 