### PR TITLE
DPL-188 simplified heron request graph

### DIFF
--- a/app/models/submission/linear_request_graph.rb
+++ b/app/models/submission/linear_request_graph.rb
@@ -33,7 +33,9 @@ module Submission::LinearRequestGraph
 
   private
 
-  # Generates a list of RequestType and multiplier pairs for the instance.
+  # Returns an array of arrays.
+  # The inner array has two elements: a RequestType instance, and an integer (the "multiplier").
+  # e.g. [ [ RequestType instance 1, 1 ], [ RequestType instance 2, 1 ] ]
   def build_request_type_multiplier_pairs # rubocop:todo Metrics/AbcSize
     # Ensure that the keys of the multipliers hash are strings, otherwise we get weirdness!
     multipliers =

--- a/config/default_records/request_types/004_limber_high_throughput.yml
+++ b/config/default_records/request_types/004_limber_high_throughput.yml
@@ -156,6 +156,20 @@ limber_heron_lthr:
     - Sanger_tailed_artic_v1_384
     - PCR amplicon tailed adapters 96
     - PCR amplicon tailed adapters 384
+limber_heron_lthr_v2:
+  <<: *limber_htp_library
+  name: Limber Heron LTHR V2
+  request_class_name: IlluminaHtp::Requests::HeronTailedRequest
+  for_multiplexing: true
+  acceptable_purposes:
+    - LTHR RT
+    - LTHR-384 RT
+    - LTHR Cherrypick
+  library_types:
+    - Sanger_tailed_artic_v1_96
+    - Sanger_tailed_artic_v1_384
+    - PCR amplicon tailed adapters 96
+    - PCR amplicon tailed adapters 384
 limber_pwgs-384:
   <<: *limber_htp_library
   name: Limber pWGS-384

--- a/config/default_records/request_types/004_limber_high_throughput.yml
+++ b/config/default_records/request_types/004_limber_high_throughput.yml
@@ -161,6 +161,7 @@ limber_heron_lthr_v2:
   name: Limber Heron LTHR V2
   request_class_name: IlluminaHtp::Requests::HeronTailedRequest
   for_multiplexing: true
+  target_purpose_name: LB Lib Pool Norm
   acceptable_purposes:
     - LTHR RT
     - LTHR-384 RT

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -183,8 +183,7 @@ namespace :limber do
           submission_class_name: 'LinearSubmission',
           submission_parameters: {
             request_type_ids_list: [
-              RequestType.where(key: 'limber_heron_lthr').ids,
-              RequestType.where(key: 'limber_multiplexing').ids,
+              RequestType.where(key: 'limber_heron_lthr_v2').ids,
               RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
             ],
             project_id: Limber::Helper.find_project('Project Heron').id

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -177,9 +177,39 @@ namespace :limber do
         role: 'LTHR'
       ).build!
 
+      heron_lthr_catalogue = ProductCatalogue.find_or_create_by!(name: 'Heron LTHR')
+      Limber::Helper::TemplateConstructor.new(
+        prefix: 'Heron LTHR V2',
+        catalogue: heron_lthr_catalogue,
+        sequencing_keys: base_list,
+        role: 'LTHR'
+      ).build!
+      Limber::Helper::LibraryOnlyTemplateConstructor.new(
+        prefix: 'Heron LTHR V2',
+        catalogue: heron_lthr_catalogue,
+        role: 'LTHR'
+      ).build!
+
       unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR - Automated')
         SubmissionTemplate.create!(
           name: 'Limber - Heron LTHR - Automated',
+          submission_class_name: 'LinearSubmission',
+          submission_parameters: {
+            request_type_ids_list: [
+              RequestType.where(key: 'limber_heron_lthr').ids,
+              RequestType.where(key: 'limber_multiplexing').ids,
+              RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
+            ],
+            project_id: Limber::Helper.find_project('Project Heron').id
+          },
+          product_line: ProductLine.find_by!(name: 'Illumina-HTP'),
+          product_catalogue: ProductCatalogue.find_by!(name: 'Generic')
+        )
+      end
+
+      unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR V2 - Automated')
+        SubmissionTemplate.create!(
+          name: 'Limber - Heron LTHR V2 - Automated',
           submission_class_name: 'LinearSubmission',
           submission_parameters: {
             request_type_ids_list: [


### PR DESCRIPTION
Closes #3451 

~TODO: write code for updating old submission templates to fill in 'superceded_by_id' and 'superceded_at' fields.~

See Limber and Integration Suite PRs of the same name