### PR TITLE
Fix submission template record loader mistake

### DIFF
--- a/config/default_records/submission_templates/001_cardinal_submission_templates.wip.yml
+++ b/config/default_records/submission_templates/001_cardinal_submission_templates.wip.yml
@@ -2,16 +2,14 @@
 # They are in a separate file to allow us to soft-release them before
 # the real release.
 ---
-limber_cardinal:
-  name: "Limber - Cardinal"
+Limber - Cardinal:
   submission_class_name: "LinearSubmission"
   related_records:
     request_type_keys: ["limber_cardinal"]
     project_name: "Project Cardinal"
     product_line_name: Cardinal
     product_catalogue_name: Cardinal
-limber_cardinal_banking:
-  name: "Limber - Cardinal cell banking"
+Limber - Cardinal cell banking:
   submission_class_name: "LinearSubmission"
   related_records:
     request_type_keys: ["limber_cardinal_banking"]


### PR DESCRIPTION
Fix issue with submission template record loader - mistake made when transferring this from limber.rake

- submission_template_loader uses the key for the submission template name, so take out the 'name' field from these default records and modify the key
