### PR TITLE
Add support for requests coming from the Docker local host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Support requests coming from other Docker containers on localhost.
+  config.hosts << 'host.docker.internal'
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
Needed for sanger/limber#933

Changes proposed in this pull request:

* Allow connections from the docker localhost (i.e. when Limber is in a Docker container)
