### PR TITLE
DPL 173: Add emSEQ library type

### DIFF
--- a/app/models/tube/purpose.rb
+++ b/app/models/tube/purpose.rb
@@ -67,5 +67,6 @@ end
 require_dependency 'qcable_tube_purpose'
 require_dependency 'illumina_htp/mx_tube_purpose'
 require_dependency 'illumina_htp/stock_tube_purpose'
+require_dependency 'illumina_htp/initial_stock_tube_purpose'
 require_dependency 'tube/standard_mx'
 require_dependency 'tube/stock_mx'

--- a/app/uat_actions/uat_actions/generate_tag_group.rb
+++ b/app/uat_actions/uat_actions/generate_tag_group.rb
@@ -25,7 +25,11 @@ class UatActions::GenerateTagGroup < UatActions
              :select,
              label: 'Adapter Type Name',
              help: 'The name of the adapter type for the tag group.',
-             select_options: -> { TagGroup::AdapterType.order(:name).pluck(:name) }
+             select_options: -> { TagGroup::AdapterType.order(:name).pluck(:name) },
+             options: {
+               include_blank: 'No Adapter Type'
+             }
+
 
   validates :size,
             numericality: {
@@ -59,7 +63,7 @@ class UatActions::GenerateTagGroup < UatActions
   end
 
   def create_tag_group(name, adapter_type)
-    tag_group = TagGroup.create!(name: name, adapter_type_id: adapter_type.id)
+    tag_group = TagGroup.create!(name: name, adapter_type_id: adapter_type&.id)
 
     tag_group.tags.build(
       OligoEnumerator.new(size.to_i).each_with_index.map { |oligo, map_id| { oligo: oligo, map_id: map_id + 1 } }

--- a/app/uat_actions/uat_actions/generate_tag_group.rb
+++ b/app/uat_actions/uat_actions/generate_tag_group.rb
@@ -30,7 +30,6 @@ class UatActions::GenerateTagGroup < UatActions
                include_blank: 'No Adapter Type'
              }
 
-
   validates :size,
             numericality: {
               less_than_or_equal_to: ->(record) { record.existing_tags },

--- a/config/default_records/request_types/005_limber_bespoke.yml
+++ b/config/default_records/request_types/005_limber_bespoke.yml
@@ -10,9 +10,20 @@ limber_pcr_bespoke:
   acceptable_plate_purposes:
     - LBB Cherrypick
   library_types:
-    - Ribozero RNA depletion
     - ChIP-Seq Auto
+    - Chromium single cell HTO
+    - Chromium single cell surface protein
+    - Chromium Visium
+    - emSEQ
+    - Haplotagging
+    - Hi-C
+    - Hi-C - Arima v1
+    - Hi-C - Arima v2
+    - Hi-C - Dovetail
+    - Hi-C - OmniC
+    - Hi-C - Qiagen
     - Manual Standard WGS (Plate)
+    - Ribozero RNA depletion
     - Ribozero RNA-seq (Bacterial)
     - Ribozero RNA-seq (HMR)
     - RNA-seq dUTP eukaryotic
@@ -21,16 +32,6 @@ limber_pcr_bespoke:
     - Standard
     - TraDIS
     - TruSeq mRNA (RNA Seq)
-    - Chromium Visium
-    - Hi-C
-    - Hi-C - Arima v2
-    - Hi-C - Qiagen
-    - Hi-C - OmniC
-    - Hi-C - Arima v1
-    - Hi-C - Dovetail
-    - Haplotagging
-    - Chromium single cell HTO
-    - Chromium single cell surface protein
 limber_chromium_bespoke:
   <<: *limber_bespoke_library
   name: Limber Chromium Bespoke

--- a/spec/uat_actions/generate_tag_group_spec.rb
+++ b/spec/uat_actions/generate_tag_group_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe UatActions::GenerateTagGroup do
-  context 'with valid options' do
+  context 'when valid options' do
     let(:parameters) { { name: 'Test group', size: '3' } }
     let(:uat_action) { described_class.new(parameters) }
     let(:report) do
@@ -19,7 +19,7 @@ describe UatActions::GenerateTagGroup do
       expect(TagGroup.find_by(name: 'Test group').adapter_type_id).to be_nil
     end
 
-    context 'including an adapter type' do
+    context 'with an adapter type' do
       let(:adapter_type) { create(:adapter_type) }
       let(:parameters) { { name: 'Test group', size: '3', adapter_type_name: adapter_type.name } }
 

--- a/spec/uat_actions/generate_tag_group_spec.rb
+++ b/spec/uat_actions/generate_tag_group_spec.rb
@@ -4,8 +4,7 @@ require 'rails_helper'
 
 describe UatActions::GenerateTagGroup do
   context 'with valid options' do
-    let(:adapter_type) { create(:adapter_type) }
-    let(:parameters) { { name: 'Test group', size: '3', adapter_type_name: adapter_type.name } }
+    let(:parameters) { { name: 'Test group', size: '3' } }
     let(:uat_action) { described_class.new(parameters) }
     let(:report) do
       # A report is a hash of key value pairs which get returned to the user.
@@ -17,7 +16,19 @@ describe UatActions::GenerateTagGroup do
       expect(uat_action.perform).to eq true
       expect(uat_action.report).to eq report
       expect(TagGroup.find_by(name: 'Test group').tags.count).to eq 3
-      expect(TagGroup.find_by(name: 'Test group').adapter_type_id).to eq adapter_type.id
+      expect(TagGroup.find_by(name: 'Test group').adapter_type_id).to be_nil
+    end
+
+    context 'including an adapter type' do
+      let(:adapter_type) { create(:adapter_type) }
+      let(:parameters) { { name: 'Test group', size: '3', adapter_type_name: adapter_type.name } }
+
+      it 'can be performed' do
+        expect(uat_action.perform).to eq true
+        expect(uat_action.report).to eq report
+        expect(TagGroup.find_by(name: 'Test group').tags.count).to eq 3
+        expect(TagGroup.find_by(name: 'Test group').adapter_type_id).to eq adapter_type.id
+      end
     end
   end
 


### PR DESCRIPTION
Closes #3416 

Changes proposed in this pull request:

* Add emSEQ library type to `limber_pcr_bespoke` request type.
* Update the UAT action for creating tag groups so that no adapter type needs to be provided.
