### PR TITLE
Upgrade_prettier

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -46,9 +46,8 @@ class BulkSubmissionsController < ApplicationController # rubocop:todo Style/Doc
 
   def find_submission_template_groups
     @submission_template_groups =
-      SubmissionTemplate
-        .visible
-        .include_product_line
-        .group_by { |t| t.product_line.try(:name) || DEFAULT_SUBMISSION_TEMPLATE_GROUP }
+      SubmissionTemplate.visible.include_product_line.group_by do |t|
+        t.product_line.try(:name) || DEFAULT_SUBMISSION_TEMPLATE_GROUP
+      end
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -445,18 +445,12 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
     ActiveRecord::Base.transaction do
       # Update the lab events for the request so that they reference the batch that the request is moving to
-      batch_request_left
-        .request
-        .lab_events
-        .each do |event|
-          event.update!(batch_id: batch_request_right.batch_id) if event.batch_id == batch_request_left.batch_id
-        end
-      batch_request_right
-        .request
-        .lab_events
-        .each do |event|
-          event.update!(batch_id: batch_request_left.batch_id) if event.batch_id == batch_request_right.batch_id
-        end
+      batch_request_left.request.lab_events.each do |event|
+        event.update!(batch_id: batch_request_right.batch_id) if event.batch_id == batch_request_left.batch_id
+      end
+      batch_request_right.request.lab_events.each do |event|
+        event.update!(batch_id: batch_request_left.batch_id) if event.batch_id == batch_request_right.batch_id
+      end
 
       # Swap the two batch requests so that they are correct.  This involves swapping both the batch and the lane but
       # ensuring that the two requests don't clash on position by removing one of them.

--- a/app/models/cherrypick_pipeline.rb
+++ b/app/models/cherrypick_pipeline.rb
@@ -27,10 +27,9 @@ class CherrypickPipeline < CherrypickingPipeline
       .requests
       .select(&:passed?)
       .each do |request|
-        request
-          .asset
-          .stock_wells
-          .each { |stock| EventSender.send_pick_event(stock, target_purpose, "Pickup well #{request.asset.id}") }
+        request.asset.stock_wells.each do |stock|
+          EventSender.send_pick_event(stock, target_purpose, "Pickup well #{request.asset.id}")
+        end
       end
     batch.release_pending_requests
     batch.output_plates.each(&:cherrypick_completed)

--- a/app/models/delegate_validation.rb
+++ b/app/models/delegate_validation.rb
@@ -16,10 +16,9 @@ module DelegateValidation
     validates_each(*args) do |record, _attr, value|
       validator = record.send(:"#{delegation_target}_delegate_validator").new(value)
       validator.valid?.tap do
-        validator
-          .errors
-          .messages
-          .each { |attrib, message| record.errors.add("#{attribute_tag}.#{attrib}", message.join('; ')) }
+        validator.errors.messages.each do |attrib, message|
+          record.errors.add("#{attribute_tag}.#{attrib}", message.join('; '))
+        end
       end
     end
   end

--- a/app/models/plate/sample_tube_factory.rb
+++ b/app/models/plate/sample_tube_factory.rb
@@ -7,10 +7,9 @@ class Plate::SampleTubeFactory < SimpleDelegator
   end
 
   def create_child_sample_tube(well)
-    Tube::Purpose
-      .standard_sample_tube
-      .create!
-      .tap { |sample_tube| sample_tube.receptacle.transfer_requests_as_target.create!(asset: well) }
+    Tube::Purpose.standard_sample_tube.create!.tap do |sample_tube|
+      sample_tube.receptacle.transfer_requests_as_target.create!(asset: well)
+    end
   end
 
   def create_sample_tubes_and_print_barcodes(barcode_printer)

--- a/app/models/request/statemachine.rb
+++ b/app/models/request/statemachine.rb
@@ -22,15 +22,12 @@ module Request::Statemachine # rubocop:todo Style/Documentation
       # Destroy all evidence of the statemachine we've inherited!  Ugly, but it works!
       old_machine = AASM::StateMachineStore.fetch(self) && AASM::StateMachineStore.fetch(self).machine(:default)
       if old_machine
-        old_machine
-          .events
-          .keys
-          .each do |event|
-            undef_method(event)
-            undef_method(:"#{event}!")
-            undef_method(:"#{event}_without_validation!")
-            undef_method(:"may_#{event}?")
-          end
+        old_machine.events.keys.each do |event|
+          undef_method(event)
+          undef_method(:"#{event}!")
+          undef_method(:"#{event}_without_validation!")
+          undef_method(:"may_#{event}?")
+        end
         old_machine.states.each { |state| undef_method(:"#{state}?") }
       end
 

--- a/app/models/sample_manifest/multiplexed_library_behaviour.rb
+++ b/app/models/sample_manifest/multiplexed_library_behaviour.rb
@@ -18,12 +18,9 @@ module SampleManifest::MultiplexedLibraryBehaviour
     end
 
     def generate_mx_library
-      Tube::Purpose
-        .standard_mx_tube
-        .create!
-        .tap do |mx_tube|
-          RequestFactory.create_external_multiplexed_library_creation_requests(@library_tubes, mx_tube, study)
-        end
+      Tube::Purpose.standard_mx_tube.create!.tap do |mx_tube|
+        RequestFactory.create_external_multiplexed_library_creation_requests(@library_tubes, mx_tube, study)
+      end
     end
 
     def io_samples

--- a/app/models/sample_manifest/plate_behaviour.rb
+++ b/app/models/sample_manifest/plate_behaviour.rb
@@ -128,15 +128,12 @@ module SampleManifest::PlateBehaviour
       plates.each do |plate|
         sanger_sample_ids = generate_sanger_ids(plate.size)
 
-        plate
-          .maps
-          .in_column_major_order
-          .each do |well_map|
-            sanger_sample_id = sanger_sample_ids.shift
-            generated_sanger_sample_id = SangerSampleId.generate_sanger_sample_id!(study_abbreviation, sanger_sample_id)
+        plate.maps.in_column_major_order.each do |well_map|
+          sanger_sample_id = sanger_sample_ids.shift
+          generated_sanger_sample_id = SangerSampleId.generate_sanger_sample_id!(study_abbreviation, sanger_sample_id)
 
-            well_data << [well_map, generated_sanger_sample_id]
-          end
+          well_data << [well_map, generated_sanger_sample_id]
+        end
       end
 
       generate_wells(well_data, plates)

--- a/app/models/stock_stamper.rb
+++ b/app/models/stock_stamper.rb
@@ -45,7 +45,6 @@ class StockStamper # rubocop:todo Style/Documentation
     @file_content = Robot::Generator::Tecan.new(picking_data: picking_data, layout: layout, total_volume: 0).as_text
   end
 
-  # rubocop:todo Metrics/MethodLength
   def generate_tecan_data # rubocop:todo Metrics/AbcSize
     source_barcode = "#{plate.machine_barcode}_s"
     destination_barcode = "#{plate.machine_barcode}_d"
@@ -66,23 +65,18 @@ class StockStamper # rubocop:todo Style/Documentation
         }
       }
     }
-    plate
-      .wells
-      .without_blank_samples
-      .each do |well|
-        next unless well.get_current_volume
+    plate.wells.without_blank_samples.each do |well|
+      next unless well.get_current_volume
 
-        data_object['destination'][destination_barcode]['mapping'] << {
-          'src_well' => [source_barcode, well.map.description],
-          'dst_well' => well.map.description,
-          'volume' => volume(well),
-          'buffer_volume' => well.get_buffer_volume
-        }
-      end
+      data_object['destination'][destination_barcode]['mapping'] << {
+        'src_well' => [source_barcode, well.map.description],
+        'dst_well' => well.map.description,
+        'volume' => volume(well),
+        'buffer_volume' => well.get_buffer_volume
+      }
+    end
     data_object
   end
