### PR TITLE
DPL-188 deployment fix

### DIFF
--- a/config/default_records/product_catalogues/002_default_product_catalogues.yml
+++ b/config/default_records/product_catalogues/002_default_product_catalogues.yml
@@ -1,0 +1,8 @@
+# Default Product Catalogue records
+---
+Generic:
+  selection_behaviour: SingleProduct
+Targeted-NanoSeq:
+  selection_behaviour: SingleProduct
+Heron LTHR:
+  selection_behaviour: SingleProduct

--- a/config/default_records/product_catalogues/002_targeted_nanoseq_product_catalogues.yml
+++ b/config/default_records/product_catalogues/002_targeted_nanoseq_product_catalogues.yml
@@ -1,4 +1,0 @@
-# This product catalogue is associated with the Limber Targeted Nanoseq pipeline.
----
-Targeted-NanoSeq:
-  selection_behaviour: SingleProduct

--- a/config/default_records/request_types/007_illumina.yml
+++ b/config/default_records/request_types/007_illumina.yml
@@ -1,0 +1,65 @@
+# These request types were are used for illumina sequencing
+---
+illumina_b_hiseq_2500_paired_end_sequencing:
+  name: Illumina-B HiSeq 2500 Paired end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: false
+  product_line_name: Illumina-B
+illumina_b_hiseq_2500_single_end_sequencing:
+  name: Illumina-B HiSeq 2500 Single end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: false
+  product_line_name: Illumina-B
+illumina_b_miseq_sequencing:
+  name: Illumina-B MiSeq sequencing
+  asset_type: LibraryTube
+  order: 1
+  request_class_name: MiSeqSequencingRequest
+  for_multiplexing: false
+  billable: false
+illumina_b_hiseq_v4_paired_end_sequencing:
+  name: Illumina-B HiSeq V4 Paired end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: true
+  product_line_name: Illumina-B
+illumina_b_hiseq_x_paired_end_sequencing:
+  name: Illumina-B HiSeq X Paired end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: true
+  product_line_name: Illumina-B
+illumina_htp_hiseq_4000_paired_end_sequencing:
+  name: Illumina-HTP HiSeq 4000 Paired end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: true
+  product_line_name: Illumina-HTP
+illumina_htp_hiseq_4000_single_end_sequencing:
+  name: Illumina-HTP HiSeq 4000 Single end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: true
+  product_line_name: Illumina-HTP
+illumina_htp_novaseq_6000_paired_end_sequencing:
+  name: Illumina-HTP NovaSeq 6000 Paired end sequencing
+  asset_type: LibraryTube
+  order: 2
+  request_class_name: HiSeqSequencingRequest
+  for_multiplexing: false
+  billable: true
+  product_line_name: Illumina-HTP

--- a/config/default_records/submission_templates/003_heron_submission_templates.yml
+++ b/config/default_records/submission_templates/003_heron_submission_templates.yml
@@ -1,0 +1,74 @@
+# These submission templates are the latest associated with the Heron
+# pipeline as of 06/01/2021.
+# The older ones are in limber.rake at time of writing.
+---
+Limber - Heron LTHR V2 - Automated:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_htp_novaseq_6000_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Generic
+Limber-Htp - Heron LTHR V2 - HiSeq 2500 Paired end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_b_hiseq_2500_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - HiSeq 2500 Single end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_b_hiseq_2500_single_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - MiSeq sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_b_miseq_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - HiSeq V4 Paired end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_b_hiseq_v4_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - HiSeq X Paired end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_b_hiseq_x_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - HiSeq 4000 Paired end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_htp_hiseq_4000_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - HiSeq 4000 Single end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_htp_hiseq_4000_single_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2 - NovaSeq 6000 Paired end sequencing:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2", "illumina_htp_novaseq_6000_paired_end_sequencing"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR
+Limber-Htp - Heron LTHR V2:
+  submission_class_name: "LinearSubmission"
+  related_records:
+    request_type_keys: ["limber_heron_lthr_v2"]
+    project_name: "Project Heron"
+    product_line_name: Illumina-HTP
+    product_catalogue_name: Heron LTHR

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -177,19 +177,6 @@ namespace :limber do
         role: 'LTHR'
       ).build!
 
-      heron_lthr_catalogue = ProductCatalogue.find_or_create_by!(name: 'Heron LTHR')
-      Limber::Helper::TemplateConstructor.new(
-        prefix: 'Heron LTHR V2',
-        catalogue: heron_lthr_catalogue,
-        sequencing_keys: base_list,
-        role: 'LTHR'
-      ).build!
-      Limber::Helper::LibraryOnlyTemplateConstructor.new(
-        prefix: 'Heron LTHR V2',
-        catalogue: heron_lthr_catalogue,
-        role: 'LTHR'
-      ).build!
-
       unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR - Automated')
         SubmissionTemplate.create!(
           name: 'Limber - Heron LTHR - Automated',
@@ -198,22 +185,6 @@ namespace :limber do
             request_type_ids_list: [
               RequestType.where(key: 'limber_heron_lthr').ids,
               RequestType.where(key: 'limber_multiplexing').ids,
-              RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
-            ],
-            project_id: Limber::Helper.find_project('Project Heron').id
-          },
-          product_line: ProductLine.find_by!(name: 'Illumina-HTP'),
-          product_catalogue: ProductCatalogue.find_by!(name: 'Generic')
-        )
-      end
-
-      unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR V2 - Automated')
-        SubmissionTemplate.create!(
-          name: 'Limber - Heron LTHR V2 - Automated',
-          submission_class_name: 'LinearSubmission',
-          submission_parameters: {
-            request_type_ids_list: [
-              RequestType.where(key: 'limber_heron_lthr_v2').ids,
               RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
             ],
             project_id: Limber::Helper.find_project('Project Heron').id


### PR DESCRIPTION
move new Heron submission templates to record loader
- because deployment was failing
- they are dependent on the new request type which was in record loader, and limber:setup is run before record loader, on deploy
- had to also move some existing request types over otherwise it didn't work locally when running db:setup
