### PR TITLE
DPL183 Targeted Nanoseq - Fix capitalisation in library type name

### DIFF
--- a/config/default_records/request_types/004_limber_high_throughput.yml
+++ b/config/default_records/request_types/004_limber_high_throughput.yml
@@ -194,4 +194,4 @@ limber_targeted_nanoseq:
     - LTN Stock
     - LTN Cherrypick
   library_types:
-    - Targeted NanoSeq
+    - Targeted Nanoseq


### PR DESCRIPTION
Was causing duplicate joins between request type and library type to be created in database.