-
-  # rubocop:enable Metrics/MethodLength
 
   def create_asset_audit_event
     AssetAudit.create(

--- a/app/models/tasks/plate_transfer_handler.rb
+++ b/app/models/tasks/plate_transfer_handler.rb
@@ -20,26 +20,23 @@ module Tasks::PlateTransferHandler # rubocop:todo Style/Documentation
     source_wells = batch_requests.map(&:asset)
     raise InvalidBatch if unsuitable_wells?(source_wells)
 
-    task
-      .purpose
-      .create!
-      .tap do |target|
-        well_map = target.wells.index_by { |well| well.map_id }
+    task.purpose.create!.tap do |target|
+      well_map = target.wells.index_by { |well| well.map_id }
 
-        batch_requests.each do |outer_request|
-          source = outer_request.asset
-          TransferRequest.create!(
-            asset: source,
-            target_asset: well_map[source.map_id],
-            submission_id: outer_request.submission_id
-          )
-          TransferRequest.create!(
-            asset: well_map[source.map_id],
-            target_asset: outer_request.target_asset,
-            submission_id: outer_request.submission_id
-          )
-        end
+      batch_requests.each do |outer_request|
+        source = outer_request.asset
+        TransferRequest.create!(
+          asset: source,
+          target_asset: well_map[source.map_id],
+          submission_id: outer_request.submission_id
+        )
+        TransferRequest.create!(
+          asset: well_map[source.map_id],
+          target_asset: outer_request.target_asset,
+          submission_id: outer_request.submission_id
+        )
       end
+    end
   end
 
   # rubocop:enable Metrics/MethodLength

--- a/app/resources/api/v2/work_order_resource.rb
+++ b/app/resources/api/v2/work_order_resource.rb
@@ -59,11 +59,9 @@ module Api
       end
 
       def options
-        _model
-          .example_request
-          .request_metadata
-          .attributes
-          .reject { |key, value| IGNORED_METADATA_FIELDS.include?(key) || value.blank? }
+        _model.example_request.request_metadata.attributes.reject do |key, value|
+          IGNORED_METADATA_FIELDS.include?(key) || value.blank?
+        end
       end
     end
   end

--- a/app/views/assets/show.xml.builder
+++ b/app/views/assets/show.xml.builder
@@ -30,16 +30,13 @@ xml.asset(api_data) do
         xml.request do
           xml.id asset_request.id
           xml.properties do
-            asset_request
-              .request_metadata
-              .attribute_value_pairs
-              .each do |attribute, value|
-                xml.property do
-                  xml.key attribute.name.to_s
-                  xml.name attribute.to_field_info.display_name
-                  xml.value value
-                end
+            asset_request.request_metadata.attribute_value_pairs.each do |attribute, value|
+              xml.property do
+                xml.key attribute.name.to_s
+                xml.name attribute.to_field_info.display_name
+                xml.value value
               end
+            end
           end
         end
       end

--- a/app/views/batches/released.xml.builder
+++ b/app/views/batches/released.xml.builder
@@ -6,19 +6,16 @@ xml.batches do |batches|
       batch.id b.id
       batch.lanes do |lanes|
         count = 0
-        b
-          .items
-          .ordered
-          .each do |item|
-            count = count + 1
-            lanes.lane('position' => count) do |lane|
-              if item.resource?
-                lane.control('id' => item.ident, 'name' => item.name, 'request_id' => item.request)
-              else
-                lane.sample('id' => item.ident, 'name' => item.name, 'request_id' => item.request)
-              end
+        b.items.ordered.each do |item|
+          count = count + 1
+          lanes.lane('position' => count) do |lane|
+            if item.resource?
+              lane.control('id' => item.ident, 'name' => item.name, 'request_id' => item.request)
+            else
+              lane.sample('id' => item.ident, 'name' => item.name, 'request_id' => item.request)
             end
           end
+        end
       end
     end
   end

--- a/app/views/labware/show.xml.builder
+++ b/app/views/labware/show.xml.builder
@@ -27,16 +27,13 @@ xml.asset(api_data) do
         xml.request do
           xml.id asset_request.id
           xml.properties do
-            asset_request
-              .request_metadata
-              .attribute_value_pairs
-              .each do |attribute, value|
-                xml.property do
-                  xml.key attribute.name.to_s
-                  xml.name attribute.to_field_info.display_name
-                  xml.value value
-                end
+            asset_request.request_metadata.attribute_value_pairs.each do |attribute, value|
+              xml.property do
+                xml.key attribute.name.to_s
+                xml.name attribute.to_field_info.display_name
+                xml.value value
               end
+            end
           end
         end
       end

--- a/app/views/projects/show.xml.builder
+++ b/app/views/projects/show.xml.builder
@@ -6,14 +6,11 @@ xml.project(api_data) do
   xml.approved @project.approved
   xml.state @project.state
   xml.descriptors do
-    @project
-      .project_metadata
-      .attribute_value_pairs
-      .each do |attribute, value|
-        xml.descriptor do
-          xml.name attribute.to_field_info.display_name
-          xml.value value
-        end
+    @project.project_metadata.attribute_value_pairs.each do |attribute, value|
+      xml.descriptor do
+        xml.name attribute.to_field_info.display_name
+        xml.value value
       end
+    end
   end
 end

--- a/app/views/receptacles/show.xml.builder
+++ b/app/views/receptacles/show.xml.builder
@@ -27,16 +27,13 @@ xml.asset(api_data) do
         xml.request do
           xml.id asset_request.id
           xml.properties do
-            asset_request
-              .request_metadata
-              .attribute_value_pairs
-              .each do |attribute, value|
-                xml.property do
-                  xml.key attribute.name.to_s
-                  xml.name attribute.to_field_info.display_name
-                  xml.value value
-                end
+            asset_request.request_metadata.attribute_value_pairs.each do |attribute, value|
+              xml.property do
+                xml.key attribute.name.to_s
+                xml.name attribute.to_field_info.display_name
+                xml.value value
               end
+            end
           end
         end
       end

--- a/app/views/requests/show.xml.builder
+++ b/app/views/requests/show.xml.builder
@@ -12,15 +12,12 @@ xml.request(api_data) do
   xml.state @request.state
 
   xml.properties do
-    @request
-      .request_metadata
-      .attribute_value_pairs
-      .each do |attribute, value|
-        xml.property do
-          xml.name(attribute.to_field_info.display_name)
-          xml.value(value)
-        end
+    @request.request_metadata.attribute_value_pairs.each do |attribute, value|
+      xml.property do
+        xml.name(attribute.to_field_info.display_name)
+        xml.value(value)
       end
+    end
   end
 
   # Events

--- a/app/views/samples/index.xml.builder
+++ b/app/views/samples/index.xml.builder
@@ -14,16 +14,13 @@ else
         samples.workflow_sample do |workflow_sample|
           workflow_sample.id ws.id
           workflow_sample.descriptors do |descriptors|
-            ws
-              .sample_metadata
-              .attribute_value_pairs
-              .each do |attribute, value|
-                descriptors.descriptor do |descriptor|
-                  xml.comment! attribute.to_field_info.display_name
-                  descriptor.key attribute.name.to_s
-                  descriptor.value value
-                end
+            ws.sample_metadata.attribute_value_pairs.each do |attribute, value|
+              descriptors.descriptor do |descriptor|
+                xml.comment! attribute.to_field_info.display_name
+                descriptor.key attribute.name.to_s
+                descriptor.value value
               end
+            end
           end
         end
       end

--- a/app/views/samples/show.xml.builder
+++ b/app/views/samples/show.xml.builder
@@ -16,31 +16,25 @@ xml.sample(api_data) do
   # Descriptors
 
   xml.properties do
-    @sample
-      .sample_metadata
-      .attribute_value_pairs
-      .each do |attribute, value|
-        # puts attribute.name.to_s
-        xml.property do
-          # NOTE: The display text is targeted at HTML, so contains escaped entities, which we must unescape for XML.
-          xml.name(REXML::Text.unnormalize(attribute.to_field_info.display_name))
+    @sample.sample_metadata.attribute_value_pairs.each do |attribute, value|
+      # puts attribute.name.to_s
+      xml.property do
+        # NOTE: The display text is targeted at HTML, so contains escaped entities, which we must unescape for XML.
+        xml.name(REXML::Text.unnormalize(attribute.to_field_info.display_name))
+        xml.value(value)
+      end
+    end
+    @sample.sample_metadata.association_value_pairs.each do |attribute, value|
+      xml.property do
+        # NOTE: The display text is targeted at HTML, so contains escaped entities, which we must unescape for XML.
+        xml.name(REXML::Text.unnormalize(attribute.to_field_info.display_name))
+        if (attribute.to_field_info.display_name == 'Reference Genome') && (value.blank?)
+          xml.value(nil)
+        else
           xml.value(value)
         end
       end
-    @sample
-      .sample_metadata
-      .association_value_pairs
-      .each do |attribute, value|
-        xml.property do
-          # NOTE: The display text is targeted at HTML, so contains escaped entities, which we must unescape for XML.
-          xml.name(REXML::Text.unnormalize(attribute.to_field_info.display_name))
-          if (attribute.to_field_info.display_name == 'Reference Genome') && (value.blank?)
-            xml.value(nil)
-          else
-            xml.value(value)
-          end
-        end
-      end
+    end
   end
 
   if study_id

--- a/app/views/studies/index_deprecated_xml.xml.builder
+++ b/app/views/studies/index_deprecated_xml.xml.builder
@@ -28,15 +28,12 @@ xml.studies(api_data) do
         xml.created_at study.created_at
         xml.updated_at study.updated_at
         xml.descriptors do
-          study
-            .study_metadata
-            .attribute_value_pairs
-            .each do |attribute, _name|
-              xml.descriptor do
-                xml.name attribute.to_field_info.display_name
-                xml.value value
-              end
+          study.study_metadata.attribute_value_pairs.each do |attribute, _name|
+            xml.descriptor do
+              xml.name attribute.to_field_info.display_name
+              xml.value value
             end
+          end
         end
       end
     end

--- a/app/views/studies/show.xml.builder
+++ b/app/views/studies/show.xml.builder
@@ -28,28 +28,22 @@ xml.study(api_data) do |study|
   study.updated_at @study.updated_at
 
   study.descriptors do |descriptors|
-    @study
-      .study_metadata
-      .attribute_value_pairs
-      .each do |attribute, value|
-        descriptors.descriptor do |descriptor|
-          descriptor.name(attribute.to_field_info.display_name)
+    @study.study_metadata.attribute_value_pairs.each do |attribute, value|
+      descriptors.descriptor do |descriptor|
+        descriptor.name(attribute.to_field_info.display_name)
+        descriptor.value(value)
+      end
+    end
+
+    @study.study_metadata.association_value_pairs.each do |attribute, value|
+      descriptors.descriptor do |descriptor|
+        descriptor.name(attribute.to_field_info.display_name)
+        if (attribute.to_field_info.display_name == 'Reference Genome') && (value.blank?)
+          descriptor.value(nil)
+        else
           descriptor.value(value)
         end
       end
-
-    @study
-      .study_metadata
-      .association_value_pairs
-      .each do |attribute, value|
-        descriptors.descriptor do |descriptor|
-          descriptor.name(attribute.to_field_info.display_name)
-          if (attribute.to_field_info.display_name == 'Reference Genome') && (value.blank?)
-            descriptor.value(nil)
-          else
-            descriptor.value(value)
-          end
-        end
-      end
+    end
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,34 +6,31 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-Rails
-  .application
-  .config
-  .content_security_policy do |policy|
-    #   policy.default_src :self, :https
-    #   policy.font_src    :self, :https, :data
-    #   policy.img_src     :self, :https, :data
-    #   policy.object_src  :none
-    #   policy.script_src  :self, :https
-    #   policy.style_src   :self, :https
+Rails.application.config.content_security_policy do |policy|
+  #   policy.default_src :self, :https
+  #   policy.font_src    :self, :https, :data
+  #   policy.img_src     :self, :https, :data
+  #   policy.object_src  :none
+  #   policy.script_src  :self, :https
+  #   policy.style_src   :self, :https
 
-    #   # If you are using webpack-dev-server then specify webpack-dev-server host
-    #   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+  #   # If you are using webpack-dev-server then specify webpack-dev-server host
+  #   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-    #   # Specify URI for violation reports
-    #   # policy.report_uri "/csp-violation-report-endpoint"
+  #   # Specify URI for violation reports
+  #   # policy.report_uri "/csp-violation-report-endpoint"
 
-    # Snippet provided after running
-    # `bundle exec rails webpacker:install:vue`
-    # > You need to enable unsafe-eval rule.
-    # > This can be done in Rails 5.2+ for development environment in the CSP initializer
-    # > config/initializers/content_security_policy.rb with a snippet like this:
-    if Rails.env.development?
-      policy.script_src :self, :https, :unsafe_eval
-    else
-      policy.script_src :self, :https
-    end
+  # Snippet provided after running
+  # `bundle exec rails webpacker:install:vue`
+  # > You need to enable unsafe-eval rule.
+  # > This can be done in Rails 5.2+ for development environment in the CSP initializer
+  # > config/initializers/content_security_policy.rb with a snippet like this:
+  if Rails.env.development?
+    policy.script_src :self, :https, :unsafe_eval
+  else
+    policy.script_src :self, :https
   end
+end
 
 # If you are using UJS then enable automatic nonce generation
 Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,611 +1,608 @@
 # frozen_string_literal: true
-Rails
-  .application
-  .routes
-  .draw do
-    # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+Rails.application.routes.draw do
+  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-    root to: 'homes#show'
-    resource :health, only: [:show]
-    resource :home, only: [:show]
+  root to: 'homes#show'
+  resource :health, only: [:show]
+  resource :home, only: [:show]
 
-    resource :phi_x, only: [:show] do
-      scope module: :phi_x do
-        resources :stocks
-        resources :spiked_buffers
-      end
+  resource :phi_x, only: [:show] do
+    scope module: :phi_x do
+      resources :stocks
+      resources :spiked_buffers
     end
+  end
 
-    mount Api::RootService.new => '/api/1'
+  mount Api::RootService.new => '/api/1'
 
-    namespace :api do
-      namespace :v2 do
-        jsonapi_resources :pick_lists
-        jsonapi_resources :aliquots
-        jsonapi_resources :assets
-        jsonapi_resources :comments
-        jsonapi_resources :custom_metadatum_collections
-        jsonapi_resources :labware
-        jsonapi_resources :lanes
-        jsonapi_resources :lot_types
-        jsonapi_resources :lots
-        jsonapi_resources :orders
-        jsonapi_resources :plate_templates
-        jsonapi_resources :plates
-        jsonapi_resources :pre_capture_pools
-        jsonapi_resources :primer_panels
-        jsonapi_resources :projects
-        jsonapi_resources :purposes
-        jsonapi_resources :qc_assays
-        jsonapi_resources :qc_results
-        jsonapi_resources :qcables
-        jsonapi_resources :racked_tubes
-        jsonapi_resources :receptacles
-        jsonapi_resources :request_types
-        jsonapi_resources :requests
-        jsonapi_resources :samples
-        jsonapi_resources :sample_manifests
-        jsonapi_resources :studies
-        jsonapi_resources :submissions
-        jsonapi_resources :tag_groups
-        jsonapi_resources :tag_layout_templates
-        jsonapi_resources :transfer_requests
-        jsonapi_resources :tube_rack_statuses
-        jsonapi_resources :tube_racks
-        jsonapi_resources :tubes
-        jsonapi_resources :users
-        jsonapi_resources :wells
-        jsonapi_resources :work_orders
+  namespace :api do
+    namespace :v2 do
+      jsonapi_resources :pick_lists
+      jsonapi_resources :aliquots
+      jsonapi_resources :assets
+      jsonapi_resources :comments
+      jsonapi_resources :custom_metadatum_collections
+      jsonapi_resources :labware
+      jsonapi_resources :lanes
+      jsonapi_resources :lot_types
+      jsonapi_resources :lots
+      jsonapi_resources :orders
+      jsonapi_resources :plate_templates
+      jsonapi_resources :plates
+      jsonapi_resources :pre_capture_pools
+      jsonapi_resources :primer_panels
+      jsonapi_resources :projects
+      jsonapi_resources :purposes
+      jsonapi_resources :qc_assays
+      jsonapi_resources :qc_results
+      jsonapi_resources :qcables
+      jsonapi_resources :racked_tubes
+      jsonapi_resources :receptacles
+      jsonapi_resources :request_types
+      jsonapi_resources :requests
+      jsonapi_resources :samples
+      jsonapi_resources :sample_manifests
+      jsonapi_resources :studies
+      jsonapi_resources :submissions
+      jsonapi_resources :tag_groups
+      jsonapi_resources :tag_layout_templates
+      jsonapi_resources :transfer_requests
+      jsonapi_resources :tube_rack_statuses
+      jsonapi_resources :tube_racks
+      jsonapi_resources :tubes
+      jsonapi_resources :users
+      jsonapi_resources :wells
+      jsonapi_resources :work_orders
 
-        namespace :aker do
-          resources :jobs, only: [:create]
-        end
-
-        namespace :heron do
-          resources :tube_rack_statuses, only: [:create]
-          resources :tube_racks, only: [:create]
-          resources :plates, only: [:create]
-        end
-      end
-    end
-
-    resources :samples do
-      resources :assets, except: :destroy
-      resources :comments, controller: 'samples/comments'
-      resources :studies
-
-      member do
-        get :history
-        put :add_to_study
-        get :release
-        get :remove_from_study
+      namespace :aker do
+        resources :jobs, only: [:create]
       end
 
-      collection do
-        get :upload
-        post :review
-      end
-    end
-
-    resources :projects do
-      resources :studies
-      member do
-        get :related_studies
-        get :collaborators
-        get :follow
-        post :grant_role
-        post :remove_role
-      end
-    end
-
-    match '/login' => 'sessions#login', :as => :login, :via => %i[get post]
-    match '/logout' => 'sessions#logout', :as => :logout, :via => %i[get post]
-
-    resources :plate_summaries, only: %i[index show] do
-      collection { get :search }
-    end
-
-    resources :tube_rack_summaries, only: :show
-    resources :tube_rack_statuses, only: :index
-
-    resources :reference_genomes
-    resources :barcode_printers
-
-    resources :robot_verifications do
-      collection do
-        post :submission
-        get :submission
-        post :download
-        get :finish
-      end
-    end
-
-    resources :stock_stampers, only: %i[new create] do
-      collection do
-        post :generate_tecan_file
-        post :print_label
-      end
-    end
-
-    scope 'npg_actions', module: 'npg_actions' do
-      resources :assets, only: [] do
-        post :pass_qc_state, action: :pass, format: :xml
-        post :fail_qc_state, action: :fail, format: :xml
-      end
-    end
-
-    resources :batches do
-      resources :requests, controller: 'batches/requests'
-      resources :comments, controller: 'batches/comments'
-
-      resources :robots do
-        resource :driver_file, only: :show
-      end
-
-      member do
-        get :print_labels
-        get :print_plate_labels
-        get :filtered
-        post :swap
-        post :fail_items
-        post :reset_batch
-        get :download_spreadsheet
-        get :fail
-        get :pacbio_sample_sheet
-        get :print
-        post :print_multiplex_barcodes
-        get :print_multiplex_labels
-        get :print_stock_multiplex_labels
-        get :verify
-        post :verify_tube_layout
-        get :previous_qc_state
-        get :released
-        get :sample_prep_worksheet
-        get :new_stock_assets
-      end
-
-      collection do
-        post :print_barcodes
-        post :print_plate_barcodes
-        post :print_multiplex_barcodes
-        post :sort
-        get 'find_batch_by_barcode/:id', action: 'find_batch_by_barcode'
-      end
-    end
-    resources :uuids, only: [:show]
-
-    get 'pipelines/release/:id' => 'pipelines#release', :as => :release_batch
-    get 'pipelines/finish/:id' => 'pipelines#finish', :as => :finish_batch
-
-    resources :events
-    resources :sources
-
-    get '/taxon_lookup_by_term/:term' => 'samples#taxon_lookup'
-    get '/taxon_lookup_by_id/:id' => 'samples#taxon_lookup'
-
-    post '/studies/:study_id/information/summary_detailed/:id' => 'studies/information#summary_detailed'
-
-    get 'studies/accession/:id' => 'studies#accession'
-    get 'studies/policy_accession/:id' => 'studies#policy_accession'
-    get 'studies/dac_accession/:id' => 'studies#dac_accession'
-
-    get 'studies/accession/show/:id' => 'studies#show_accession', :as => :study_show_accession
-    get 'studies/accession/dac/show/:id' => 'studies#show_dac_accession', :as => :study_show_dac_accession
-    get 'studies/accession/policy/show/:id' => 'studies#show_policy_accession', :as => :study_show_policy_accession
-
-    get 'samples/accession/:id' => 'samples#accession'
-    get 'samples/accession/show/:id' => 'samples#show_accession'
-    get 'samples/accession/show/:id' => 'samples#show_accession', :as => :sample_show_accession
-
-    resources :studies do
-      collection { get :study_list }
-
-      member do
-        get :study_reports
-        get :sample_manifests
-        get :suppliers
-        get :assembly
-        put :assembly
-        post :close
-        post :open
-        get :follow
-        get :projects
-        get :study_status
-        get :collaborators
-        get :properties
-        get :state
-        post :grant_role
-        post :remove_role
-        get :accession_all_samples
-      end
-
-      resources :assets, except: [:destroy]
-
-      resources :samples, controller: 'studies/samples'
-      resources :events, controller: 'studies/events'
-
-      resources :requests do
-        member do
-          post :reset
-          get :cancel
-        end
-      end
-
-      resources :comments, controller: 'studies/comments'
-
-      resources :asset_groups, controller: 'studies/asset_groups' do
-        member do
-          post :search
-          post :add
-          get :print
-          post :print_labels
-        end
-        collection { get :printing }
-      end
-
-      resources :plates, controller: 'studies/plates', except: :destroy do
-        collection do
-          post :view_wells
-          post :asset_group
-          get :show_asset_group
-        end
-
-        member { post :remove_wells }
-
-        resources :wells, expect: %i[destroy edit]
-      end
-
-      resource :information, controller: 'studies/information' do
-        member do
-          get :summary
-          get :show_summary
-        end
-
-        resources :assets # Legacy path, redirects to receptacles
-        resources :receptacles do
-          collection { post :print }
-        end
-      end
-
-      resources :documents, controller: 'studies/documents', only: %i[show destroy]
-    end
-
-    resources :bulk_submissions, only: %i[index new create]
-    resources :bulk_submission_excel_downloads, only: %i[create new], controller: 'bulk_submission_excel/downloads'
-
-    resources :submissions do
-      collection do
-        get :study_assets
-        get :order_fields
-        get :project_details
-        get :study
-      end
-      member do
-        post :change_priority
-        post :cancel
-      end
-    end
-
-    resources :orders
-    resources :documents
-
-    get 'requests/:id/change_decision' => 'requests#filter_change_decision', :as => :filter_change_decision_request
-    put 'requests/:id/change_decision' => 'requests#change_decision', :as => :change_decision_request
-
-    resources :requests do
-      resources :comments, controller: 'requests/comments'
-
-      member do
-        get :history
-        get :copy
-        get :cancel
-        get :print
-        delete 'reset_qc_information/:event_id', action: :reset_qc_information
-      end
-    end
-
-    resources :searches
-
-    namespace :admin do
-      resources :abilities, only: :index
-      resources :custom_texts
-
-      resources :primer_panels, except: :destroy
-
-      resources :studies, except: [:destroy] do
-        collection do
-          get :index
-          post :filter
-          post :edit
-        end
-        member { put :managed_update }
-      end
-
-      resources :projects, except: [:destroy] do
-        collection do
-          get :index
-          post :filter
-          post :edit
-        end
-        member { put :managed_update }
-      end
-
-      resources :plate_purposes
-      resources :delayed_jobs
-      resources :faculty_sponsors
-      resources :programs
-      resources :delayed_jobs
-
-      resources :users do
-        collection { post :filter }
-
-        member do
-          get :switch
-          post :grant_user_role
-          post :remove_user_role
-        end
-      end
-
-      resources :roles, only: %i[index show new create] do
-        resources :users, controller: 'roles/users'
-      end
-
-      resources :robots do
-        resources :robot_properties do
-          member { get :print_labels }
-        end
-      end
-      resources :bait_libraries
-
-      scope module: :bait_libraries do
-        resources :bait_library_types
-        resources :bait_library_suppliers
-      end
-    end
-
-    get 'admin' => 'admin#index', :as => :admin
-    get 'admin/filter'
-
-    resources :profile, controller: 'users' do
-      member do
-        get :study_reports
-        get :projects
-      end
-    end
-
-    resources :plate_templates
-
-    resources :gels do
-      collection do
-        post :lookup
-        get :find
-      end
-
-      # TODO: Remove this route. get gels/:id should be show
-      member { get :show }
-    end
-
-    resources :machine_barcodes, only: [:show]
-
-    resources :pipelines, except: [:delete] do
-      collection { post :update_priority }
-      member do
-        get :reception
-        get :deactivate
-        get :activate
-        get :show_comments
-        get :batches
-        get :summary
-      end
-
-      resources :batches, only: [:index] do
-        collection do
-          get :pending
-          get :started
-          get :released
-          get :completed
-          get :failed
-          get :discarded
-        end
-      end
-    end
-
-    resources :lab_searches
-    resources :events
-
-    resources :workflows, only: [] do
-      member do
-        # Yes, this is every bit as horrible as it looks.
-        # HTTP Verbs! Gotta catch em all!
-        # workflows/stage controller need substantial
-        # reworking.
-        patch 'stage/:id' => 'workflows#stage'
-        get 'stage/:id' => 'workflows#stage'
-        post 'stage/:id' => 'workflows#stage'
-      end
-      collection { get :generate_manifest }
-    end
-
-    resources :asset_audits
-
-    resources :qc_reports, except: %i[delete update] do
-      collection { post :qc_file }
-    end
-
-    get 'assets/lookup' => 'assets#lookup', :as => :assets_lookup
-
-    get 'assets/find_by_barcode', to: redirect('labware/find_by_barcode')
-    get 'labware/find_by_barcode' => 'labware#find_by_barcode'
-
-    get 'lab_view' => 'labware#lab_view', :as => :lab_view
-    post 'labware/lab_view'
-
-    resources :tag_groups, except: [:destroy] do
-      resources :tags, except: %i[destroy index create new edit]
-    end
-
-    resources :tag_layout_templates, only: %i[index new create show]
-
-    resources :assets, except: %i[create new] do
-      collection do
-        get :reception
-        post :print_labels
-      end
-
-      member do
-        get :parent_assets
-        get :child_assets
-        get :show_plate
-        get :new_request
-        post :create_request
-        get :summary
-        get :print
-        get :history
-        post :move
-        post :print_assets
-      end
-
-      resources :qc_files
-    end
-
-    resources :labware, except: %i[create new] do
-      collection do
-        get :reception
-        post :print_labels
-      end
-
-      member do
-        get :parent_assets
-        get :child_assets
-        get :show_plate
-        get :summary
-        get :close
-        get :print
-        get :history
-        post :move
-        post :print_assets
-      end
-
-      resources :qc_files
-      resources :comments, controller: 'labware/comments'
-    end
-
-    resources :receptacles, except: %i[create new] do
-      collection do
-        get :reception
-        post :print_labels
-      end
-
-      resources :tag_substitutions, only: :new
-
-      member do
-        get :parent_assets
-        get :child_assets
-        get :show_plate
-        get :new_request
-        post :create_request
-        get :summary
-        get :close
-        get :print
-        post :print_items
-        get :history
-        post :move
-        post :print_assets
-      end
-
-      resources :comments, controller: 'receptacles/comments'
-    end
-
-    # Merge conflict tip: Specifying controller: :assets here is to
-    # handle the current lack of the receptacles controller. If you're seeing
-    # the more fully specced route alongside this, then it should be enough to
-    # add resource :parent, only: :show to the more fully specced route
-    resources :receptacles, only: [:show], controller: :assets do
-      resource :parent, only: :show
-    end
-
-    resources :plates do
-      collection do
-        post :create
-        get :to_sample_tubes
-        post :create_sample_tubes
-      end
-
-      member { get :fluidigm_file }
-    end
-
-    resources :sequenom_qc_plates, only: :index
-    resources :study_reports
-
-    resources :tag_substitutions, only: :create
-
-    resources :sample_logistics do
-      collection { get :lab }
-    end
-
-    scope '/sdb', module: 'sdb' do
-      resources :sample_manifests do
-        member do
-          get :export
-          get :uploaded_spreadsheet
-          post :print_labels
-        end
-      end
-
-      resources :suppliers do
-        member do
-          get :sample_manifests
-          get :studies
-        end
-      end
-
-      get '/' => 'home#index'
-    end
-
-    resources :labwhere_receptions, only: %i[index create]
-
-    resources :report_fails, only: %i[index create]
-
-    resources :qc_files, only: %i[show create]
-
-    resources :user_queries, only: %i[new create]
-
-    resources :poolings, only: %i[new create]
-
-    post 'get_your_qc_completed_tubes_here' => 'get_your_qc_completed_tubes_here#create',
-         :as => :get_your_qc_completed_tubes_here
-    resources :sample_manifest_upload_with_tag_sequences, only: %i[new create]
-
-    namespace :aker do
-      resources :jobs, only: %i[index show] do
-        member do
-          put 'start'
-          put 'complete'
-          put 'cancel'
-        end
-      end
-    end
-
-    resources :uat_actions
-
-    resources :location_reports, only: %i[index show create]
-
-    # this is for test only test/functional/authentication_controller_test.rb
-    # to be removed?
-    get 'authentication/open'
-    get 'authentication/restricted'
-
-    resources :messengers, only: :show
-
-    # We removed workflows, which broke study links. Some customers may have their own studies bookmarked
-    get 'studies/:study_id/workflows/:id', to: redirect('studies/%{study_id}/information')
-
-    resources :quad_stamp, only: %i[new create]
-    resources :pick_lists, only: %i[index show]
-    resource :plate_picks, only: [:show] do
-      member do
-        get 'plates/:barcode', to: 'plate_picks#plates'
-        get 'batches/:id', to: 'plate_picks#batches'
+      namespace :heron do
+        resources :tube_rack_statuses, only: [:create]
+        resources :tube_racks, only: [:create]
+        resources :plates, only: [:create]
       end
     end
   end
+
+  resources :samples do
+    resources :assets, except: :destroy
+    resources :comments, controller: 'samples/comments'
+    resources :studies
+
+    member do
+      get :history
+      put :add_to_study
+      get :release
+      get :remove_from_study
+    end
+
+    collection do
+      get :upload
+      post :review
+    end
+  end
+
+  resources :projects do
+    resources :studies
+    member do
+      get :related_studies
+      get :collaborators
+      get :follow
+      post :grant_role
+      post :remove_role
+    end
+  end
+
+  match '/login' => 'sessions#login', :as => :login, :via => %i[get post]
+  match '/logout' => 'sessions#logout', :as => :logout, :via => %i[get post]
+
+  resources :plate_summaries, only: %i[index show] do
+    collection { get :search }
+  end
+
+  resources :tube_rack_summaries, only: :show
+  resources :tube_rack_statuses, only: :index
+
+  resources :reference_genomes
+  resources :barcode_printers
+
+  resources :robot_verifications do
+    collection do
+      post :submission
+      get :submission
+      post :download
+      get :finish
+    end
+  end
+
+  resources :stock_stampers, only: %i[new create] do
+    collection do
+      post :generate_tecan_file
+      post :print_label
+    end
+  end
+
+  scope 'npg_actions', module: 'npg_actions' do
+    resources :assets, only: [] do
+      post :pass_qc_state, action: :pass, format: :xml
+      post :fail_qc_state, action: :fail, format: :xml
+    end
+  end
+
+  resources :batches do
+    resources :requests, controller: 'batches/requests'
+    resources :comments, controller: 'batches/comments'
+
+    resources :robots do
+      resource :driver_file, only: :show
+    end
+
+    member do
+      get :print_labels
+      get :print_plate_labels
+      get :filtered
+      post :swap
+      post :fail_items
+      post :reset_batch
+      get :download_spreadsheet
+      get :fail
+      get :pacbio_sample_sheet
+      get :print
+      post :print_multiplex_barcodes
+      get :print_multiplex_labels
+      get :print_stock_multiplex_labels
+      get :verify
+      post :verify_tube_layout
+      get :previous_qc_state
+      get :released
+      get :sample_prep_worksheet
+      get :new_stock_assets
+    end
+
+    collection do
+      post :print_barcodes
+      post :print_plate_barcodes
+      post :print_multiplex_barcodes
+      post :sort
+      get 'find_batch_by_barcode/:id', action: 'find_batch_by_barcode'
+    end
+  end
+  resources :uuids, only: [:show]
+
+  get 'pipelines/release/:id' => 'pipelines#release', :as => :release_batch
+  get 'pipelines/finish/:id' => 'pipelines#finish', :as => :finish_batch
+
+  resources :events
+  resources :sources
+
+  get '/taxon_lookup_by_term/:term' => 'samples#taxon_lookup'
+  get '/taxon_lookup_by_id/:id' => 'samples#taxon_lookup'
+
+  post '/studies/:study_id/information/summary_detailed/:id' => 'studies/information#summary_detailed'
+
+  get 'studies/accession/:id' => 'studies#accession'
+  get 'studies/policy_accession/:id' => 'studies#policy_accession'
+  get 'studies/dac_accession/:id' => 'studies#dac_accession'
+
+  get 'studies/accession/show/:id' => 'studies#show_accession', :as => :study_show_accession
+  get 'studies/accession/dac/show/:id' => 'studies#show_dac_accession', :as => :study_show_dac_accession
+  get 'studies/accession/policy/show/:id' => 'studies#show_policy_accession', :as => :study_show_policy_accession
+
+  get 'samples/accession/:id' => 'samples#accession'
+  get 'samples/accession/show/:id' => 'samples#show_accession'
+  get 'samples/accession/show/:id' => 'samples#show_accession', :as => :sample_show_accession
+
+  resources :studies do
+    collection { get :study_list }
+
+    member do
+      get :study_reports
+      get :sample_manifests
+      get :suppliers
+      get :assembly
+      put :assembly
+      post :close
+      post :open
+      get :follow
+      get :projects
+      get :study_status
+      get :collaborators
+      get :properties
+      get :state
+      post :grant_role
+      post :remove_role
+      get :accession_all_samples
+    end
+
+    resources :assets, except: [:destroy]
+
+    resources :samples, controller: 'studies/samples'
+    resources :events, controller: 'studies/events'
+
+    resources :requests do
+      member do
+        post :reset
+        get :cancel
+      end
+    end
+
+    resources :comments, controller: 'studies/comments'
+
+    resources :asset_groups, controller: 'studies/asset_groups' do
+      member do
+        post :search
+        post :add
+        get :print
+        post :print_labels
+      end
+      collection { get :printing }
+    end
+
+    resources :plates, controller: 'studies/plates', except: :destroy do
+      collection do
+        post :view_wells
+        post :asset_group
+        get :show_asset_group
+      end
+
+      member { post :remove_wells }
+
+      resources :wells, expect: %i[destroy edit]
+    end
+
+    resource :information, controller: 'studies/information' do
+      member do
+        get :summary
+        get :show_summary
+      end
+
+      resources :assets # Legacy path, redirects to receptacles
+      resources :receptacles do
+        collection { post :print }
+      end
+    end
+
+    resources :documents, controller: 'studies/documents', only: %i[show destroy]
+  end
+
+  resources :bulk_submissions, only: %i[index new create]
+  resources :bulk_submission_excel_downloads, only: %i[create new], controller: 'bulk_submission_excel/downloads'
+
+  resources :submissions do
+    collection do
+      get :study_assets
+      get :order_fields
+      get :project_details
+      get :study
+    end
+    member do
+      post :change_priority
+      post :cancel
+    end
+  end
+
+  resources :orders
+  resources :documents
+
+  get 'requests/:id/change_decision' => 'requests#filter_change_decision', :as => :filter_change_decision_request
+  put 'requests/:id/change_decision' => 'requests#change_decision', :as => :change_decision_request
+
+  resources :requests do
+    resources :comments, controller: 'requests/comments'
+
+    member do
+      get :history
+      get :copy
+      get :cancel
+      get :print
+      delete 'reset_qc_information/:event_id', action: :reset_qc_information
+    end
+  end
+
+  resources :searches
+
+  namespace :admin do
+    resources :abilities, only: :index
+    resources :custom_texts
+
+    resources :primer_panels, except: :destroy
+
+    resources :studies, except: [:destroy] do
+      collection do
+        get :index
+        post :filter
+        post :edit
+      end
+      member { put :managed_update }
+    end
+
+    resources :projects, except: [:destroy] do
+      collection do
+        get :index
+        post :filter
+        post :edit
+      end
+      member { put :managed_update }
+    end
+
+    resources :plate_purposes
+    resources :delayed_jobs
+    resources :faculty_sponsors
+    resources :programs
+    resources :delayed_jobs
+
+    resources :users do
+      collection { post :filter }
+
+      member do
+        get :switch
+        post :grant_user_role
+        post :remove_user_role
+      end
+    end
+
+    resources :roles, only: %i[index show new create] do
+      resources :users, controller: 'roles/users'
+    end
+
+    resources :robots do
+      resources :robot_properties do
+        member { get :print_labels }
+      end
+    end
+    resources :bait_libraries
+
+    scope module: :bait_libraries do
+      resources :bait_library_types
+      resources :bait_library_suppliers
+    end
+  end
+
+  get 'admin' => 'admin#index', :as => :admin
+  get 'admin/filter'
+
+  resources :profile, controller: 'users' do
+    member do
+      get :study_reports
+      get :projects
+    end
+  end
+
+  resources :plate_templates
+
+  resources :gels do
+    collection do
+      post :lookup
+      get :find
+    end
+
+    # TODO: Remove this route. get gels/:id should be show
+    member { get :show }
+  end
+
+  resources :machine_barcodes, only: [:show]
+
+  resources :pipelines, except: [:delete] do
+    collection { post :update_priority }
+    member do
+      get :reception
+      get :deactivate
+      get :activate
+      get :show_comments
+      get :batches
+      get :summary
+    end
+
+    resources :batches, only: [:index] do
+      collection do
+        get :pending
+        get :started
+        get :released
+        get :completed
+        get :failed
+        get :discarded
+      end
+    end
+  end
+
+  resources :lab_searches
+  resources :events
+
+  resources :workflows, only: [] do
+    member do
+      # Yes, this is every bit as horrible as it looks.
+      # HTTP Verbs! Gotta catch em all!
+      # workflows/stage controller need substantial
+      # reworking.
+      patch 'stage/:id' => 'workflows#stage'
+      get 'stage/:id' => 'workflows#stage'
+      post 'stage/:id' => 'workflows#stage'
+    end
+    collection { get :generate_manifest }
+  end
+
+  resources :asset_audits
+
+  resources :qc_reports, except: %i[delete update] do
+    collection { post :qc_file }
+  end
+
+  get 'assets/lookup' => 'assets#lookup', :as => :assets_lookup
+
+  get 'assets/find_by_barcode', to: redirect('labware/find_by_barcode')
+  get 'labware/find_by_barcode' => 'labware#find_by_barcode'
+
+  get 'lab_view' => 'labware#lab_view', :as => :lab_view
+  post 'labware/lab_view'
+
+  resources :tag_groups, except: [:destroy] do
+    resources :tags, except: %i[destroy index create new edit]
+  end
+
+  resources :tag_layout_templates, only: %i[index new create show]
+
+  resources :assets, except: %i[create new] do
+    collection do
+      get :reception
+      post :print_labels
+    end
+
+    member do
+      get :parent_assets
+      get :child_assets
+      get :show_plate
+      get :new_request
+      post :create_request
+      get :summary
+      get :print
+      get :history
+      post :move
+      post :print_assets
+    end
+
+    resources :qc_files
+  end
+
+  resources :labware, except: %i[create new] do
+    collection do
+      get :reception
+      post :print_labels
+    end
+
+    member do
+      get :parent_assets
+      get :child_assets
+      get :show_plate
+      get :summary
+      get :close
+      get :print
+      get :history
+      post :move
+      post :print_assets
+    end
+
+    resources :qc_files
+    resources :comments, controller: 'labware/comments'
+  end
+
+  resources :receptacles, except: %i[create new] do
+    collection do
+      get :reception
+      post :print_labels
+    end
+
+    resources :tag_substitutions, only: :new
+
+    member do
+      get :parent_assets
+      get :child_assets
+      get :show_plate
+      get :new_request
+      post :create_request
+      get :summary
+      get :close
+      get :print
+      post :print_items
+      get :history
+      post :move
+      post :print_assets
+    end
+
+    resources :comments, controller: 'receptacles/comments'
+  end
+
+  # Merge conflict tip: Specifying controller: :assets here is to
+  # handle the current lack of the receptacles controller. If you're seeing
+  # the more fully specced route alongside this, then it should be enough to
+  # add resource :parent, only: :show to the more fully specced route
+  resources :receptacles, only: [:show], controller: :assets do
+    resource :parent, only: :show
+  end
+
+  resources :plates do
+    collection do
+      post :create
+      get :to_sample_tubes
+      post :create_sample_tubes
+    end
+
+    member { get :fluidigm_file }
+  end
+
+  resources :sequenom_qc_plates, only: :index
+  resources :study_reports
+
+  resources :tag_substitutions, only: :create
+
+  resources :sample_logistics do
+    collection { get :lab }
+  end
+
+  scope '/sdb', module: 'sdb' do
+    resources :sample_manifests do
+      member do
+        get :export
+        get :uploaded_spreadsheet
+        post :print_labels
+      end
+    end
+
+    resources :suppliers do
+      member do
+        get :sample_manifests
+        get :studies
+      end
+    end
+
+    get '/' => 'home#index'
+  end
+
+  resources :labwhere_receptions, only: %i[index create]
+
+  resources :report_fails, only: %i[index create]
+
+  resources :qc_files, only: %i[show create]
+
+  resources :user_queries, only: %i[new create]
+
+  resources :poolings, only: %i[new create]
+
+  post 'get_your_qc_completed_tubes_here' => 'get_your_qc_completed_tubes_here#create',
+       :as => :get_your_qc_completed_tubes_here
+  resources :sample_manifest_upload_with_tag_sequences, only: %i[new create]
+
+  namespace :aker do
+    resources :jobs, only: %i[index show] do
+      member do
+        put 'start'
+        put 'complete'
+        put 'cancel'
+      end
+    end
+  end
+
+  resources :uat_actions
+
+  resources :location_reports, only: %i[index show create]
+
+  # this is for test only test/functional/authentication_controller_test.rb
+  # to be removed?
+  get 'authentication/open'
+  get 'authentication/restricted'
+
+  resources :messengers, only: :show
+
+  # We removed workflows, which broke study links. Some customers may have their own studies bookmarked
+  get 'studies/:study_id/workflows/:id', to: redirect('studies/%{study_id}/information')
+
+  resources :quad_stamp, only: %i[new create]
+  resources :pick_lists, only: %i[index show]
+  resource :plate_picks, only: [:show] do
+    member do
+      get 'plates/:barcode', to: 'plate_picks#plates'
+      get 'batches/:id', to: 'plate_picks#batches'
+    end
+  end
+end

--- a/features/support/step_definitions/pulldown_steps.rb
+++ b/features/support/step_definitions/pulldown_steps.rb
@@ -72,7 +72,7 @@ Given 'H12 on {asset_name} is empty' do |plate|
   plate.wells.located_at('H12').first.aliquots.clear
 end
 
-# rubocop:todo Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
+# rubocop:todo Metrics/PerceivedComplexity, Metrics/AbcSize
 def work_pipeline_for(submissions, name, template = nil) # rubocop:todo Metrics/CyclomaticComplexity
   raise StandardError, 'No submissions to process' if submissions.empty?
 
@@ -87,20 +87,17 @@ def work_pipeline_for(submissions, name, template = nil) # rubocop:todo Metrics/
 
   source_plate = source_plates.first
 
-  source_plate
-    .wells
-    .with_aliquots
-    .each do |w|
-      FactoryBot.create(:tag).tag!(w) if w.primary_aliquot.tag.blank? # Ensure wells are tagged
-      w.requests_as_source.first.start! # Ensure request is considered started
-    end
+  source_plate.wells.with_aliquots.each do |w|
+    FactoryBot.create(:tag).tag!(w) if w.primary_aliquot.tag.blank? # Ensure wells are tagged
+    w.requests_as_source.first.start! # Ensure request is considered started
+  end
 
   final_plate_type.create!.tap do |final_plate|
     AssetLink.create!(ancestor: source_plate, descendant: final_plate)
     template.create!(source: source_plate, destination: final_plate, user: FactoryBot.create(:user))
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+# rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
 
 Given /^(all submissions) have been worked until the last plate of the "Pulldown ISC" pipeline$/ do |submissions|
   work_pipeline_for(submissions, 'ISC cap lib pool')

--- a/features/support/step_definitions/sample_manifest_steps.rb
+++ b/features/support/step_definitions/sample_manifest_steps.rb
@@ -30,10 +30,9 @@ Then /^I should see the manifest table:$/ do |expected_results_table|
 end
 
 def sequence_sanger_sample_ids_for(plate)
-  plate
-    .wells
-    .in_column_major_order
-    .each_with_index { |well, index| well.primary_aliquot&.sample&.update!(sanger_sample_id: yield(index)) }
+  plate.wells.in_column_major_order.each_with_index do |well, index|
+    well.primary_aliquot&.sample&.update!(sanger_sample_id: yield(index))
+  end
 end
 
 Given /^I reset all of the sanger sample ids to a known number sequence$/ do

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "whatwg-fetch": "^3.3.1"
   },
   "devDependencies": {
-    "@prettier/plugin-ruby": "^1.5.5",
+    "@prettier/plugin-ruby": "^2.0.0",
     "@testing-library/jest-dom": "^5.11.2",
     "@vue/test-utils": "^1.0.3",
     "babel-core": "^7.0.0-bridge.0",

--- a/spec/bulk_submission_excel/data_worksheet_spec.rb
+++ b/spec/bulk_submission_excel/data_worksheet_spec.rb
@@ -56,10 +56,9 @@ RSpec.describe BulkSubmissionExcel::Worksheet::DataWorksheet, type: :model, bulk
     end
 
     it 'adds standard headings to worksheet' do
-      worksheet
-        .columns
-        .headings
-        .each_with_index { |heading, i| expect(spreadsheet.sheet(0).cell(2, i + 1)).to eq(heading) }
+      worksheet.columns.headings.each_with_index do |heading, i|
+        expect(spreadsheet.sheet(0).cell(2, i + 1)).to eq(heading)
+      end
     end
 
     it 'unlock cells for all columns which are unlocked' do

--- a/spec/factories/batch_factories.rb
+++ b/spec/factories/batch_factories.rb
@@ -56,16 +56,13 @@ FactoryBot.define do
     association(:pipeline, factory: :pac_bio_sequencing_pipeline)
 
     after(:build) do |batch, evaluator|
-      evaluator
-        .assets
-        .each_with_index
-        .map do |asset, index|
-          create :pac_bio_sequencing_request,
-                 asset: asset,
-                 target_asset: evaluator.target_plate.wells[index],
-                 request_type: batch.pipeline.request_types.first,
-                 batch: batch
-        end
+      evaluator.assets.each_with_index.map do |asset, index|
+        create :pac_bio_sequencing_request,
+               asset: asset,
+               target_asset: evaluator.target_plate.wells[index],
+               request_type: batch.pipeline.request_types.first,
+               batch: batch
+      end
     end
   end
 end

--- a/spec/factories/plate_factories.rb
+++ b/spec/factories/plate_factories.rb
@@ -150,12 +150,9 @@ FactoryBot.define do
 
       after(:create) do |plate, evaluator|
         plate.wells =
-          evaluator
-            .occupied_map_locations
-            .map
-            .with_index do |map, i|
-              create(:well_for_location_report, map: map, study: evaluator.studies[i], project: nil)
-            end
+          evaluator.occupied_map_locations.map.with_index do |map, i|
+            create(:well_for_location_report, map: map, study: evaluator.studies[i], project: nil)
+          end
       end
     end
 

--- a/spec/features/retrospective_failure_spec.rb
+++ b/spec/features/retrospective_failure_spec.rb
@@ -48,13 +48,10 @@ describe 'Retrospective failure' do
       create :transfer_request, asset: target_well, target_asset: child_well_1
 
       # Apply tags to make sure that gets handled correctly
-      child_well_1
-        .aliquots
-        .first
-        .tap do |aliquot|
-          aliquot.tag = tag
-          aliquot.save!
-        end
+      child_well_1.aliquots.first.tap do |aliquot|
+        aliquot.tag = tag
+        aliquot.save!
+      end
       create :transfer_request, asset: child_well_1, target_asset: child_well_2
 
       # Just double check that the setup has worked as intended

--- a/spec/models/linear_submission_spec.rb
+++ b/spec/models/linear_submission_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe LinearSubmission do
 
             it 'create requests but not comments' do
               expect { mpx_submission.process! }.to change(Request, :count).by(mx_asset_count + 1).and change(
-                                                                 Comment,
-                                                                 :count
-                                                               ).by(0)
+                                                                   Comment,
+                                                                   :count
+                                                                 ).by(0)
             end
 
             it 'be a multiplexed submission' do
