### PR TITLE
Pass study as argument of be_an_owner_of

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe User, type: :model do
 
     it 'adds an authorized role to a user' do
       user.grant_role('owner', study)
-      expect(user).to be_an_owner_of, study
+      expect(user).to be_an_owner_of study
     end
 
     context 'when a role already exists' do


### PR DESCRIPTION
This test was previously spititng out a warning, without
a very useful stack-trace to track down. However, I finallt
found it when an experimental branch started failing instead.