### PR TITLE
Remove pry-stack-explorer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,6 @@ end
 group :development, :test, :cucumber do
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'pry-stack_explorer'
 
   # Asset compilation, js and style libraries
   gem 'bootstrap', '~>4.0' # Pinned as v5 has significant changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.3.3.0)
       execjs (~> 2)
-    binding_of_caller (1.0.0)
-      debug_inspector (>= 0.0.1)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     bootstrap (4.6.0)
@@ -205,7 +203,6 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    debug_inspector (1.1.0)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
     delayed_job_active_record (4.1.6)
@@ -309,9 +306,6 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    pry-stack_explorer (0.6.1)
-      binding_of_caller (~> 1.0)
-      pry (~> 0.13)
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
@@ -588,7 +582,6 @@ DEPENDENCIES
   nokogiri
   pry-byebug
   pry-rails
-  pry-stack_explorer
   puma
   rack-acceptable
   rack-cors


### PR DESCRIPTION
Pry-stack-explorer is redundant with pry-byebug and the pry-byebug instructions suggest you remove it:
[Pry-bybug](https://github.com/deivid-rodriguez/pry-byebug#alternatives)

This also removes two transitive dependencies.