@@ -111,9 +111,9 @@ RSpec.describe LinearSubmission do
 
             it 'create requests but not comments' do
               expect { mpx_submission.process! }.to change(Request, :count).by(mx_asset_count + 2).and change(
-                                                                 Comment,
-                                                                 :count
-                                                               ).by(0)
+                                                                   Comment,
+                                                                   :count
+                                                                 ).by(0)
             end
           end
         end
@@ -183,7 +183,7 @@ RSpec.describe LinearSubmission do
       describe '#process!' do
         it 'create requests but not comments' do
           expect { submission.process! }.to change(Request, :count).by(sx_asset_count * 2).and change(Comment, :count)
-                                                             .by(sx_asset_count * 2)
+                                                               .by(sx_asset_count * 2)
         end
 
         context 'when it has been run' do

--- a/spec/models/plate/quad_creator_spec.rb
+++ b/spec/models/plate/quad_creator_spec.rb
@@ -127,16 +127,16 @@ RSpec.describe Plate::QuadCreator, type: :model do
         it 'creates the correct transfer request collection' do
           expected_transfers = number_of_parents * occupied_wells.length
           expect { quad_creator.save }.to change(TransferRequestCollection, :count).by(1).and change(
-                                                               TransferRequest,
-                                                               :count
-                                                             ).by(expected_transfers)
+                                                                TransferRequest,
+                                                                :count
+                                                              ).by(expected_transfers)
         end
 
         it 'creates a custom metadatum collection and custom metadata' do
           expect { quad_creator.save }.to change(CustomMetadatumCollection, :count).by(1).and change(
-                                                               CustomMetadatum,
-                                                               :count
-                                                             ).by(4)
+                                                                CustomMetadatum,
+                                                                :count
+                                                              ).by(4)
         end
       end
     end

