### PR TITLE
DPL-112 Get QC results for tubes

### DIFF
--- a/app/resources/api/v2/receptacle_resource.rb
+++ b/app/resources/api/v2/receptacle_resource.rb
@@ -18,6 +18,7 @@ module Api
 
       has_many :requests_as_source, readonly: true
       has_many :requests_as_target, readonly: true
+      has_many :qc_results, readonly: true
       has_many :aliquots, readonly: true
 
       has_many :downstream_assets, readonly: true, polymorphic: true

--- a/spec/resources/api/v2/receptacle_resource_spec.rb
+++ b/spec/resources/api/v2/receptacle_resource_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Api::V2::ReceptacleResource, type: :resource do
     expect(subject).to have_updatable_field(:coverage)
     expect(subject).to have_updatable_field(:diluent_volume)
 
+    expect(subject).to have_many(:qc_results).with_class_name('QcResult')
     expect(subject).to have_many(:samples).with_class_name('Sample')
     expect(subject).to have_many(:projects).with_class_name('Project')
     expect(subject).to have_many(:studies).with_class_name('Study')


### PR DESCRIPTION
This was supported in Wells but not for Tubes.  Tubes have a receptacle and the QC Results are associated with that.