### PR TITLE
DPL-179 "poolings/new" should take "tag_depth" into account

### DIFF
--- a/app/models/aliquot.rb
+++ b/app/models/aliquot.rb
@@ -154,6 +154,10 @@ class Aliquot < ApplicationRecord
     [tag.try(:oligo), tag2.try(:oligo)]
   end
 
+  def tags_and_tag_depth_combination
+    [tag.try(:oligo), tag2.try(:oligo), tag_depth]
+  end
+
   def tag_count_name
     TAG_COUNT_NAMES[tag_count]
   end

--- a/app/models/pooling/tag_clash_report.rb
+++ b/app/models/pooling/tag_clash_report.rb
@@ -7,7 +7,7 @@ class Pooling::TagClashReport < SimpleDelegator
   include SampleManifestExcel::Tags::ClashesFinder
 
   # An oligo pair which clashes and details about the clashes causing the problem
-  Clash = Struct.new(:i7_oligo, :i5_oligo, :clashes)
+  Clash = Struct.new(:i7_oligo, :i5_oligo, :tag_depth, :clashes)
   ClashInfo = Struct.new(:sample, :library, :asset)
   UNTAGGED = '-'
 
@@ -16,14 +16,15 @@ class Pooling::TagClashReport < SimpleDelegator
   end
 
   def duplicates
-    @duplicates ||= grouped_aliquots.select { |_oligos, clashes| clashes.length > 1 }
+    @duplicates ||= grouped_aliquots.select { |_unique_key, aliquot_group| aliquot_group.length > 1 }
   end
 
   def clashes
-    duplicates.map do |oligos, clashes|
+    duplicates.map do |unique_key, clashes|
       Clash.new(
-        oligos.first || UNTAGGED,
-        oligos.last || UNTAGGED,
+        unique_key[0] || UNTAGGED,
+        unique_key[1] || UNTAGGED,
+        unique_key[2],
         clashes.map { |clashed_aliquot| clash_info(clashed_aliquot) }
       )
     end
@@ -31,8 +32,21 @@ class Pooling::TagClashReport < SimpleDelegator
 
   private
 
+  # Returns a hash, where:
+  #    the key is an array of attributes, which together must be unique
+  #    the value is an array of aliquots
+  # For example (where tag 1 and tag 2 oligo sequences make up the key):
+  #
+  # {
+  #   ["T", "C"]=>[
+  #     #<Aliquot id: 87 ...>,
+  #     #<Aliquot id: 90 ...>,
+  #     ...
+  #   ],
+  #   ...
+  # }
   def grouped_aliquots
-    aliquots.group_by(&:tags_combination)
+    aliquots.group_by(&:tags_and_tag_depth_combination)
   end
 
   def aliquots

--- a/spec/models/pooling_spec.rb
+++ b/spec/models/pooling_spec.rb
@@ -147,4 +147,35 @@ describe Pooling, type: :model, poolings: true do
       end
     end
   end
+
+  context 'when samples have the same tags' do
+    let(:barcodes) { [tagged_lb_tube1.machine_barcode, tagged_lb_tube2.machine_barcode] }
+
+    before do
+      # set the tags in the second tube to be the same as the first, to create a tag clash
+      tag1 = tagged_lb_tube1.aliquots.first.tag
+      tag2 = tagged_lb_tube1.aliquots.first.tag2
+      tagged_lb_tube2.aliquots.first.update!(tag: tag1, tag2: tag2)
+    end
+
+    it 'is not valid due to the tag clash' do
+      expect(pooling).not_to be_valid
+    end
+
+    # Tag depth is an identifier added to each aliquot in a receptacle
+    #   to indicate that they can be distinguished, despite having the same tags.
+    # It was introduced for the Cardinal pipeline, where they can be distinguished
+    #   due to having been previously sequenced.
+    # Therefore, if the tag depths are different, there should be no 'tag clash'.
+    context 'when samples have same tags but different tag depths' do
+      before do
+        tagged_lb_tube1.aliquots.first.update!(tag_depth: 2)
+        tagged_lb_tube2.aliquots.first.update!(tag_depth: 3)
+      end
+
+      it 'is valid because the tag depths are different' do
+        expect(pooling).to be_valid
+      end
+    end
+  end
 end


### PR DESCRIPTION
Reverts sanger/sequencescape#3430

Draft pull requests just for visibility of the changes for now. Dependent on the tag_depth field in revert-3428-disable_sequencing_request_changes branch