--- a/spec/models/robot/pick_data_spec.rb
+++ b/spec/models/robot/pick_data_spec.rb
@@ -167,16 +167,13 @@ RSpec.describe Robot::PickData, robot_verification: true do
 
       context 'when we create the requests in different order' do
         let(:requests) do
-          transfers
-            .to_a
-            .reverse
-            .map do |source, target|
-              create :cherrypick_request,
-                     asset: source,
-                     target_asset: target,
-                     request_type: pipeline.request_types.first,
-                     state: 'passed'
-            end
+          transfers.to_a.reverse.map do |source, target|
+            create :cherrypick_request,
+                   asset: source,
+                   target_asset: target,
+                   request_type: pipeline.request_types.first,
+                   state: 'passed'
+          end
         end
 
         it_behaves_like 'a picking process'

--- a/spec/models/sample_manifest_spec.rb
+++ b/spec/models/sample_manifest_spec.rb
@@ -169,9 +169,9 @@ RSpec.describe SampleManifest, type: :model, sample_manifest: true do
 
           it 'create 1 MX tube' do
             expect { manifest.generate }.to change(LibraryTube, :count).by(count).and change(
-                                                       MultiplexedLibraryTube,
-                                                       :count
-                                                     ).by(1).and change(BroadcastEvent, :count).by(1)
+                                                        MultiplexedLibraryTube,
+                                                        :count
+                                                      ).by(1).and change(BroadcastEvent, :count).by(1)
           end
 
           it 'create sample manifest asset' do
