### PR TITLE
DPL-074-1 consolidate samples - addition

### DIFF
--- a/app/resources/api/v2/submission_resource.rb
+++ b/app/resources/api/v2/submission_resource.rb
@@ -28,6 +28,7 @@ module Api
       attribute :used_tags, readonly: true
 
       # Filters
+      filter :uuid, apply: ->(records, value, _options) { records.with_uuid(value) }
 
       # Custom methods
       # These shouldn't be used for business logic, and a more about


### PR DESCRIPTION
Add uuid filter to Submission V2 API resource
- allows Limber to query .where(uuid: 'xyz')
