### PR TITLE
Improvements to compound sample creation

### DIFF
--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -9,7 +9,7 @@ class CompoundAliquot # rubocop:todo Style/Documentation
 
   attr_accessor :request, :source_aliquots
 
-  attr_reader :component_samples
+  attr_reader :component_samples, :compound_sample
 
   validate :tag_depth_is_unique
 
@@ -33,10 +33,23 @@ class CompoundAliquot # rubocop:todo Style/Documentation
 
   # Generates the compound sample, under the default study, using the component samples
   def create_compound_sample
-    default_compound_study.samples.create!(
-      name: SangerSampleId.generate_sanger_sample_id!(default_compound_study.abbreviation),
-      component_samples: component_samples
-    )
+    @compound_sample =
+      default_compound_study.samples.create!(
+        name: SangerSampleId.generate_sanger_sample_id!(default_compound_study.abbreviation),
+        component_samples: component_samples
+      )
+  end
+
+  def aliquot_attributes
+    {
+      tag_id: tag_id,
+      tag2_id: tag2_id,
+      library_type: default_library_type,
+      study_id: default_compound_study.id,
+      project_id: default_compound_project_id,
+      library_id: copy_library_id,
+      sample: compound_sample
+    }
   end
 
   # Default study that the new compound sample will use

--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -33,7 +33,7 @@ class CompoundAliquot
   # Check that the component samples in the compound sample will be able to be distinguished -
   # this is represented by them all having a unique 'tag_depth'
   def tag_depth_is_unique
-    return unless source_aliquots.pluck(:tag_depth).uniq.count != source_aliquots.size
+    return unless source_aliquots.pluck(:tag_depth).uniq!
 
     errors.add("#{DUPLICATE_TAG_DEPTH_ERROR_MSG}: #{component_samples.map(&:name)}")
   end

--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -31,6 +31,14 @@ class CompoundAliquot # rubocop:todo Style/Documentation
     source_aliquots.first.library_type
   end
 
+  # Generates the compound sample, under the default study, using the component samples
+  def create_compound_sample
+    default_compound_study.samples.create!(
+      name: SangerSampleId.generate_sanger_sample_id!(default_compound_study.abbreviation),
+      component_samples: component_samples
+    )
+  end
+
   # Default study that the new compound sample will use
   # Uses the one from the request if it's present,
   # otherwise, the one from the source aliquots if it's consistent.

--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class CompoundAliquot # rubocop:todo Style/Documentation
+  include ActiveModel::Model
+
+  DUPLICATE_TAG_DEPTH_ERROR_MSG = "Cannot create compound sample from following samples due to duplicate 'tag depth'"
+  MULTIPLE_STUDIES_ERROR_MSG =
+    'Cannot create compound sample due to the component samples being under different studies.'
+
+  attr_accessor :request, :source_aliquots
+
+  attr_reader :component_samples
+
+  validate :tag_depth_is_unique
+
+  def initialize(attributes)
+    super
+
+    @component_samples = source_aliquots.map(&:sample)
+  end
+
+  # Check that the component samples in the compound sample will be able to be distinguished -
+  # this is represented by them all having a unique 'tag_depth'
+  def tag_depth_is_unique
+    return unless source_aliquots.pluck(:tag_depth).uniq.count != source_aliquots.size
+
+    errors.add("#{DUPLICATE_TAG_DEPTH_ERROR_MSG}: #{component_samples.map(&:name)}")
+  end
+
+  def default_library_type
+    source_aliquots.first.library_type
+  end
+
+  # Default study that the new compound sample will use
+  # Uses the one from the request if it's present,
+  # otherwise, the one from the source aliquots if it's consistent.
+  def default_compound_study
+    request.initial_study ||
+      begin
+        raise MULTIPLE_STUDIES_ERROR_MSG if studies.count > 1
+
+        studies.first
+      end
+  end
+
+  def studies
+    source_aliquots.map(&:study).uniq
+  end
+
+  # Default project that the new compound sample will use
+  # Uses the one from the request if it's present,
+  # otherwise, one grabbed from a source aliquot.
+  def default_compound_project_id
+    request.initial_project_id || source_aliquots.first.project_id
+  end
+
+  # If the library_id is the same on all source aliquots, we can confidently transfer it to the target aliquot
+  # How the library_id should be set if the source aliquots have different library_ids is not defined
+  # Therefore, set it to nil for now, until we have a real requirement
+  def copy_library_id
+    library_ids = source_aliquots.map(&:library_id).uniq
+    library_ids.size == 1 ? library_ids.first : nil
+  end
+
+  def tag_id
+    source_aliquots.first.tag_id
+  end
+
+  def tag2_id
+    source_aliquots.first.tag2_id
+  end
+end