@@ -279,7 +279,7 @@ RSpec.describe SampleManifest, type: :model, sample_manifest: true do
 
           it "create #{count} tubes(s)" do
             expect { manifest.generate }.to change(SampleTube, :count).by(count).and change { manifest.assets.count }
-                                                      .by(count)
+                                                       .by(count)
             expect(manifest.assets).to eq(SampleTube.with_barcode(manifest.barcodes).map(&:receptacle))
           end
 

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -243,13 +243,10 @@ RSpec.describe Study, type: :model do
       before do
         2.times do
           r = create(:passed_request, request_type: request_type, initial_study_id: study.id)
-          r
-            .asset
-            .aliquots
-            .each do |al|
-              al.study = study
-              al.save!
-            end
+          r.asset.aliquots.each do |al|
+            al.study = study
+            al.save!
+          end
         end
 
         create_list(:order, 2, study: study)

--- a/spec/models/tag2_layout_spec.rb
+++ b/spec/models/tag2_layout_spec.rb
@@ -11,23 +11,17 @@ RSpec.describe Tag2Layout, type: :model do
 
   it 'applies its tag to every well of the plate' do
     expect(subject.plate.wells).to be_present
-    subject
-      .plate
-      .wells
-      .each do |well|
-        expect(well.aliquots).to be_present
-        well.aliquots.each { |aliquot| expect(aliquot.reload.tag2).to eq(tag) }
-      end
+    subject.plate.wells.each do |well|
+      expect(well.aliquots).to be_present
+      well.aliquots.each { |aliquot| expect(aliquot.reload.tag2).to eq(tag) }
+    end
   end
 
   it 'sets a library on every well of the plate' do
     expect(subject.plate.wells).to be_present
