### PR TITLE
Remove fluidigm irods data-source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,6 @@ group :default do
   # Locked for ruby version
   gem 'delayed_job_active_record'
 
-  gem 'irods_reader', '>=0.0.2', github: 'sanger/irods_reader'
-
   # For the API level
   gem 'json'
   gem 'multi_json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,12 +18,6 @@ GIT
       rubyzip (>= 1.2.1)
 
 GIT
-  remote: https://github.com/sanger/irods_reader.git
-  revision: 14db88aa7783118d2d4a8351c5028d07e6ee5644
-  specs:
-    irods_reader (0.0.2)
-
-GIT
   remote: https://github.com/sanger/sanger_barcode_format.git
   revision: 8e93771a9f38e1efb07c1d82dca1a81d74353e11
   branch: development
@@ -568,7 +562,6 @@ DEPENDENCIES
   factory_bot_rails
   font-awesome-sass
   formtastic
-  irods_reader (>= 0.0.2)!
   jquery-rails
   jquery-ui-rails
   json

--- a/GemfileNext.lock
+++ b/GemfileNext.lock
@@ -18,12 +18,6 @@ GIT
       rubyzip (>= 1.2.1)
 
 GIT
-  remote: https://github.com/sanger/irods_reader.git
-  revision: 14db88aa7783118d2d4a8351c5028d07e6ee5644
-  specs:
-    irods_reader (0.0.2)
-
-GIT
   remote: https://github.com/sanger/sanger_barcode_format.git
   revision: 8e93771a9f38e1efb07c1d82dca1a81d74353e11
   branch: development
@@ -564,7 +558,6 @@ DEPENDENCIES
   factory_bot_rails
   font-awesome-sass
   formtastic
-  irods_reader (>= 0.0.2)!
   jquery-rails
   jquery-ui-rails
   json

--- a/app/models/fluidigm_file.rb
+++ b/app/models/fluidigm_file.rb
@@ -19,25 +19,8 @@ class FluidigmFile # rubocop:todo Style/Documentation
       end
     end
 
-    class Irods # rubocop:todo Style/Documentation
-      def initialize(barcode)
-        @data =
-          IrodsReader::DataObj.find('seq', 'dcterms:audience' => configatron.irods_audience, :fluidigm_plate => barcode)
-      end
-
-      def empty?
-        @data.empty?
-      end
-
-      def content(index = nil)
-        raise StandardError, 'Multiple files found' if data.size > 1 && index.nil?
-
-        @data[index || 0].retrive
-      end
-    end
-
     def self.default
-      { 'irods' => Irods, 'directory' => Directory }.fetch(configatron.fluidigm_data.source)
+      { 'directory' => Directory }.fetch(configatron.fluidigm_data.source)
     end
 
     def self.find(barcode)

--- a/config/config.rb
+++ b/config/config.rb
@@ -29,7 +29,6 @@ configatron.default_policy_text = 'https://www.example.com/'
 configatron.default_policy_title = 'Default Policy Title'
 configatron.fluidigm_data.source = 'directory'
 configatron.fluidigm_data.directory = "#{Rails.root}/data/fluidigm"
-configatron.irods_audience = 'http://localhost:3000'
 configatron.mail_prefix = '[DEVELOPMENT]'
 configatron.phix_tag.tag_map_id = 888
 configatron.r_and_d_division = 'RandD'


### PR DESCRIPTION
Historically we tried pulling fluidigm data from irods, but ran into
severe performance issues with the imeta query to find the data.

This code has been unused for several years, and I doubt the assumptions
it makes are still even true.
