### PR TITLE
Remove mini racer

### DIFF
--- a/.github/workflows/append_release.yml
+++ b/.github/workflows/append_release.yml
@@ -14,6 +14,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
 
       # Establish a cache of js modules to improve performance
       - name: Cache js

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
       # Establish a cache of js modules to improve performance
       - name: Cache js
         uses: actions/cache@v2

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -83,6 +83,10 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       # Establish a cache of js modules to improve performance
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
       - name: Cache js
         uses: actions/cache@v2
         with:
@@ -160,6 +164,10 @@ jobs:
         with:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       # Establish a cache of js modules to improve performance
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12"
       - name: Cache js
         uses: actions/cache@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -120,9 +120,6 @@ group :development do
   # find unused routes and controller actions by runnung `rake traceroute` from CL
   gem 'traceroute'
 
-  # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-  gem 'mini_racer'
-
   # Pat of the JS assets pipleine
   gem 'uglifier', '>= 1.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,6 @@ GEM
       rake
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8-node (16.10.0.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -269,8 +268,6 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
-    mini_racer (0.5.0)
-      libv8-node (~> 16.10.0.0)
     minitest (5.14.4)
     minitest-profiler (0.0.2)
       activesupport (>= 4.1.0)
@@ -565,7 +562,6 @@ DEPENDENCIES
   launchy
   listen
   mime-types
-  mini_racer
   minitest
   minitest-profiler
   mocha

--- a/spec/features/perform_a_tag_substitution_spec.rb
+++ b/spec/features/perform_a_tag_substitution_spec.rb
@@ -78,7 +78,10 @@ describe 'Perform a tag substitution', js: true do
         "#{sample_a_orig_tag.map_id} - #{sample_a_orig_tag.oligo}",
         from: 'tag_substitution[substitutions][][substitute_tag_id]'
       )
+
+    scroll_to(find_button('Substitute Tags'))
     click_button 'Substitute Tags'
+
     expect(page).to have_content "Receptacle #{lane.display_name}"
     expect(page).to have_content 'Your substitution was performed.'
     find('td', text: sample_a.name).sibling('td', text: "(#{sample_b_orig_tag.oligo})")
@@ -115,13 +118,14 @@ describe 'Perform a tag substitution', js: true do
         "#{sample_b_orig_tag2.map_id} - #{sample_b_orig_tag2.oligo}",
         from: 'tag_substitution[substitutions][][substitute_tag2_id]'
       )
+
+    scroll_to(find_button('Substitute Tags'))
     click_button 'Substitute Tags'
+
     expect(page).to have_content(lane.name)
     expect(page).to have_content 'Your tag substitution could not be performed.'
-    expect(
-      page
-      # rubocop:todo Layout/LineLength
-    ).to have_content "Tag pair #{sample_b_orig_tag.oligo}-#{sample_b_orig_tag2.oligo} features multiple times in the pool."
-    # rubocop:enable Layout/LineLength
+    expect(page).to have_content(
+      "Tag pair #{sample_b_orig_tag.oligo}-#{sample_b_orig_tag2.oligo} features multiple times in the pool."
+    )
   end
 end


### PR DESCRIPTION
- Remove mini-racer dependency
- Add node actions to other GH actions

Miniracer is a requirement of execjs, which is used in a few places in the rails js pipeline (mostly the sprockets stuff)
It is able to use a few js engines, including node.

When originally we adopted mini-racer, we weren't using node, so it seemed the simpler dependency. However now we have a node-install available for the other bits of the asset compilation pipeline, so it makes sense to use that.

This change was driven by breaking changes in mini-race 0.5