-    subject
-      .plate
-      .wells
-      .each do |well|
-        expect(well.aliquots).to be_present
-        well.aliquots.each { |aliquot| expect(aliquot.reload.library_id).to eq(well.id) }
-      end
+    subject.plate.wells.each do |well|
+      expect(well.aliquots).to be_present
+      well.aliquots.each { |aliquot| expect(aliquot.reload.library_id).to eq(well.id) }
+    end
   end
 end

--- a/spec/models/tag2_layout_template_spec.rb
+++ b/spec/models/tag2_layout_template_spec.rb
@@ -12,24 +12,18 @@ RSpec.describe Tag2LayoutTemplate, type: :model do
 
   it 'applies its tag to every well of the plate' do
     expect(subject.plate.wells).to be_present
-    subject
-      .plate
-      .wells
-      .each do |well|
-        expect(well.aliquots).to be_present
-        well.aliquots.each { |aliquot| expect(aliquot.reload.tag2).to eq(tag) }
-      end
+    subject.plate.wells.each do |well|
+      expect(well.aliquots).to be_present
+      well.aliquots.each { |aliquot| expect(aliquot.reload.tag2).to eq(tag) }
+    end
   end
 
   it 'sets a library on every well of the plate' do
     expect(subject.plate.wells).to be_present
