### PR TITLE
Fix missing button styles

### DIFF
--- a/app/assets/stylesheets/all/components.scss
+++ b/app/assets/stylesheets/all/components.scss
@@ -79,9 +79,9 @@ div.batch-summary-events {
 
 // Apply basic button formatting to all buttons
 // Exclude any where a specific class has been applied
-input[type="submit"]:not(.btn) {
-  @extend .btn;
+input[type="submit"] {
   @extend .btn-primary;
+  @extend .btn;
 }
 
 .link-panel {

--- a/app/assets/stylesheets/all/components.scss
+++ b/app/assets/stylesheets/all/components.scss
@@ -78,7 +78,7 @@ div.batch-summary-events {
 }
 
 // Apply basic button formatting to all buttons
-// |Specific styles will overdie the default due to CSS specificity rules
+// Specific styles will override the default due to CSS specificity rules
 input[type="submit"] {
   @extend .btn-primary;
   @extend .btn;

--- a/app/assets/stylesheets/all/components.scss
+++ b/app/assets/stylesheets/all/components.scss
@@ -78,7 +78,7 @@ div.batch-summary-events {
 }
 
 // Apply basic button formatting to all buttons
-// Exclude any where a specific class has been applied
+// |Specific styles will overdie the default due to CSS specificity rules
 input[type="submit"] {
   @extend .btn-primary;
   @extend .btn;


### PR DESCRIPTION
The upgrade to Sassc broke some button styling. It turns out that
this rule was the problem, and was resolving to a transparent
background colour.

It appears that this was a side effect of the not(.btn) rule clashing
with the subsequent import of btn.

Fortunately this exclusion was entirely unnecessary, as the usual
css rules mean that classes count as more specific operators, and
override the default button styles anyway.

Closes #

Changes proposed in this pull request:

*
*
* ...
