### PR TITLE
Compound sample creation fix

### DIFF
--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -41,6 +41,8 @@ module Request::SampleCompoundAliquotTransfer
   def transfer_into_compound_sample_aliquot(source_aliquots)
     samples = source_aliquots.map(&:sample)
 
+    # Check that the component samples in the compound sample will be able to be distinguished -
+    # this is represented by them all having a unique 'tag_depth'
     if source_aliquots.pluck(:tag_depth).uniq.count != source_aliquots.size
       raise "Cannot create compound sample from following samples due to duplicate 'tag depth': #{samples.map(&:name)}"
     end

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-# Module to provide support to handle creation of a compound sample
+# Module to provide support to handle creation of compound samples
 # from the list of samples at the source.
 #
 # Assumptions:
 #  - This module will be included in a Request class
 module Request::SampleCompoundAliquotTransfer
-  # Indicates if a compound sample creation is needed, if any of the aliquots
-  # at the source has a different tag_depth defined
+  # Indicates if a compound sample creation is needed:
+  # If any of the source aliquots share the same tag1 and tag2, but have distinct tag_depths
   def compound_samples_needed?
     return false if asset.aliquots.count == 1
 
     _tag_clash?
   end
 
-  # Creates a sample in a single aliquot at destination as a compound sample
-  # where the component samples are all samples at source
+  # Groups the source aliquots by their tag1 and tag2 combination
+  # For each of these groups, create a compound sample,
+  # to hide the fact from Illumina deplexing NPG software that there are
+  # actually multiple samples with this combination.
   def transfer_aliquots_into_compound_sample_aliquots
     _aliquots_by_tags_combination.each do |_tags_combo, aliquot_list|
       transfer_into_compound_sample_aliquot(aliquot_list)

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -25,10 +25,13 @@ module Request::SampleCompoundAliquotTransfer
       end
 
       compound_sample = _create_compound_sample(_default_compound_study, samples)
+
       target_asset
         .aliquots
         .create(sample: compound_sample)
         .tap do |aliquot|
+          aliquot.tag_id = aliquot_list.first.tag_id
+          aliquot.tag2_id = aliquot_list.first.tag2_id
           aliquot.library_type = _default_library_type
           aliquot.study_id = _default_compound_study.id
           aliquot.project_id = _default_compound_project_id
@@ -40,7 +43,7 @@ module Request::SampleCompoundAliquotTransfer
   private
 
   def _tag_clash?
-    _aliquots_by_tags_combination.any{ |_tags_combo, aliquot_list| aliquot_list.size > 1 }
+    _aliquots_by_tags_combination.any?{ |_tags_combo, aliquot_list| aliquot_list.size > 1 }
   end
 
   def _aliquots_by_tags_combination

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -32,13 +32,13 @@ module Request::SampleCompoundAliquotTransfer
   # For each of these groups, create a compound sample.
   def transfer_aliquots_into_compound_sample_aliquots
     _aliquots_by_tags_combination.each do |_tags_combo, aliquot_list|
-      transfer_into_compound_sample_aliquot(aliquot_list)
+      _transfer_into_compound_sample_aliquot(aliquot_list)
     end
   end
 
   private
 
-  def transfer_into_compound_sample_aliquot(source_aliquots)
+  def _transfer_into_compound_sample_aliquot(source_aliquots)
     samples = source_aliquots.map(&:sample)
 
     # Check that the component samples in the compound sample will be able to be distinguished -
@@ -49,10 +49,10 @@ module Request::SampleCompoundAliquotTransfer
 
     compound_sample = _create_compound_sample(_default_compound_study, samples)
 
-    add_aliquot(compound_sample, source_aliquots.first.tag_id, source_aliquots.first.tag2_id)
+    _add_aliquot(compound_sample, source_aliquots.first.tag_id, source_aliquots.first.tag2_id)
   end
 
-  def add_aliquot(sample, tag_id, tag2_id)
+  def _add_aliquot(sample, tag_id, tag2_id)
     target_asset
       .aliquots
       .create(sample: sample)

--- a/app/models/sequencing_request.rb
+++ b/app/models/sequencing_request.rb
@@ -36,7 +36,7 @@ class SequencingRequest < CustomerRequest # rubocop:todo Style/Documentation
 
   def on_started
     super
-    compound_samples_needed? ? transfer_aliquots_into_compound_sample_aliquot : transfer_aliquots
+    compound_samples_needed? ? transfer_aliquots_into_compound_sample_aliquots : transfer_aliquots
   end
 
   def order=(_)