--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -58,7 +58,7 @@ class CompoundAliquot
       library_type: default_library_type,
       study_id: default_compound_study.id,
       project_id: default_compound_project_id,
-      library_id: copy_library_id,
+      library_id: default_library_id,
       sample: compound_sample
     }
   end
@@ -89,7 +89,7 @@ class CompoundAliquot
   # If the library_id is the same on all source aliquots, we can confidently transfer it to the target aliquot
   # How the library_id should be set if the source aliquots have different library_ids is not defined
   # Therefore, set it to nil for now, until we have a real requirement
-  def copy_library_id
+  def default_library_id
     library_ids = source_aliquots.map(&:library_id).uniq
     library_ids.size == 1 ? library_ids.first : nil
   end

--- a/app/models/compound_aliquot.rb
+++ b/app/models/compound_aliquot.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
-class CompoundAliquot # rubocop:todo Style/Documentation
+# Factory class for creating Aliquots with compound samples in them.
+# At time of writing, called from Request::SampleCompoundAliquotTransfer, in the context of a Request.
+#
+# The inputs are:
+#   request           A Request for transferring source_aliquots into a target receptacle.
+#                     At time of writing, only used for a SequencingRequest, from a multiplex tube into a lane.
+#   source_aliquots   A list of Aliquots that should be transferred into a single Aliquot in a target Receptacle,
+#                     that containes  contain a single compound sample.
+#                     The list of component samples is derived from source_aliquots.
+#                     Some attributes are transferred from the source aliquots onto the compound aliquot.
+#
+class CompoundAliquot
   include ActiveModel::Model
 
   DUPLICATE_TAG_DEPTH_ERROR_MSG = "Cannot create compound sample from following samples due to duplicate 'tag depth'"

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -56,20 +56,9 @@ module Request::SampleCompoundAliquotTransfer
 
     raise compound_aliquot.errors unless compound_aliquot.valid?
 
-    compound_sample = _create_compound_sample(compound_aliquot)
+    compound_sample = compound_aliquot.create_compound_sample
 
     _add_aliquot(compound_sample, compound_aliquot)
-  end
-
-  # Private method to generate a compound sample in a study from a list of
-  # component samples
-  def _create_compound_sample(compound_aliquot)
-    study = compound_aliquot.default_compound_study
-
-    study.samples.create!(
-      name: SangerSampleId.generate_sanger_sample_id!(study.abbreviation),
-      component_samples: compound_aliquot.component_samples
-    )
   end
 
   def _add_aliquot(sample, compound_aliquot)

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -21,37 +21,33 @@
 # Assumptions:
 #  - This module will be included in a Request class
 module Request::SampleCompoundAliquotTransfer
-  DUPLICATE_TAG_DEPTH_ERROR_MSG = "Cannot create compound sample from following samples due to duplicate 'tag depth'"
-  MULTIPLE_STUDIES_ERROR_MSG =
-    'Cannot create compound sample due to the component samples being under different studies.'
-
   # Indicates if a compound sample creation is needed, by checking
   # if any of the source aliquots share the same tag1 and tag2
   def compound_samples_needed?
     return false if asset.aliquots.count == 1
 
-    _any_aliquots_share_tag_combination?
+    any_aliquots_share_tag_combination?
   end
 
   # Groups the source aliquots by their tag1 and tag2 combination
   # For each of these groups, create a compound sample.
   def transfer_aliquots_into_compound_sample_aliquots
-    _aliquots_by_tags_combination.each do |_tags_combo, aliquot_list|
-      _transfer_into_compound_sample_aliquot(aliquot_list)
+    aliquots_by_tags_combination.each do |_tags_combo, aliquot_list|
+      transfer_into_compound_sample_aliquot(aliquot_list)
     end
   end
 
   private
 
-  def _any_aliquots_share_tag_combination?
-    _aliquots_by_tags_combination.any? { |_tags_combo, aliquot_list| aliquot_list.size > 1 }
+  def any_aliquots_share_tag_combination?
+    aliquots_by_tags_combination.any? { |_tags_combo, aliquot_list| aliquot_list.size > 1 }
   end
 