-    subject
-      .plate
-      .wells
-      .each do |well|
-        expect(well.aliquots).to be_present
-        well.aliquots.each { |aliquot| expect(aliquot.reload.library_id).to eq(well.id) }
-      end
+    subject.plate.wells.each do |well|
+      expect(well.aliquots).to be_present
+      well.aliquots.each { |aliquot| expect(aliquot.reload.library_id).to eq(well.id) }
+    end
   end
 
   it 'records itself against the submissions' do

--- a/spec/sample_manifest_excel/upload/processor_spec.rb
+++ b/spec/sample_manifest_excel/upload/processor_spec.rb
@@ -538,14 +538,10 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
             it 'will process a partial upload' do
               processor.update_samples_and_aliquots(nil)
               expect(
-                upload
-                  .sample_manifest
-                  .samples
-                  .reload
-                  .count do |sample|
-                    sample.reload
-                    sample.sample_metadata.concentration.present?
-                  end
+                upload.sample_manifest.samples.reload.count do |sample|
+                  sample.reload
+                  sample.sample_metadata.concentration.present?
+                end
               ).to eq(2)
               processor.update_sample_manifest
               expect(processor).to be_processed
@@ -833,8 +829,8 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
           RSpec::Matchers.define_negated_matcher :not_change, :change
 
           expect { processor.run(nil) }.to not_change { TubeRack.count }.and not_change {
-                           RackedTube.count
-                         }.and not_change { Barcode.count }
+                                              RackedTube.count
+                                            }.and not_change { Barcode.count }
         end
       end
 
