### PR TITLE
Pre-populate the nCoV-2019/V4 primer panel in dev

### DIFF
--- a/config/default_records/primer_panels/primer_panels.dev.yml
+++ b/config/default_records/primer_panels/primer_panels.dev.yml
@@ -23,3 +23,12 @@ nCoV-2019/V3/B:
     pcr 2:
       name:
       duration: "60"
+nCoV-2019/V4:
+  snp_count: 98
+  programs:
+    pcr 1:
+      name:
+      duration: "60"
+    pcr 2:
+      name:
+      duration: "60"


### PR DESCRIPTION
This is a source of annoyance if you reset your database.  It was overlooked when we added the primer panel a few months ago.  We need to remember to add the next one in a few weeks as well.
