### PR TITLE
DPL-188 re-enable

### DIFF
--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -2,8 +2,11 @@
 
 namespace :application do
   # In Sanger PSD we have the ansible deployment project configured to run:
-  # `rails db:migrate`` --> `rake application:post_deploy`
-  #
+  # `rake application:deploy` --> `rails db:migrate`` --> `rake application:post_deploy`
+
+  # Leave this here empty in case it's needed in future
+  task :deploy
+
   # Record loader is configured here to run *before* limber:setup,
   # so we can gradually get rid of limber:setup by migrating things into record loader.
   # This allows limber:setup to be dependent on record loader, which makes things easier to migrate.

--- a/lib/tasks/application.rake
+++ b/lib/tasks/application.rake
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 namespace :application do
-  task deploy: ['limber:setup']
-
-  # Placeholder task for RecordLoader behaviour
-  task :post_deploy
+  # In Sanger PSD we have the ansible deployment project configured to run:
+  # `rails db:migrate`` --> `rake application:post_deploy`
+  #
+  # Record loader is configured here to run *before* limber:setup,
+  # so we can gradually get rid of limber:setup by migrating things into record loader.
+  # This allows limber:setup to be dependent on record loader, which makes things easier to migrate.
+  task post_deploy: %w[record_loader:all limber:setup]
 end

--- a/lib/tasks/limber.rake
+++ b/lib/tasks/limber.rake
@@ -177,19 +177,19 @@ namespace :limber do
         role: 'LTHR'
       ).build!
 
-      # DPL-188 TODO - broken atm due to dependency on Request Type added by Record Loader
-      # heron_lthr_catalogue = ProductCatalogue.find_or_create_by!(name: 'Heron LTHR')
-      # Limber::Helper::TemplateConstructor.new(
-      #   prefix: 'Heron LTHR V2',
-      #   catalogue: heron_lthr_catalogue,
-      #   sequencing_keys: base_list,
-      #   role: 'LTHR'
-      # ).build!
-      # Limber::Helper::LibraryOnlyTemplateConstructor.new(
-      #   prefix: 'Heron LTHR V2',
-      #   catalogue: heron_lthr_catalogue,
-      #   role: 'LTHR'
-      # ).build!
+      heron_lthr_catalogue = ProductCatalogue.find_or_create_by!(name: 'Heron LTHR')
+      Limber::Helper::TemplateConstructor.new(
+        prefix: 'Heron LTHR V2',
+        catalogue: heron_lthr_catalogue,
+        sequencing_keys: base_list,
+        role: 'LTHR'
+      ).build!
+      Limber::Helper::LibraryOnlyTemplateConstructor.new(
+        prefix: 'Heron LTHR V2',
+        catalogue: heron_lthr_catalogue,
+        role: 'LTHR'
+      ).build!
+
       unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR - Automated')
         SubmissionTemplate.create!(
           name: 'Limber - Heron LTHR - Automated',
@@ -207,22 +207,22 @@ namespace :limber do
         )
       end
 
-      # DPL-188 TODO - broken atm due to dependency on Request Type added by Record Loader
-      # unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR V2 - Automated')
-      #   SubmissionTemplate.create!(
-      #     name: 'Limber - Heron LTHR V2 - Automated',
-      #     submission_class_name: 'LinearSubmission',
-      #     submission_parameters: {
-      #       request_type_ids_list: [
-      #         RequestType.where(key: 'limber_heron_lthr_v2').ids,
-      #         RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
-      #       ],
-      #       project_id: Limber::Helper.find_project('Project Heron').id
-      #     },
-      #     product_line: ProductLine.find_by!(name: 'Illumina-HTP'),
-      #     product_catalogue: ProductCatalogue.find_by!(name: 'Generic')
-      #   )
-      # end
+      unless SubmissionTemplate.find_by(name: 'Limber - Heron LTHR V2 - Automated')
+        SubmissionTemplate.create!(
+          name: 'Limber - Heron LTHR V2 - Automated',
+          submission_class_name: 'LinearSubmission',
+          submission_parameters: {
+            request_type_ids_list: [
+              RequestType.where(key: 'limber_heron_lthr_v2').ids,
+              RequestType.where(key: 'illumina_htp_novaseq_6000_paired_end_sequencing').ids
+            ],
+            project_id: Limber::Helper.find_project('Project Heron').id
+          },
+          product_line: ProductLine.find_by!(name: 'Illumina-HTP'),
+          product_catalogue: ProductCatalogue.find_by!(name: 'Generic')
+        )
+      end
+
       lcbm_catalogue =
         ProductCatalogue.create_with(selection_behaviour: 'SingleProduct').find_or_create_by!(name: 'LCMB')
       Limber::Helper::LibraryOnlyTemplateConstructor.new(prefix: 'LCMB', catalogue: lcbm_catalogue).build!

--- a/lib/tasks/record_loader.rake
+++ b/lib/tasks/record_loader.rake
@@ -12,11 +12,5 @@ namespace :record_loader do
   end
 end
 
-# In Sanger PSD we have the ansible deployment project configured to run `rake application:post_deploy` after migrations
-# for selected applications.
-# Uncomment the following to automatically trigger record loader on running the application:post_deploy task.
-# You may need to set `post_deploy: true` in the ansible configuration for your application.
-task 'application:post_deploy' => 'record_loader:all'
-
 # Automatically run record loader before seeds
 task 'db:seed' => 'record_loader:all_except_in_test'


### PR DESCRIPTION
Re-enable the new submission templates.

Change deployment order of limber:setup and record loader so that:
- it matches what happens locally when you run `db:reset` and then `limber:setup`
- limber:setup can now have dependencies on record loader
- this will make it easier to gradually move things from limber:setup to record loader, without having to move a huge block to include all the dependencies


Also see https://github.com/sanger/deployment/pull/143