@@ -851,8 +847,8 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
           RSpec::Matchers.define_negated_matcher :not_change, :change
 
           expect { processor.run(nil) }.to not_change { TubeRack.count }.and not_change {
-                           RackedTube.count
-                         }.and not_change { Barcode.count }
+                                              RackedTube.count
+                                            }.and not_change { Barcode.count }
         end
 
         it 'will have errors' do

--- a/spec/sample_manifest_excel/worksheet_spec.rb
+++ b/spec/sample_manifest_excel/worksheet_spec.rb
@@ -123,10 +123,9 @@ RSpec.describe SampleManifestExcel::Worksheet, type: :model, sample_manifest_exc
     end
 
     it 'adds standard headings to worksheet' do
-      worksheet
-        .columns
-        .headings
-        .each_with_index { |heading, i| expect(spreadsheet.sheet(0).cell(9, i + 1)).to eq(heading) }
+      worksheet.columns.headings.each_with_index do |heading, i|
+        expect(spreadsheet.sheet(0).cell(9, i + 1)).to eq(heading)
+      end
     end
 
     it 'unlock cells for all columns which are unlocked' do
@@ -320,10 +319,9 @@ RSpec.describe SampleManifestExcel::Worksheet, type: :model, sample_manifest_exc
       end
 
       it 'adds standard headings to worksheet' do
-        worksheet
-          .columns
-          .headings
-          .each_with_index { |heading, i| expect(spreadsheet.sheet(0).cell(9, i + 1)).to eq(heading) }
+        worksheet.columns.headings.each_with_index do |heading, i|
+          expect(spreadsheet.sheet(0).cell(9, i + 1)).to eq(heading)
+        end
       end
 
       it 'adds the data' do

--- a/spec/shared_contexts/limber_shared_context.rb
+++ b/spec/shared_contexts/limber_shared_context.rb
@@ -56,16 +56,10 @@ shared_context 'a limber target plate with submissions' do |library_state = 'sta
   before do
     build_library_requests
     submission_request_types[1..].each do |downstream_type|
-      input_plate
-        .wells
-        .count
-        .times do
-          create_list :multiplex_request,
-                      requests_per_well,
-                      request_type: downstream_type,
-                      submission: target_submission
-          create :multiplex_request, request_type: downstream_type, submission: decoy_submission
-        end
+      input_plate.wells.count.times do
+        create_list :multiplex_request, requests_per_well, request_type: downstream_type, submission: target_submission
+        create :multiplex_request, request_type: downstream_type, submission: decoy_submission
+      end
     end
   end
 end

--- a/spec/uat_actions/generate_sample_manifest_spec.rb
+++ b/spec/uat_actions/generate_sample_manifest_spec.rb
@@ -96,8 +96,8 @@ describe UatActions::GenerateSampleManifest do
 
       it 'create tubes(s)' do
         expect { uat_action.generate_manifest(manifest) }.to change(SampleTube, :count).by(count).and change {
-                                                  manifest.assets.count
-                                                }.by(count)
+                                                   manifest.assets.count
+                                                 }.by(count)
         expect(manifest.assets).to eq(SampleTube.with_barcode(manifest.barcodes).map(&:receptacle))
       end
 

--- a/test/performance/work_completions_test.rb
+++ b/test/performance/work_completions_test.rb
@@ -34,13 +34,10 @@ class WorkCompletionsTest < ActionDispatch::PerformanceTest
              state: 'started'
     end
     submission_request_types[1..].each do |downstream_type|
-      input_plate
-        .wells
-        .count
-        .times do
-          create :multiplex_request, request_type: downstream_type, submission: @target_submission
-          create :multiplex_request, request_type: downstream_type, submission: decoy_submission
-        end
+      input_plate.wells.count.times do
+        create :multiplex_request, request_type: downstream_type, submission: @target_submission
+        create :multiplex_request, request_type: downstream_type, submission: decoy_submission
+      end
     end
   end
 

--- a/test/unit/cherrypick_task_test.rb
+++ b/test/unit/cherrypick_task_test.rb
@@ -37,15 +37,12 @@ class CherrypickTaskTest < ActiveSupport::TestCase
         end
 
       @mini_plate_purpose =
-        PlatePurpose
-          .stock_plate_purpose
-          .clone
-          .tap do |pp|
-            pp.size = 12
-            pp.name = 'Clonepp'
-            pp.asset_shape = @asset_shape
-            pp.save!
-          end
+        PlatePurpose.stock_plate_purpose.clone.tap do |pp|
+          pp.size = 12
+          pp.name = 'Clonepp'
+          pp.asset_shape = @asset_shape
+          pp.save!
+        end
 
       @task = build :cherrypick_task
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,12 +1082,12 @@
   resolved "https://registry.yarnpkg.com/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz#d26b6b7483fb70cd62189d05c95d2f67153e43f2"
   integrity sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==
 
-"@prettier/plugin-ruby@^1.5.5":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-1.6.1.tgz#14489985513a72e052b57c1cf9beae288880faa8"
-  integrity sha512-PGDCATgVTQz0s/NB9nStiXVCIr+hG/XnKeAO/kguaHrNf8VwCpP5Ul+/KQao0z0QFBy2PDY8kWptfDQCa7WMXg==
+"@prettier/plugin-ruby@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@prettier/plugin-ruby/-/plugin-ruby-2.0.0.tgz#a9f2d4183b56a9db9f80bbc685832a3b78685793"
+  integrity sha512-pA0rjTi5J7cT86XPNhXp7CpdV2Tlyj5oqDIsnQRxMu2P7LY2KJI/pyOSM8pzTH8BgRyQfe1P1NPCcTwxUnUWtQ==
   dependencies:
-    prettier ">=1.10"
+    prettier ">=2.3.0"
 
 "@rails/webpacker@^5.1.1":
   version "5.1.1"
@@ -7970,10 +7970,10 @@ pretender@^3.4.3:
     fake-xml-http-request "^2.1.1"
     route-recognizer "^0.3.3"
 
-prettier@>=1.10, prettier@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+prettier@>=2.3.0, prettier@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 prettier@^1.18.2:
   version "1.19.1"


### PR DESCRIPTION
- Mostly major architectural changes
- A handful of formatting changes, mostly improvements on handling
  method chains that feed into blocks. Seems less likely to split
  over mutliple lines.
- Also some adjustments to whitespace in some RSpec files where we chain
  multiple assertions. Seems to prevent runaway whitespace, but still
  somewhat clunky. Elsewhere using && rather than .and seems to result in
  better formatting. But want to keep this strictly formatting changes.