-  def _aliquots_by_tags_combination
+  def aliquots_by_tags_combination
     asset.aliquots.group_by(&:tags_combination)
   end
 
-  def _transfer_into_compound_sample_aliquot(source_aliquots)
+  def transfer_into_compound_sample_aliquot(source_aliquots)
     compound_aliquot = CompoundAliquot.new(request: self, source_aliquots: source_aliquots)
 
     raise compound_aliquot.errors unless compound_aliquot.valid?

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -21,6 +21,9 @@
 # Assumptions:
 #  - This module will be included in a Request class
 module Request::SampleCompoundAliquotTransfer
+  class Error < StandardError
+  end
+
   # Indicates if a compound sample creation is needed, by checking
   # if any of the source aliquots share the same tag1 and tag2
   def compound_samples_needed?
@@ -49,8 +52,9 @@ module Request::SampleCompoundAliquotTransfer
 
   def transfer_into_compound_sample_aliquot(source_aliquots)
     compound_aliquot = CompoundAliquot.new(request: self, source_aliquots: source_aliquots)
-
-    raise compound_aliquot.errors unless compound_aliquot.valid?
+    unless compound_aliquot.valid?
+      raise Request::SampleCompoundAliquotTransfer::Error, compound_aliquot.errors.full_messages
+    end
 
     compound_aliquot.create_compound_sample
 

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -102,18 +102,12 @@ module Request::SampleCompoundAliquotTransfer
   # Uses the one from the request if it's present,
   # otherwise, the one from the source aliquots if it's consistent.
   def _default_compound_study(source_aliquots)
-    _initial_study ||
+    initial_study ||
       begin
         raise MULTIPLE_STUDIES_ERROR_MSG if _studies(source_aliquots).count > 1
 
         _studies(source_aliquots).first
       end
-  end
-
-  def _initial_study
-    return nil unless initial_study_id
-
-    Study.find(initial_study_id)
   end
 
   def _studies(source_aliquots)

--- a/app/models/request/sample_compound_aliquot_transfer.rb
+++ b/app/models/request/sample_compound_aliquot_transfer.rb
@@ -56,27 +56,8 @@ module Request::SampleCompoundAliquotTransfer
 
     raise compound_aliquot.errors unless compound_aliquot.valid?
 
-    compound_sample = compound_aliquot.create_compound_sample
+    compound_aliquot.create_compound_sample
 
-    _add_aliquot(compound_sample, compound_aliquot)
-  end
-
-  def _add_aliquot(sample, compound_aliquot)
-    target_asset
-      .aliquots
-      .create(sample: sample)
-      .tap do |aliquot|
-        _set_aliquot_attributes(aliquot, compound_aliquot)
-        aliquot.save
-      end
-  end
-
-  def _set_aliquot_attributes(aliquot, compound_aliquot)
-    aliquot.tag_id = compound_aliquot.tag_id
-    aliquot.tag2_id = compound_aliquot.tag2_id
-    aliquot.library_type = compound_aliquot.default_library_type
-    aliquot.study_id = compound_aliquot.default_compound_study.id
-    aliquot.project_id = compound_aliquot.default_compound_project_id
-    aliquot.library_id = compound_aliquot.copy_library_id
+    target_asset.aliquots.create(compound_aliquot.aliquot_attributes)
   end
 end

--- a/spec/models/request/sample_compound_aliquot_transfer_spec.rb
+++ b/spec/models/request/sample_compound_aliquot_transfer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
   let(:samples) { create_list :sample, 2 }
   let(:study1) { create :study }
   let(:study2) { create :study }
-  let(:project) { create :project }
+  let(:project1) { create :project }
+  let(:project2) { create :project }
   let(:destination) { create :receptacle }
   let(:source) { create :receptacle, aliquots: [aliquot1, aliquot2] }
   let(:library_tube) { create :library_tube, receptacles: [source] }
@@ -19,7 +20,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
 
   describe '#compound_samples_needed?' do
     context 'when number of aliquots is 1' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: 1, tag_depth: 1, project: project }
+      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: 1, tag_depth: 1, project: project1 }
       let(:source) { create :receptacle, aliquots: [aliquot1] }
 
       it 'returns false' do
@@ -28,8 +29,8 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
     end
 
     context 'when there is no tag clash, using tags 1 and 2' do
