### PR TITLE
DPL-231 [BUG] Heron - failing labware fails

### DIFF
--- a/app/models/request/statemachine.rb
+++ b/app/models/request/statemachine.rb
@@ -192,7 +192,13 @@ module Request::Statemachine # rubocop:todo Style/Documentation
   def on_hold; end
 
   def failed_upstream!
-    fail_from_upstream! unless failed?
+    # Don't transition it again if it's already failed
+    return if failed?
+
+    # Only transition it if *all* upstream requests are failed, not just the one we came from.
+    return unless upstream_requests.all?(&:failed?)
+
+    fail_from_upstream!
   end
 
   def failed_downstream!


### PR DESCRIPTION
Fix bug where failing multiple library requests connected to a single sequencing request threw an exception (due to it trying to cancel the sequencing request twice). The sequencing request should only be transitioned if all upstream requests are failed - hence it will only be transitioned once if a whole upstream plate is failed

Details in case useful:

The error was: `There is an issue with the API connection to Sequencescape ({"general":["Event 'fail_from_upstream' cannot transition from 'cancelled'."]})`

This was because:
- `on_failed` in `std_library_request.rb` was getting called once per well, when failing a plate
- this found the `next_requests` and called `failed_upstream!` on each of them
- prior to the changes from https://github.com/sanger/sequencescape/issues/3451, `next_requests` would have returned a multiplexing request, a different one for each well
- after DPL-188, it returns a sequencing request, just one for the whole plate
- this means that `failed_upstream!` in `models > request > statemachine.rb` got called more than once for the same sequencing request
- the first time, the configured transitions meant it changed from `pending` to `cancelled`
- the second time, there was no configured transition from `cancelled` onwards, so it threw an error
- my changes mean that it should not call this a second time