### PR TITLE
Add library type to aliquot api

### DIFF
--- a/app/resources/api/v2/aliquot_resource.rb
+++ b/app/resources/api/v2/aliquot_resource.rb
@@ -25,6 +25,7 @@ module Api
       attribute :tag2_oligo, readonly: true
       attribute :tag2_index, readonly: true
       attribute :suboptimal, readonly: true
+      attribute :library_type, readonly: true
 
       # Filters
 

--- a/spec/resources/api/v2/aliquot_resource_spec.rb
+++ b/spec/resources/api/v2/aliquot_resource_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe Api::V2::AliquotResource, type: :resource do
     expect(subject).to have_attribute :tag_index
     expect(subject).to have_attribute :tag2_index
     expect(subject).to have_attribute :suboptimal
+    expect(subject).to have_attribute :library_type
     expect(subject).not_to have_updatable_field(:id)
     expect(subject).not_to have_updatable_field(:tag_oligo)
     expect(subject).not_to have_updatable_field(:tag2_oligo)
     expect(subject).not_to have_updatable_field(:suboptimal)
+    expect(subject).not_to have_updatable_field(:library_type)
     expect(subject).to have_one(:sample).with_class_name('Sample')
   end
 


### PR DESCRIPTION
Allows library type to be imported into traction if
supplied by library manifest.