-      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, project: project }
-      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[2].id, project: project }
+      let(:aliquot1) { create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, project: project1 }
+      let(:aliquot2) { create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[2].id, project: project1 }
 
       it 'returns false' do
         expect(sequencing_request).not_to be_compound_samples_needed
@@ -38,10 +39,10 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
 
     context 'when there is a tag clash, using tags 1 and 2' do
       let(:aliquot1) do
-        create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, project: project
+        create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, project: project1
       end
       let(:aliquot2) do
-        create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, project: project
+        create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, project: project1
       end
 
       it 'returns true' do
@@ -58,7 +59,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
              tag2_id: tags[1].id,
              tag_depth: 1,
              study: study1,
-             project: project,
+             project: project1,
              library_type: 'Standard',
              library_id: 54
     end
@@ -69,7 +70,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
              tag2_id: tags[1].id,
              tag_depth: 2,
              study: study1,
-             project: project,
+             project: project1,
              library_type: 'Standard',
              library_id: 54
     end
@@ -80,38 +81,41 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
       expect(sequencing_request.target_asset.aliquots.count).to eq(1)
       expect(sequencing_request.target_asset.aliquots.first.library_type).to eq('Standard')
       expect(sequencing_request.target_asset.aliquots.first.study).to eq(study1)
-      expect(sequencing_request.target_asset.aliquots.first.project).to eq(project)
+      expect(sequencing_request.target_asset.aliquots.first.project).to eq(project1)
       expect(sequencing_request.target_asset.aliquots.first.library_id).to eq(54)
       expect(sequencing_request.target_asset.samples.first.component_samples.order(:id)).to eq(samples.sort)
     end
 
     # How the library_id should be set if the source aliquots have different library_ids is not defined
     # Therefore, set it to nil for now, until we have a real requirement
-    context 'with conflicting library_ids' do
-      before { aliquot1.update!(library_id: 82) }
+    context 'with conflicting library_ids and library_types' do
+      before { aliquot1.update!(library_id: 82, library_type: 'Not Standard') }
 
-      it 'creates a compound sample with a blank library id' do
+      it 'creates a compound sample with a blank library id and library type' do
         sequencing_request.transfer_aliquots_into_compound_sample_aliquots
         expect(sequencing_request.target_asset.aliquots.count).to eq(1)
         expect(sequencing_request.target_asset.aliquots.first.library_id).to be_nil
+        expect(sequencing_request.target_asset.aliquots.first.library_type).to be_nil
       end
     end
 
-    context 'with a different study specified on the sequencing request to on the source aliquots' do
-      before { sequencing_request.update!(initial_study_id: study2.id) }
+    context 'with a different study and project specified on the sequencing request to on the source aliquots' do
+      before { sequencing_request.update!(initial_study_id: study2.id, initial_project_id: project2.id) }
 
-      it 'uses the study from the request' do
+      it 'uses the study and project from the request' do
         sequencing_request.transfer_aliquots_into_compound_sample_aliquots
         expect(sequencing_request.target_asset.aliquots.first.study).to eq(study2)
+        expect(sequencing_request.target_asset.aliquots.first.project).to eq(project2)
       end
     end
 
-    context 'with no study specified on the sequencing request' do
-      before { sequencing_request.update!(initial_study_id: nil) }
+    context 'with no study or project specified on the sequencing request' do
+      before { sequencing_request.update!(initial_study_id: nil, initial_project_id: nil) }
 
-      it 'uses the study from the source aliquots' do
+      it 'uses the study and project from the source aliquots' do
         sequencing_request.transfer_aliquots_into_compound_sample_aliquots
         expect(sequencing_request.target_asset.aliquots.first.study).to eq(study1)
+        expect(sequencing_request.target_asset.aliquots.first.project).to eq(project1)
       end
 
       # If the component samples are under different studies, this is a potential data governance issue
@@ -121,7 +125,21 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
 
         it 'throws an exception' do
           expect { sequencing_request.transfer_aliquots_into_compound_sample_aliquots }.to raise_error(
-            CompoundAliquot::MULTIPLE_STUDIES_ERROR_MSG
+            Request::SampleCompoundAliquotTransfer::Error,
+            /#{CompoundAliquot::MULTIPLE_STUDIES_ERROR_MSG}/o
+          )
+        end
+      end
+
+      # If the component samples are under different projects, this could cause billing issues.
+      # Error in this case.
+      context 'with conflicting project_ids' do
+        before { aliquot1.update!(project: project2) }
+
+        it 'throws an exception' do
+          expect { sequencing_request.transfer_aliquots_into_compound_sample_aliquots }.to raise_error(
+            Request::SampleCompoundAliquotTransfer::Error,
+            /#{CompoundAliquot::MULTIPLE_PROJECTS_ERROR_MSG}/o
           )
         end
       end