--- a/spec/models/request/sample_compound_aliquot_transfer_spec.rb
+++ b/spec/models/request/sample_compound_aliquot_transfer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
   let(:source) { create :receptacle, aliquots: [aliquot1, aliquot2] }
   let(:library_tube) { create :library_tube, receptacles: [source] }
   let(:sequencing_request) { create(:sequencing_request, asset: source, target_asset: destination) }
+  let(:tags) { create_list :tag, 3 }
 
   describe '#compound_samples_needed?' do
     context 'when number of aliquots is 1' do
@@ -23,40 +24,49 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
       end
     end
 
-    context 'when tag_depth is different across aliquots' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: 1, tag_depth: 1, project: project }
-      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: 2, tag_depth: 2, project: project }
+    context 'when there is no tag clash, using tags 1 and 2' do
+      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, project: project }
+      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[2].id, project: project }
+
+      it 'returns false' do
+        expect(sequencing_request).not_to be_compound_samples_needed
+      end
+    end
+
+    context 'when there is a tag clash, using tags 1 and 2' do
+      let(:aliquot1) do
+        create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, project: project
+      end
+      let(:aliquot2) do
+        create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, project: project
+      end
 
       it 'returns true' do
         expect(sequencing_request).to be_compound_samples_needed
-      end
-    end
-
-    context 'when tag_depth is not defined' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], study: study, project: project }
-      let(:aliquot2) { create :aliquot, sample: samples[1], study: study, project: project }
-
-      it 'returns false' do
-        expect(sequencing_request).not_to be_compound_samples_needed
-      end
-    end
-
-    context 'when tag_depth is equal in all aliquots' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], study: study, tag_depth: 2, project: project }
-      let(:aliquot2) { create :aliquot, sample: samples[1], study: study, tag_depth: 2, project: project }
-
-      it 'returns false' do
-        expect(sequencing_request).not_to be_compound_samples_needed
       end
     end
   end
 
   describe '#transfer_aliquots_into_compound_sample_aliquots' do
     let(:aliquot1) do
-      create :aliquot, sample: samples[0], tag_depth: 1, study: study, project: project, library_type: 'Standard'
+      create :aliquot,
+             sample: samples[0],
+             tag_id: tags[0].id,
+             tag2_id: tags[1].id,
+             tag_depth: 1,
+             study: study,
+             project: project,
+             library_type: 'Standard'
     end
     let(:aliquot2) do
-      create :aliquot, sample: samples[1], tag_depth: 2, study: study, project: project, library_type: 'Standard'
+      create :aliquot,
+             sample: samples[1],
+             tag_id: tags[0].id,
+             tag2_id: tags[1].id,
+             tag_depth: 2,
+             study: study,
+             project: project,
+             library_type: 'Standard'
     end
 
     it 'creates a compound sample and transfers an aliquot of it' do

--- a/spec/models/request/sample_compound_aliquot_transfer_spec.rb
+++ b/spec/models/request/sample_compound_aliquot_transfer_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
     end
   end
 
-  describe '#transfer_aliquots_into_compound_sample_aliquot' do
+  describe '#transfer_aliquots_into_compound_sample_aliquots' do
     let(:aliquot1) do
       create :aliquot, sample: samples[0], tag_depth: 1, study: study, project: project, library_type: 'Standard'
     end
@@ -61,7 +61,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
 
     it 'creates a compound sample and transfers an aliquot of it' do
       expect(sequencing_request.target_asset.aliquots.count).to eq(0)
-      sequencing_request.transfer_aliquots_into_compound_sample_aliquot
+      sequencing_request.transfer_aliquots_into_compound_sample_aliquots
       expect(sequencing_request.target_asset.aliquots.count).to eq(1)
       expect(sequencing_request.target_asset.aliquots.first.library_type).to eq('Standard')
       expect(sequencing_request.target_asset.aliquots.first.study).to eq(study)

--- a/spec/models/sequencing_request_spec.rb
+++ b/spec/models/sequencing_request_spec.rb
@@ -139,13 +139,19 @@ RSpec.describe SequencingRequest, type: :model do
     let(:samples) { create_list :sample, 2 }
     let(:study) { create :study, samples: samples }
     let(:destination) { create :receptacle }
-    let(:source) { create :receptacle, aliquots: [aliquot1, aliquot2] }
+    let(:aliquots) { [aliquot1, aliquot2] }
+    let(:source) { create :receptacle, aliquots: aliquots }
     let(:library_tube) { create :library_tube, receptacles: [source] }
     let(:sequencing_request) { create(:sequencing_request, asset: source, target_asset: destination) }
+    let(:tags) { create_list :tag, 4 }
 
-    context 'when no tag_depth is defined in the source asset aliquots' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: 1, study: study }
-      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: 2, study: study }
+    before do
+      expect(tags.map(&:oligo).uniq.size == tags.size)
+    end
+
+    context 'when compound samples are not necessary because each aliquot has a unique tag combination' do
+      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, study: study }
+      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[2].id, study: study }
 
       it 'performs a normal transfer of aliquots' do
         expect(sequencing_request.target_asset.aliquots.count).to eq(0)
