### PR TITLE
Sample Manifest UAT action tweak

### DIFF
--- a/app/uat_actions/uat_actions/generate_sample_manifest.rb
+++ b/app/uat_actions/uat_actions/generate_sample_manifest.rb
@@ -78,7 +78,7 @@ class UatActions::GenerateSampleManifest < UatActions
       raise 'Manifest for plates is not supported yet' unless asset_type == '1dtube'
 
       create_sample("Sample_#{asset.human_barcode}_1", sample_manifest).tap do |sample|
-        asset.aliquots.create!(sample: sample, study: study, library: asset)
+        asset.aliquots.create!(sample: sample, study: study)
         study.samples << sample
       end
     end


### PR DESCRIPTION
Don't specify the library_id on the aliquot
- this is not appropriate for the cardinal pipeline - it should be set later on when the tags are added
- it is probably appropriate for other types of manifest, however the only use I know of so far is the cardinal pipeline, so keep it simple