@@ -152,7 +170,6 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
                library_id: 55
       end
       let(:tags_extra) { create_list :tag, 2 }
-      let(:project2) { create :project }
       let(:source) { create :receptacle, aliquots: [aliquot1, aliquot2, aliquot3, aliquot4] }
 
       before { sequencing_request.update!(initial_study_id: nil) }
@@ -165,7 +182,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
         expect(sequencing_request.target_asset.aliquots[1].library_type).to eq('Standard')
         expect(sequencing_request.target_asset.aliquots[0].study).to eq(study1)
         expect(sequencing_request.target_asset.aliquots[1].study).to eq(study2)
-        expect(sequencing_request.target_asset.aliquots[0].project).to eq(project)
+        expect(sequencing_request.target_asset.aliquots[0].project).to eq(project1)
         expect(sequencing_request.target_asset.aliquots[1].project).to eq(project2)
         expect(sequencing_request.target_asset.aliquots[0].library_id).to eq(54)
         expect(sequencing_request.target_asset.aliquots[1].library_id).to eq(55)

--- a/spec/models/request/sample_compound_aliquot_transfer_spec.rb
+++ b/spec/models/request/sample_compound_aliquot_transfer_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Request::SampleCompoundAliquotTransfer' do
 
         it 'throws an exception' do
           expect { sequencing_request.transfer_aliquots_into_compound_sample_aliquots }.to raise_error(
-            Request::SampleCompoundAliquotTransfer::MULTIPLE_STUDIES_ERROR_MSG
+            CompoundAliquot::MULTIPLE_STUDIES_ERROR_MSG
           )
         end
       end

--- a/spec/models/sequencing_request_spec.rb
+++ b/spec/models/sequencing_request_spec.rb
@@ -138,11 +138,20 @@ RSpec.describe SequencingRequest, type: :model do
   context 'on start' do
     let(:samples) { create_list :sample, 2 }
     let(:study) { create :study, samples: samples }
+    let(:project) { create :project }
     let(:destination) { create :receptacle }
     let(:aliquots) { [aliquot1, aliquot2] }
     let(:source) { create :receptacle, aliquots: aliquots }
     let(:library_tube) { create :library_tube, receptacles: [source] }
-    let(:sequencing_request) { create(:sequencing_request, asset: source, target_asset: destination) }
+    let(:sequencing_request) do
+      create(
+        :sequencing_request,
+        asset: source,
+        target_asset: destination,
+        initial_study: study,
+        initial_project: project
+      )
+    end
     let(:tags) { create_list :tag, 4 }
 
     context 'when compound samples are not necessary because each aliquot has a unique tag combination' do
@@ -160,10 +169,22 @@ RSpec.describe SequencingRequest, type: :model do
     context 'when compound samples are necessary because each aliquot does not have a unique tag combination' do
       context 'when there is one tag combination' do
         let(:aliquot1) do
-          create :aliquot, sample: samples[0], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 1, study: study
+          create :aliquot,
+                 sample: samples[0],
+                 tag_id: tags[0].id,
+                 tag2_id: tags[1].id,
+                 tag_depth: 1,
+                 study: study,
+                 project: project
         end
         let(:aliquot2) do
-          create :aliquot, sample: samples[1], tag_id: tags[0].id, tag2_id: tags[1].id, tag_depth: 2, study: study
+          create :aliquot,
+                 sample: samples[1],
+                 tag_id: tags[0].id,
+                 tag2_id: tags[1].id,
+                 tag_depth: 2,
+                 study: study,
+                 project: project
         end
 
         it 'creates a compound sample and transfers an aliquot of it' do


### PR DESCRIPTION
- to do with setting the study id on the target aliquots (the study that will end up in iseq_flowcell)
- if the user specifies a study on the sequencing submission/ request, use that (it was previously being ignored)
- otherwise, same logic as before - use the one from the source aliquots if it's consistent, error if not