@@ -155,15 +161,40 @@ RSpec.describe SequencingRequest, type: :model do
       end
     end
 
-    context 'when tag_depth is defined in the source asset aliquots' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], tag_depth: 1, study: study }
-      let(:aliquot2) { create :aliquot, sample: samples[1], tag_depth: 2, study: study }
+    context 'when compound samples are necessary because each aliquot does not have a unique tag combination' do
+      context 'when there is one tag combination' do
+        let(:aliquot1) do
+ create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study end
+        let(:aliquot2) do
+ create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study end
 
-      it 'creates a compound sample and transfers an aliquot of it' do
-        expect(sequencing_request.target_asset.aliquots.count).to eq(0)
-        sequencing_request.start!
-        expect(sequencing_request.target_asset.aliquots.count).to eq(1)
-        expect(sequencing_request.target_asset.samples.first.component_samples.order(:id)).to eq(samples.sort)
+        it 'creates a compound sample and transfers an aliquot of it' do
+          expect(sequencing_request.target_asset.aliquots.count).to eq(0)
+          sequencing_request.start!
+          expect(sequencing_request.target_asset.aliquots.count).to eq(1)
+          expect(sequencing_request.target_asset.samples.first.component_samples.order(:id)).to eq(samples.sort)
+        end
+      end
+
+      context 'when there are two tag combinations' do
+        let(:samples) { create_list :sample, 4 }
+        let(:aliquot1) do
+ create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study end
+        let(:aliquot2) do
+ create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study end
+        let(:aliquot3) do
+ create :aliquot, sample: samples[2], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 1, study: study end
+        let(:aliquot4) do
+ create :aliquot, sample: samples[3], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 2, study: study end
+        let(:aliquots) { [aliquot1, aliquot2, aliquot3, aliquot4] }
+
+        it 'creates two compound samples and transfers an aliquot of each' do
+          expect(sequencing_request.target_asset.aliquots.count).to eq(0)
+          sequencing_request.start!
+          expect(sequencing_request.target_asset.aliquots.count).to eq(2)
+          expect(sequencing_request.target_asset.samples.first.component_samples.order(:id)).to eq(samples[0..1].sort)
+          expect(sequencing_request.target_asset.samples.last.component_samples.order(:id)).to eq(samples[2..3].sort)
+        end
       end
     end
   end

--- a/spec/models/sequencing_request_spec.rb
+++ b/spec/models/sequencing_request_spec.rb
@@ -145,10 +145,6 @@ RSpec.describe SequencingRequest, type: :model do
     let(:sequencing_request) { create(:sequencing_request, asset: source, target_asset: destination) }
     let(:tags) { create_list :tag, 4 }
 
-    before do
-      expect(tags.map(&:oligo).uniq.size == tags.size)
-    end
-
     context 'when compound samples are not necessary because each aliquot has a unique tag combination' do
       let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, study: study }
       let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[2].id, study: study }
@@ -164,9 +160,11 @@ RSpec.describe SequencingRequest, type: :model do
     context 'when compound samples are necessary because each aliquot does not have a unique tag combination' do
       context 'when there is one tag combination' do
         let(:aliquot1) do
- create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study end
+          create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study
+        end
         let(:aliquot2) do
- create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study end
+          create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study
+        end
 
         it 'creates a compound sample and transfers an aliquot of it' do
           expect(sequencing_request.target_asset.aliquots.count).to eq(0)
@@ -179,13 +177,17 @@ RSpec.describe SequencingRequest, type: :model do
       context 'when there are two tag combinations' do
         let(:samples) { create_list :sample, 4 }
         let(:aliquot1) do
- create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study end
+          create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study
+        end
         let(:aliquot2) do
- create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study end
+          create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study
+        end
         let(:aliquot3) do
- create :aliquot, sample: samples[2], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 1, study: study end
+          create :aliquot, sample: samples[2], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 1, study: study
+        end
         let(:aliquot4) do
- create :aliquot, sample: samples[3], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 2, study: study end
+          create :aliquot, sample: samples[3], tag_id: tags[2].id, tag2_id: tags[3].id, tag_depth: 2, study: study
+        end
         let(:aliquots) { [aliquot1, aliquot2, aliquot3, aliquot4] }
 
         it 'creates two compound samples and transfers an aliquot of each' do


### PR DESCRIPTION
Issue discovered in UAT - compound sample creation, on sequencing batch creation (#3383) was expecting just one compound sample. We need to handle the creation of multiple compound samples.
