### PR TITLE
Issue3314/dpl 123 as a long read user i would like a sample manifest with library type added {c s v 4}

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -929,7 +929,6 @@ Rails/FilePath:
     - 'lib/accession/accession.rb'
     - 'lib/tasks/cucumber.rake'
     - 'lib/tasks/sample_manifest_excel_tests.rake'
-    - 'lib/tasks/test.rake'
     - 'test/test_helper.rb'
     - 'test/unit/fluidigm_file_test.rb'
     - 'test/unit/import_fluidigm_data_test.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -181,7 +181,6 @@ end
 
 group :test, :cucumber do
   gem 'capybara'
-  gem 'capybara-selenium'
   gem 'database_cleaner'
   gem 'factory_bot_rails', require: false
   gem 'jsonapi-resources-matchers', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,9 +129,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-selenium (0.0.6)
-      capybara
-      selenium-webdriver
     carrierwave (2.2.2)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -541,7 +538,6 @@ DEPENDENCIES
   bullet
   cancancan
   capybara
-  capybara-selenium
   carrierwave
   configatron
   cucumber-rails

--- a/app/controllers/sdb/sample_manifests_controller.rb
+++ b/app/controllers/sdb/sample_manifests_controller.rb
@@ -55,8 +55,10 @@ class Sdb::SampleManifestsController < Sdb::BaseController # rubocop:todo Style/
   end
 
   def index
-    pending_sample_manifests = SampleManifest.pending_manifests.paginate(page: params[:page])
-    completed_sample_manifests = SampleManifest.completed_manifests.paginate(page: params[:page])
+    pending_sample_manifests =
+      SampleManifest.pending_manifests.includes(:study, :supplier, :user).paginate(page: params[:page])
+    completed_sample_manifests =
+      SampleManifest.completed_manifests.includes(:study, :supplier, :user).paginate(page: params[:page])
     @display_manifests = pending_sample_manifests | completed_sample_manifests
     @sample_manifests = SampleManifest.paginate(page: params[:page])
   end

--- a/app/models/library_type.rb
+++ b/app/models/library_type.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require './lib/record_loader/library_type_loader'
+
 # A library type is an identifier which describes how a library has been produced
 # Whereas {RequestType} is largely internal to sequencescape, a library type directly
 # reflects the science, and thus has a many to many relationship with request type.

--- a/app/models/library_type.rb
+++ b/app/models/library_type.rb
@@ -16,7 +16,7 @@
 class LibraryType < ApplicationRecord
   include SharedBehaviour::Named
 
-  scope :long_read, -> { alphabetical.where(name: records_in('001_long_read')) }
+  scope :from_record_loaders, ->(loader) { alphabetical.where(name: records_in(loader)) }
 
   has_many :library_types_request_types, inverse_of: :library_type, dependent: :destroy
   has_many :request_types, through: :library_types_request_types

--- a/app/models/library_type.rb
+++ b/app/models/library_type.rb
@@ -1,9 +1,29 @@
 # frozen_string_literal: true
-class LibraryType < ApplicationRecord
-  validates :name, presence: true
 
-  scope :alphabetical, -> { order(:name) }
+# A library type is an identifier which describes how a library has been produced
+# Whereas {RequestType} is largely internal to sequencescape, a library type directly
+# reflects the science, and thus has a many to many relationship with request type.
+# LibraryType gets exposed in the multi-lims warehouse, and can affect downstream
+# processing.
+#
+# Some library types have no request type associated. These may be used by
+# external pipelines, such as Traction, or may be of use exclusively for library
+# manifests.
+#
+# @note For historical reasons, library type is *not* a relationship on request_metadata
+# or on aliquot. This is because library_types used to by hardcoded in the {Request}
+# class.
+class LibraryType < ApplicationRecord
+  include SharedBehaviour::Named
+
+  scope :long_read, -> { alphabetical.where(name: records_in('001_long_read')) }
 
   has_many :library_types_request_types, inverse_of: :library_type, dependent: :destroy
   has_many :request_types, through: :library_types_request_types
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  def self.records_in(file_name)
+    RecordLoader::LibraryTypeLoader.new(files: [file_name]).names
+  end
 end

--- a/app/models/request_type/validator.rb
+++ b/app/models/request_type/validator.rb
@@ -70,10 +70,14 @@ class RequestType::Validator < ApplicationRecord
     def default
       nil
     end
+
+    def valid_options
+      []
+    end
   end
 
-  belongs_to :request_type
-  validates :request_type, :request_option, :valid_options, presence: true
+  belongs_to :request_type, optional: false
+  validates :request_option, :valid_options, presence: true
   serialize :valid_options
 
   delegate :include?, to: :valid_options

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -141,8 +141,6 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
     custom_attribute(:disease)
 
     custom_attribute(:genome_size)
-    custom_attribute(:saphyr)
-    custom_attribute(:pacbio)
 
     # Consent withdrawn
     custom_attribute(:consent_withdrawn)

--- a/app/models/sample_manifest/library_tube_behaviour.rb
+++ b/app/models/sample_manifest/library_tube_behaviour.rb
@@ -17,6 +17,10 @@ module SampleManifest::LibraryTubeBehaviour
       @tubes = []
     end
 
+    def generate
+      @tubes = generate_tubes(Tube::Purpose.standard_library_tube)
+    end
+
     def io_samples
       samples.map do |sample|
         {
@@ -27,10 +31,6 @@ module SampleManifest::LibraryTubeBehaviour
           library_information: sample.primary_receptacle.library_information
         }
       end
-    end
-
-    def generate
-      @tubes = generate_tubes(Tube::Purpose.standard_library_tube)
     end
 
     def labware_from_samples

--- a/app/models/tag_substitution/substitution.rb
+++ b/app/models/tag_substitution/substitution.rb
@@ -19,7 +19,7 @@ class TagSubstitution::Substitution
   delegate :disable_match_expectation, to: :tag_substituter, allow_nil: true
 
   delegate :friendly_name, to: :sample, prefix: true
-  validates :sample_id, :library_id, presence: true
+  validates :sample_id, presence: true
   validates :original_tag_id, presence: { if: :substitute_tag_id }
   validates :original_tag2_id, presence: { if: :substitute_tag2_id }
   validates :matching_aliquots, presence: { message: 'could not be found' }, unless: :disable_match_expectation

--- a/app/sequencescape_excel/sequencescape_excel/column.rb
+++ b/app/sequencescape_excel/sequencescape_excel/column.rb
@@ -91,6 +91,7 @@ module SequencescapeExcel
     end
 
     def specialised_field?
+      # We can't use const_defined? here as we want to make sure we trigger rails class loading
       specialised_field.present?
     end
 

--- a/app/sequencescape_excel/sequencescape_excel/range.rb
+++ b/app/sequencescape_excel/sequencescape_excel/range.rb
@@ -150,7 +150,7 @@ module SequencescapeExcel
     end
 
     def create_dynamic_options
-      klass.public_send(@scope).pluck(@identifier)
+      klass.public_send(*Array(@scope)).pluck(@identifier)
     end
 
     def klass

--- a/config/default_records/library_types/.about_library_types
+++ b/config/default_records/library_types/.about_library_types
@@ -1,0 +1,4 @@
+Note:
+Library types may also be registered by the request-type record loader.
+This record loader exists to also allow the creation of library types
+with no associated request type.

--- a/config/default_records/library_types/001_long_read.yml
+++ b/config/default_records/library_types/001_long_read.yml
@@ -1,0 +1,14 @@
+---
+# DO NOT RENAME THIS FILE
+# These library types are associated with the long-read pipeline
+# This file is also used directly to populate the LongRead manifest
+# Note: There is some redundancy with the corresponding data in
+# Traction. However it was felt this was preferable to introducing
+# a downstream dependency on traction
+Pacbio_HiFi: {}
+Pacbio_HiFi_mplx: {}
+Pacbio_Microbial_mplx: {}
+Pacbio_IsoSeq: {}
+PacBio_IsoSeq_mplx: {}
+PacBio_Ultra_Low_Input: {}
+PacBio_Ultra_Low_Input_mplx: {}

--- a/config/locales/metadata/en.yml
+++ b/config/locales/metadata/en.yml
@@ -307,10 +307,6 @@ en:
           edit_info: "EGA"
         genome_size:
           label: Genome Size
-        saphyr:
-          label: Saphyr
-        pacbio:
-          label: Pacbio
 
     study:
       metadata:

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -811,46 +811,6 @@ genome_size:
     empty_cell:
     number_greater_than_zero:
     is_text:
-saphyr:
-  heading: SAPHYR?
-  unlocked: true
-  validation:
-    options:
-      type: :list
-      formula1: "$A$1:$A$2"
-      allowBlank: false
-      showDropDown: false
-      showInputMessage: true
-      promptTitle: "Will this sample be sequenced on Saphyr?"
-      prompt: "Please Enter Y or N."
-      showErrorMessage: true
-      errorStyle: :stop
-      errorTitle: "Will this sample be sequenced on Saphyr?"
-      error: "You must enter either Y or N."
-    range_name: :yes_no
-  conditional_formattings:
-    empty_cell:
-    is_error:
-pacbio:
-  heading: PACBIO?
-  unlocked: true
-  validation:
-    options:
-      type: :list
-      formula1: "$A$1:$A$2"
-      allowBlank: false
-      showDropDown: false
-      showInputMessage: true
-      promptTitle: "Will this sample be sequenced on Pacbio?"
-      prompt: "Please Enter Y or N."
-      showErrorMessage: true
-      errorStyle: :stop
-      errorTitle: "Will this sample be sequenced on Pacbio?"
-      error: "You must enter either Y or N."
-    range_name: :yes_no
-  conditional_formattings:
-    empty_cell:
-    is_error:
 primer_panel:
   heading: PRIMER PANEL
   unlocked: true

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -179,6 +179,27 @@ library_type:
   conditional_formattings:
     empty_cell:
     is_error:
+library_type_long_read:
+  name: library_type
+  heading: LIBRARY TYPE
+  unlocked: true
+  validation:
+    options:
+      type: :list
+      formula1: "$A$1:$A$2"
+      allowBlank: false
+      showDropDown: false
+      showInputMessage: true
+      showErrorMessage: true
+      errorStyle: :stop
+      errorTitle: "Library type"
+      error: "You must enter a Library type from the list provided."
+      promptTitle: "Library type"
+      prompt: "Provide a library type from the approved list"
+    range_name: :library_type_long_read
+  conditional_formattings:
+    empty_cell:
+    is_error:
 reference_genome:
   heading: REFERENCE GENOME
   unlocked: true

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -623,8 +623,24 @@ long_read:
     - :sample_ebi_accession_number
     - :donor_id
     - :genome_size
-    - :saphyr
-    - :pacbio
+    - :library_type_long_read
+long_read_plate:
+  heading: "Long Read Plate"
+  asset_type: "plate"
+  columns:
+    - :sanger_plate_id
+    - :well
+    - :sanger_sample_id
+    - :supplier_name
+    - :volume
+    - :concentration
+    - :sample_public_name
+    - :sample_taxon_id
+    - :sample_common_name
+    - :sample_ebi_accession_number
+    - :donor_id
+    - :genome_size
+    - :library_type_long_read
 heron:
   heading: "Heron"
   asset_type: "plate"

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -558,20 +558,6 @@ tube_multiplexed_chromium_library:
     - :sample_ebi_accession_number
     - :donor_id
     - :phenotype
-saphyr:
-  heading: "Saphyr"
-  asset_type: "1dtube"
-  columns:
-    - :sanger_tube_id
-    - :sanger_sample_id
-    - :supplier_name
-    - :volume
-    - :concentration
-    - :sample_public_name
-    - :sample_taxon_id
-    - :sample_common_name
-    - :sample_ebi_accession_number
-    - :donor_id
 tube_rack_default:
   heading: "Default Tube Rack"
   asset_type: "tube_rack"
@@ -621,6 +607,7 @@ long_read:
     - :sample_taxon_id
     - :sample_common_name
     - :sample_ebi_accession_number
+    - :phenotype
     - :donor_id
     - :genome_size
     - :library_type_long_read
@@ -638,6 +625,7 @@ long_read_plate:
     - :sample_taxon_id
     - :sample_common_name
     - :sample_ebi_accession_number
+    - :phenotype
     - :donor_id
     - :genome_size
     - :library_type_long_read

--- a/config/sample_manifest_excel/ranges.yml
+++ b/config/sample_manifest_excel/ranges.yml
@@ -47,7 +47,9 @@ library_type:
   scope: :alphabetical
 library_type_long_read:
   identifier: :name
-  scope: :long_read
+  scope:
+    - :from_record_loaders
+    - 001_long_read
   scope_on: LibraryType
 primer_panel:
   identifier: :name

--- a/config/sample_manifest_excel/ranges.yml
+++ b/config/sample_manifest_excel/ranges.yml
@@ -45,6 +45,10 @@ dna_storage_conditions:
 library_type:
   identifier: :name
   scope: :alphabetical
+library_type_long_read:
+  identifier: :name
+  scope: :long_read
+  scope_on: LibraryType
 primer_panel:
   identifier: :name
   scope: :alphabetical

--- a/db/migrate/20220128112324_add_uniqueness_index_to_library_type_name.rb
+++ b/db/migrate/20220128112324_add_uniqueness_index_to_library_type_name.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Library types should be unique, otherwise things get a little confusing
+class AddUniquenessIndexToLibraryTypeName < ActiveRecord::Migration[6.0]
+  def change
+    add_index :library_types, :name, unique: true
+  end
+end

--- a/db/migrate/20220204154227_remove_unused_metadata_columns.rb
+++ b/db/migrate/20220204154227_remove_unused_metadata_columns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Remove unused long-read pipeline columns
+class RemoveUnusedMetadataColumns < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :sample_metadata, :saphyr, :string
+    remove_column :sample_metadata, :pacbio, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_09_085100) do
+ActiveRecord::Schema.define(version: 2022_01_28_112324) do
 
   create_table "aliquot_indices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false
@@ -555,6 +555,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_085100) do
     t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["name"], name: "index_library_types_on_name", unique: true
   end
 
   create_table "library_types_request_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_28_112324) do
+ActiveRecord::Schema.define(version: 2022_02_04_154227) do
 
   create_table "aliquot_indices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false
@@ -1329,8 +1329,6 @@ ActiveRecord::Schema.define(version: 2022_01_28_112324) do
     t.datetime "updated_at"
     t.string "donor_id"
     t.integer "genome_size"
-    t.string "saphyr"
-    t.string "pacbio"
     t.datetime "date_of_consent_withdrawn"
     t.integer "user_id_of_consent_withdrawn"
     t.boolean "consent_withdrawn", default: false, null: false

--- a/features/api/library_creation_requests.feature
+++ b/features/api/library_creation_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube called "tube_1"
+    And I have an empty library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/api/library_creation_requests.feature
+++ b/features/api/library_creation_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube of stuff called "tube_1"
+    And I have a library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/api/multiplexed_library_creation_requests.feature
+++ b/features/api/multiplexed_library_creation_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube called "tube_1"
+    And I have an empty library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/api/multiplexed_library_creation_requests.feature
+++ b/features/api/multiplexed_library_creation_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube of stuff called "tube_1"
+    And I have a library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/api/requests.feature
+++ b/features/api/requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the requests API"
     And the UUID for the study "Testing the requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube called "tube_1"
+    And I have an empty library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @paging

--- a/features/api/requests.feature
+++ b/features/api/requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the requests API"
     And the UUID for the study "Testing the requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube of stuff called "tube_1"
+    And I have a library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @paging
@@ -71,4 +71,3 @@ And I have a "full" authorised user with the key "cucumber"
       | multiplexed library creation | Multiplexed library creation       | sample_tubes  | 1                  | 20               |
       | sequencing                   | Illumina-C Paired end sequencing   | library_tubes | 1                  | 21               |
       | sequencing                   | Illumina-C Single ended sequencing | library_tubes | 1                  | 21               |
-

--- a/features/api/sequencing_requests.feature
+++ b/features/api/sequencing_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube called "tube_1"
+    And I have an empty library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/api/sequencing_requests.feature
+++ b/features/api/sequencing_requests.feature
@@ -19,7 +19,7 @@ And I have a "full" authorised user with the key "cucumber"
 
     Given I have an active study called "Testing the sequencing requests API"
     And the UUID for the study "Testing the sequencing requests API" is "11111111-2222-3333-4444-000000000000"
-    And I have a library tube of stuff called "tube_1"
+    And I have a library tube called "tube_1"
     And the UUID for the library tube "tube_1" is "11111111-3333-4444-5555-666666666666"
 
   @read

--- a/features/plain/5413994_request_editing_using_legacy_properties.feature
+++ b/features/plain/5413994_request_editing_using_legacy_properties.feature
@@ -5,7 +5,7 @@ Feature: Editing a request as an administrator
     Given I am an "administrator" user logged in as "John Smith"
 
     Given I have an active study called "Testing editing a request"
-    And I have a library tube called "tube_1"
+    And I have an empty library tube called "tube_1"
     And I have already made a request for library tube "tube_1" within the study "Testing editing a request"
 
   Scenario: Editing a request

--- a/features/plain/5413994_request_editing_using_legacy_properties.feature
+++ b/features/plain/5413994_request_editing_using_legacy_properties.feature
@@ -5,7 +5,7 @@ Feature: Editing a request as an administrator
     Given I am an "administrator" user logged in as "John Smith"
 
     Given I have an active study called "Testing editing a request"
-    And I have a library tube of stuff called "tube_1"
+    And I have a library tube called "tube_1"
     And I have already made a request for library tube "tube_1" within the study "Testing editing a request"
 
   Scenario: Editing a request
@@ -25,4 +25,3 @@ Feature: Editing a request as an administrator
       | Fragment size required (from): | 11111111      |
       | Fragment size required (to):   | 22222222      |
       | Library type:                  | Standard      |
-

--- a/features/samples/xml_interface.feature
+++ b/features/samples/xml_interface.feature
@@ -50,8 +50,6 @@ Feature: The XML interface to the samples
           <property><name>Sibling</name><value/></property>
           <property><name>Strain</name><value/></property>
           <property><name>Genome Size</name><value/></property>
-          <property><name>Saphyr</name><value/></property>
-          <property><name>Pacbio</name><value/></property>
           <property><name>Genotype</name><value></value></property>
           <property><name>Phenotype</name><value></value></property>
           <property><name>Age</name><value></value></property>

--- a/features/support/step_definitions/5070230_requesting_additional_hiseq_sequencing_steps.rb
+++ b/features/support/step_definitions/5070230_requesting_additional_hiseq_sequencing_steps.rb
@@ -1,24 +1,21 @@
 # frozen_string_literal: true
 
-Given /^I have a library tube of stuff called "([^"]+)"$/ do |name|
-  # TODO: check if it should be :library_tube instead
+Given 'I have a library tube called {string}' do |name|
   FactoryBot.create(:empty_library_tube, name: name)
 end
 
-# rubocop:todo Layout/LineLength
-Given /^I have already made a request for library tube "([^"]+)" within the study "([^"]+)"$/ do |library_tube_name, study_name|
-  # rubocop:enable Layout/LineLength
-  library_tube = LibraryTube.find_by(name: library_tube_name) or
-    raise StandardError, "Cannot find library tube #{library_tube_name.inspect}"
-  study = Study.find_by(name: study_name) or raise StandardError, "Cannot find study with name #{study_name.inspect}"
+Given 'I have already made a request for library tube {string} within {study_name}' do |library_tube_name, study|
+  library_tube = LibraryTube.find_by!(name: library_tube_name)
+  library_type = LibraryType.find_by(name: 'Standard') || FactoryBot.create(:library_type, name: 'Standard')
   FactoryBot
-    .create(:library_creation_request_type)
+    .create(:library_creation_request_type, :with_library_types, library_type: library_type)
     .create!(
       asset: library_tube,
       study: study,
       request_metadata_attributes: {
         fragment_size_required_from: 111,
-        fragment_size_required_to: 222
+        fragment_size_required_to: 222,
+        library_type: 'Standard'
       }
     )
 end

--- a/features/support/step_definitions/5070230_requesting_additional_hiseq_sequencing_steps.rb
+++ b/features/support/step_definitions/5070230_requesting_additional_hiseq_sequencing_steps.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-Given 'I have a library tube called {string}' do |name|
-  FactoryBot.create(:empty_library_tube, name: name)
-end
-
 Given 'I have already made a request for library tube {string} within {study_name}' do |library_tube_name, study|
   library_tube = LibraryTube.find_by!(name: library_tube_name)
   library_type = LibraryType.find_by(name: 'Standard') || FactoryBot.create(:library_type, name: 'Standard')

--- a/features/support/step_definitions/asset_steps.rb
+++ b/features/support/step_definitions/asset_steps.rb
@@ -27,6 +27,10 @@ Given /^(?:I have )?a (sample|library) tube called "([^"]+)"$/ do |tube_type, na
   FactoryBot.create(:"#{tube_type}_tube", name: name)
 end
 
+Given 'I have an empty library tube called {string}' do |name|
+  FactoryBot.create(:empty_library_tube, name: name)
+end
+
 Then 'the name of {uuid} should be {string}' do |asset, name|
   assert_equal(name, asset.name)
 end

--- a/lib/record_loader/library_type_loader.rb
+++ b/lib/record_loader/library_type_loader.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# This file was automatically generated via `rails g record_loader`
+
+# RecordLoader handles automatic population and updating of database records
+# across different environments
+# @see https://rubydoc.info/github/sanger/record_loader/
+module RecordLoader
+  # Creates the specified plate types if they are not present
+  class LibraryTypeLoader < ApplicationRecordLoader
+    config_folder 'library_types'
+
+    def create_or_update!(name, options)
+      LibraryType.create_with(options).find_or_create_by!(name: name)
+    end
+
+    def names
+      @config.keys
+    end
+  end
+end

--- a/lib/tasks/record_loader/library_type.rake
+++ b/lib/tasks/record_loader/library_type.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This file was automatically generated via `rails g record_loader`
+namespace :record_loader do
+  desc 'Automatically generate LibraryType through LibraryTypeLoader'
+  task library_type: :environment do
+    RecordLoader::LibraryTypeLoader.new.create!
+  end
+end
+
+# Automatically run this record loader as part of record_loader:all
+# Remove this line if the task should only run when invoked explicitly
+task 'record_loader:all' => 'record_loader:library_type'

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -25,10 +25,8 @@ namespace :test do
     desc 'Verify that all FactoryBot factories are valid'
     task lint: :environment do
       require 'factory_bot'
-      Dir
-        .glob(File.expand_path(File.join(Rails.root, %w[spec factories ** *.rb])))
-        .sort
-        .each { |factory_filename| require factory_filename }
+
+      Rails.root.join('spec/factories/').glob('**/*.rb').sort.each { |factory_filename| require factory_filename }
 
       if Rails.env.test?
         DatabaseCleaner.strategy = :transaction

--- a/spec/data/record_loader/library_types/two_entry_example.yml
+++ b/spec/data/record_loader/library_types/two_entry_example.yml
@@ -1,0 +1,5 @@
+---
+# This file was automatically generated via `rails g record_loader`
+# You should modify it to match your particular model.
+Unique attribute: {}
+Unique attribute 2: {}

--- a/spec/data/sample_manifest_excel/columns.yml
+++ b/spec/data/sample_manifest_excel/columns.yml
@@ -768,46 +768,6 @@ genome_size:
     empty_cell:
     number_greater_than_zero:
     is_text:
-saphyr:
-  heading: SAPHYR?
-  unlocked: true
-  validation:
-    options:
-      type: :list
-      formula1: "$A$1:$A$2"
-      allowBlank: false
-      showDropDown: false
-      showInputMessage: true
-      promptTitle: "Will this sample be sequenced on Saphyr?"
-      prompt: "Please Enter Y or N."
-      showErrorMessage: true
-      errorStyle: :stop
-      errorTitle: "Will this sample be sequenced on Saphyr?"
-      error: "You must enter either Y or N."
-    range_name: :yes_no
-  conditional_formattings:
-    empty_cell:
-    is_error:
-pacbio:
-  heading: PACBIO?
-  unlocked: true
-  validation:
-    options:
-      type: :list
-      formula1: "$A$1:$A$2"
-      allowBlank: false
-      showDropDown: false
-      showInputMessage: true
-      promptTitle: "Will this sample be sequenced on Pacbio?"
-      prompt: "Please Enter Y or N."
-      showErrorMessage: true
-      errorStyle: :stop
-      errorTitle: "Will this sample be sequenced on Pacbio?"
-      error: "You must enter either Y or N."
-    range_name: :yes_no
-  conditional_formattings:
-    empty_cell:
-    is_error:
 primer_panel:
   heading: PRIMER PANEL
   unlocked: true

--- a/spec/data/sample_manifest_excel/manifest_types.yml
+++ b/spec/data/sample_manifest_excel/manifest_types.yml
@@ -508,20 +508,6 @@ test:
     - :sample_taxon_id
     - :sibling
     - :donor_id
-saphyr:
-  heading: "Saphyr"
-  asset_type: "1dtube"
-  columns:
-    - :sanger_tube_id
-    - :sanger_sample_id
-    - :supplier_name
-    - :volume
-    - :concentration
-    - :sample_public_name
-    - :sample_taxon_id
-    - :sample_common_name
-    - :sample_ebi_accession_number
-    - :donor_id
 tube_rack_default:
   heading: "Default Tube Rack"
   asset_type: "tube_rack"

--- a/spec/data/sample_manifest_excel/manifest_types.yml
+++ b/spec/data/sample_manifest_excel/manifest_types.yml
@@ -573,8 +573,7 @@ long_read:
     - :sample_ebi_accession_number
     - :donor_id
     - :genome_size
-    - :saphyr
-    - :pacbio
+    - :library_type
 heron:
   heading: "Heron"
   asset_type: "plate"

--- a/spec/factories/pulldown_factories.rb
+++ b/spec/factories/pulldown_factories.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     factory(:full_transfer_between_plates) do
       association(:source, factory: :full_plate)
       association(:destination, factory: :full_plate)
-      transfers { ('A'..'H').map { |r| (1..12).map { |c| "#{r}#{c}" } }.flatten.map { |w| [w, w] }.to_h }
+      transfers { ('A'..'H').map { |r| (1..12).map { |c| "#{r}#{c}" } }.flatten.to_h { |w| [w, w] } }
     end
   end
 
@@ -169,20 +169,23 @@ FactoryBot.define do
         fragment_size_required_from: 100,
         fragment_size_required_to: 400,
         bait_library: bait_library,
-        library_type: create(:library_type).name
+        library_type: 'Agilent Pulldown'
       }
     end
   end
 
   factory(:re_isc_request, class: 'Pulldown::Requests::ReIscLibraryRequest') do
     association(:request_type, factory: :library_request_type)
-    asset { |target| target.association(:well_with_sample_and_plate) }
-    target_asset { |target| target.association(:empty_well) }
+    association(:asset, factory: :well_with_sample_and_plate)
+    association(:target_asset, factory: :empty_well)
     request_purpose { :standard }
-    after(:build) do |request|
-      request.request_metadata.fragment_size_required_from = 100
-      request.request_metadata.fragment_size_required_to = 400
-      request.request_metadata.bait_library = BaitLibrary.first || create(:bait_library)
+    request_metadata_attributes do
+      {
+        fragment_size_required_from: 100,
+        fragment_size_required_to: 400,
+        bait_library: BaitLibrary.first || create(:bait_library),
+        library_type: 'Agilent Pulldown'
+      }
     end
   end
 

--- a/spec/factories/request_type_factories.rb
+++ b/spec/factories/request_type_factories.rb
@@ -8,6 +8,16 @@ FactoryBot.define do
     end
   end
 
+  trait :with_library_types do
+    transient { library_type { build :library_type } }
+
+    after(:build) do |request_type, evaluator|
+      request_type.library_types_request_types <<
+        create(:library_types_request_type, library_type: evaluator.library_type, request_type: request_type)
+      request_type.request_type_validators << create(:library_request_type_validator, request_type: request_type)
+    end
+  end
+
   factory :request_type do
     name { generate :request_type_name }
     key { generate :request_type_key }
@@ -35,7 +45,6 @@ FactoryBot.define do
       factory :library_request_type do
         request_class { IlluminaHtp::Requests::StdLibraryRequest }
         billable { true }
-        library_request_validators
 
         factory :gbs_request_type do
           request_class { IlluminaHtp::Requests::GbsRequest }
@@ -55,16 +64,8 @@ FactoryBot.define do
     end
 
     factory :library_creation_request_type do
-      transient { library_type { build :library_type } }
-
       target_asset_type { 'LibraryTube' }
       request_class { LibraryCreationRequest }
-
-      after(:build) do |request_type, evaluator|
-        request_type.library_types_request_types <<
-          create(:library_types_request_type, library_type: evaluator.library_type, request_type: request_type)
-        request_type.request_type_validators << create(:library_request_type_validator, request_type: request_type)
-      end
 
       factory :isc_library_request_type do
         asset_type { 'Well' }
@@ -202,6 +203,10 @@ FactoryBot.define do
   end
 
   factory :library_type do
-    name { 'Standard' }
+    sequence(:name) { |i| "Library Type #{i}" }
+
+    factory :library_type_standard do
+      name { 'Standard' }
+    end
   end
 end

--- a/spec/features/sample_manifests/create_manifest_spec.rb
+++ b/spec/features/sample_manifests/create_manifest_spec.rb
@@ -66,7 +66,7 @@ describe 'SampleManifest controller', sample_manifest: true do
 
     it 'indicate the purpose field is used for plates only' do
       visit(new_sample_manifest_path)
-      within('#sample_manifest_template') { expect(page).to have_selector('option', count: 18) }
+      within('#sample_manifest_template') { expect(page).to have_selector('option', count: 17) }
       select(created_purpose.name, from: 'Purpose')
       expect(page).to have_text('Used for plate manifests only')
     end

--- a/spec/features/submissions/bulk_submissions_spec.rb
+++ b/spec/features/submissions/bulk_submissions_spec.rb
@@ -18,6 +18,7 @@ describe 'Bulk submission', js: false do
     create :asset_group, name: 'assetgroup123', study: study, asset_count: 2
     visit bulk_submissions_path
     expect(page).to have_content('Bulk Submission New')
+    create :library_type, name: 'Standard'
   end
 
   shared_examples 'bulk submission file upload' do

--- a/spec/features/tag_group_spec.rb
+++ b/spec/features/tag_group_spec.rb
@@ -7,7 +7,7 @@ describe 'Create a new tag group' do
 
   before { create :adapter_type, name: 'My type' }
 
-  it 'view tag groups and create a new valid one', js: true do
+  it 'view tag groups and create a new valid one' do
     login_user user
     visit tag_groups_path
     expect(page).to have_content 'Listing Tag Groups'
@@ -24,7 +24,7 @@ describe 'Create a new tag group' do
     expect(page).to have_content 'Create a new tag layout template from this tag group'
   end
 
-  it 'view tag groups and attempt to create a new one with invalid oligos', js: true do
+  it 'view tag groups and attempt to create a new one with invalid oligos' do
     login_user user
     visit tag_groups_path
     expect(page).to have_content 'Listing Tag Groups'

--- a/spec/lib/record_loader/library_type_loader_spec.rb
+++ b/spec/lib/record_loader/library_type_loader_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'record_loader/library_type_loader'
+
+# This file was initially generated via `rails g record_loader`
+RSpec.describe RecordLoader::LibraryTypeLoader, type: :model, loader: true do
+  def a_new_record_loader
+    described_class.new(directory: test_directory, files: selected_files)
+  end
+  subject(:record_loader) { a_new_record_loader }
+
+  # Tests use a separate directory to avoid coupling your specs to the data
+  let(:test_directory) { Rails.root.join('spec/data/record_loader/library_types') }
+
+  context 'with two_entry_example selected' do
+    let(:selected_files) { 'two_entry_example' }
+
+    it 'creates two records' do
+      expect { record_loader.create! }.to change(LibraryType, :count).by(2)
+    end
+
+    # It is important that multiple runs of a RecordLoader do not create additional
+    # copies of existing records.
+    it 'is idempotent' do
+      record_loader.create!
+      expect { a_new_record_loader.create! }.not_to change(LibraryType, :count)
+    end
+
+    it 'sets attributes on the created records' do
+      record_loader.create!
+      expect(LibraryType.last).to have_attributes(name: 'Unique attribute 2')
+    end
+  end
+end

--- a/spec/models/library_type_spec.rb
+++ b/spec/models/library_type_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe LibraryType do
     end
   end
 
-  describe '::long_read' do
+  describe '::from_record_loaders' do
     let(:record_loader) { RecordLoader::LibraryTypeLoader.new(files: ['001_long_read']) }
     let(:expected_library_types) do
       %w[
@@ -65,7 +65,7 @@ RSpec.describe LibraryType do
     end
 
     it 'returns long_read library types only' do
-      expect(described_class.long_read.pluck(:name)).to eq(expected_library_types)
+      expect(described_class.from_record_loaders('001_long_read').pluck(:name)).to eq(expected_library_types)
     end
   end
 end

--- a/spec/models/library_type_spec.rb
+++ b/spec/models/library_type_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LibraryType do
+  subject { described_class.new(name: name) }
+
+  context 'without a name' do
+    let(:name) { '' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with a unique name' do
+    let(:name) { 'Unique' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'with a shared name' do
+    before { create :library_type, name: 'Shared' }
+
+    let(:name) { 'Shared' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'with a shared name (case-insensitive)' do
+    before { create :library_type, name: 'Shared' }
+
+    let(:name) { 'shared' }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe '::alphabetical' do
+    before do
+      create :library_type, name: 'Brilliant'
+      create :library_type, name: 'Amazing'
+      create :library_type, name: 'Cool'
+    end
+
+    it 'returns library types in alphabetical order' do
+      expect(described_class.alphabetical.pluck(:name)).to eq(%w[Amazing Brilliant Cool])
+    end
+  end
+
+  describe '::long_read' do
+    let(:record_loader) { RecordLoader::LibraryTypeLoader.new(files: ['001_long_read']) }
+    let(:expected_library_types) do
+      %w[
+        Pacbio_HiFi
+        Pacbio_HiFi_mplx
+        Pacbio_IsoSeq
+        PacBio_IsoSeq_mplx
+        Pacbio_Microbial_mplx
+        PacBio_Ultra_Low_Input
+        PacBio_Ultra_Low_Input_mplx
+      ]
+    end
+
+    before do
+      create :library_type, name: 'Not long read'
+      record_loader.create!
+    end
+
+    it 'returns long_read library types only' do
+      expect(described_class.long_read.pluck(:name)).to eq(expected_library_types)
+    end
+  end
+end

--- a/spec/models/linear_submission_spec.rb
+++ b/spec/models/linear_submission_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LinearSubmission do
     context 'when a multiplexed submission' do
       describe 'Customer decision propagation' do
         let(:library_creation_request_type) do
-          create :well_request_type, target_purpose: purpose, for_multiplexing: true
+          create :well_request_type, :with_library_types, target_purpose: purpose, for_multiplexing: true
         end
         let(:product_criteria) { create :product_criteria }
         let(:current_report) { create :qc_report, product_criteria: product_criteria }
@@ -121,8 +121,8 @@ RSpec.describe LinearSubmission do
     end
 
     context 'with two stages of library creation' do
-      let(:library_creation_stage1) { create :library_request_type }
-      let(:library_creation_stage2) { create :library_request_type }
+      let(:library_creation_stage1) { create :library_request_type, :with_library_types }
+      let(:library_creation_stage2) { create :library_request_type, :with_library_types }
       let(:mx_request_type) { create :multiplex_request_type }
       let(:request_type_option) do
         [library_creation_stage1.id, library_creation_stage2.id, mx_request_type.id, sequencing_request_type.id]
@@ -150,7 +150,7 @@ RSpec.describe LinearSubmission do
 
     context 'when a single-plex submission' do
       let(:assets) { (1..sx_asset_count).map { |i| create(:sample_tube, name: "Asset#{i}") } }
-      let(:library_creation_request_type) { create :library_creation_request_type }
+      let(:library_creation_request_type) { create :library_creation_request_type, :with_library_types }
       let(:request_type_option) { [library_creation_request_type.id, sequencing_request_type.id] }
       let(:submission) do
         create(
@@ -230,6 +230,7 @@ RSpec.describe LinearSubmission do
     end
     let(:lib_request_type) do
       create :library_creation_request_type,
+             :with_library_types,
              asset_type: 'SampleTube',
              target_asset_type: 'LibraryTube',
              initial_state: 'pending',

--- a/spec/models/parsers/cardinal_pbmc_count_parser_spec.rb
+++ b/spec/models/parsers/cardinal_pbmc_count_parser_spec.rb
@@ -16,9 +16,7 @@ require 'rails_helper'
 # DN871908M:H1	1029	1940000	8.37	74.00%	357	675000	2.35	1386	2610000	8.57
 
 def read_file(filename)
-  content = nil
-  File.open(filename, 'r') { |fd| content = fd.read }
-  content
+  File.read(filename)
 end
 
 RSpec.describe Parsers::CardinalPbmcCountParser, type: :model do
@@ -144,7 +142,7 @@ RSpec.describe Parsers::CardinalPbmcCountParser, type: :model do
       end
 
       it 'will create the qc results for well A1' do
-        well = plate.wells.find_by(map_id: 1)
+        well = plate.wells.located_at('A1').first
         qc_results = QcResult.where(asset_id: well.id)
 
         qc_result = qc_results.find_by(key: 'viability')
@@ -163,7 +161,7 @@ RSpec.describe Parsers::CardinalPbmcCountParser, type: :model do
       end
 
       it 'will create the qc results for well H1' do
-        well = plate.wells.find_by(map_id: 85)
+        well = plate.wells.located_at('H1').first
         qc_results = QcResult.where(asset_id: well.id)
 
         qc_result = qc_results.find_by(key: 'viability')

--- a/spec/models/request_type/validator/library_type_validator_spec.rb
+++ b/spec/models/request_type/validator/library_type_validator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe RequestType::Validator::LibraryTypeValidator, type: :model do
   let(:library_type) { create :library_type, name: 'MyLibraryType' }
-  let(:request_type) { create :library_creation_request_type, library_type: library_type }
+  let(:request_type) { create :library_creation_request_type, :with_library_types, library_type: library_type }
   let(:validator) { described_class.new(request_type.id) }
 
   context 'when initialising' do

--- a/spec/models/submission/submission_creator_spec.rb
+++ b/spec/models/submission/submission_creator_spec.rb
@@ -8,7 +8,13 @@ describe Submission::SubmissionCreator do
     let(:creator) { described_class.new(user, template_id: template.id) }
 
     context 'a full template' do
-      let(:template) { create :libray_and_sequencing_template }
+      let(:library_type) { create :library_type }
+      let(:library_creation_request_type) do
+        create(:library_request_type, :with_library_types, library_type: library_type)
+      end
+      let(:template) do
+        create :submission_template, request_types: [library_creation_request_type, create(:sequencing_request_type)]
+      end
 
       it 'finds the appropriate order fields' do
         expect(creator.order_fields.length).to eq 5
@@ -24,11 +30,11 @@ describe Submission::SubmissionCreator do
         )
         expect(creator.order_fields).to include(
           FieldInfo.new(
-            default_value: 'Standard',
+            default_value: library_type.name,
             display_name: 'Library type',
             key: :library_type,
             kind: 'Selection',
-            selection: ['Standard']
+            selection: [library_type.name]
           )
         )
         expect(creator.order_fields).to include(

--- a/spec/resources/api/v2/request_resource_spec.rb
+++ b/spec/resources/api/v2/request_resource_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Api::V2::RequestResource, type: :resource do
     let(:bait_library) { create :bait_library }
     let(:expected_metadata) do
       {
-        'library_type' => 'Standard',
+        'library_type' => 'Agilent Pulldown',
         'fragment_size_required_to' => '400',
         'fragment_size_required_from' => '100',
         'bait_library' => bait_library.name,

--- a/spec/sample_manifest_excel/download_spec.rb
+++ b/spec/sample_manifest_excel/download_spec.rb
@@ -188,36 +188,6 @@ RSpec.describe SampleManifestExcel::Download, type: :model, sample_manifest_exce
     end
   end
 
-  context 'Saphyr tube' do
-    before do
-      create(:saphyr_tube_purpose)
-
-      # asset_type might be changed, based on how upload would work
-      sample_manifest = create(:tube_sample_manifest_with_samples, asset_type: '1dtube')
-      sample_manifest.generate
-      @download =
-        described_class.new(
-          sample_manifest,
-          SampleManifestExcel.configuration.columns.saphyr.dup,
-          SampleManifestExcel.configuration.ranges.dup
-        )
-      save_file
-    end
-
-    it 'create an excel file' do
-      expect(File).to be_file('test.xlsx')
-    end
-
-    it 'create the two different types of worksheet' do
-      expect(spreadsheet.sheets.first).to eq('DNA Collections Form')
-      expect(spreadsheet.sheets.last).to eq('Ranges')
-    end
-
-    it 'have the correct number of columns' do
-      expect(download.column_list.count).to eq(SampleManifestExcel.configuration.columns.saphyr.count)
-    end
-  end
-
   context 'Long read tube' do
     before do
       create(:long_read_tube_purpose)

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -148,25 +148,6 @@ RSpec.describe SampleManifestExcel::Upload, type: :model, sample_manifest_excel:
       end
     end
 
-    context 'saphyr' do
-      let!(:columns) { SampleManifestExcel.configuration.columns.saphyr.dup }
-      let!(:download) { build(:test_download_tubes, columns: columns, manifest_type: 'saphyr') }
-
-      before { download.save(test_file_name) }
-
-      it 'has the correct processor' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9)
-        expect(upload.processor).not_to be_nil
-        expect(upload.processor).to be_one_d_tube
-      end
-
-      it 'updates all of the data' do
-        upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9)
-        upload.process(tag_group)
-        expect(upload).to be_processed
-      end
-    end
-
     context 'library tube with tag sequences' do
       let!(:columns) { SampleManifestExcel.configuration.columns.tube_library_with_tag_sequences.dup }
       let!(:download) do

--- a/spec/sequencescape_excel/range_spec.rb
+++ b/spec/sequencescape_excel/range_spec.rb
@@ -143,9 +143,21 @@ RSpec.describe SequencescapeExcel::Range, type: :model, sample_manifest_excel: t
 
     it 'adjusts to changes in option number' do
       previous_last_cell = range.last_cell.column
-      create :library_type
+      create :library_type, name: 'Other'
       assert_equal original_option_size + 1, range.last_column
       assert_equal previous_last_cell.next, range.last_cell.column
+    end
+  end
+
+  context 'with dynamic options and parameters' do
+    let(:attributes) do
+      { name: 'library_type', identifier: :name, scope: [:from_record_loaders, '001_long_read'], first_row: 4 }
+    end
+    let(:range) { described_class.new(attributes) }
+
+    it 'passes the options to the scope' do
+      allow(LibraryType).to receive(:from_record_loaders).with('001_long_read').and_return(LibraryType.all)
+      range.options
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,14 +46,15 @@ require './lib/capybara_failure_logger'
 require './lib/capybara_timeout_patches'
 require 'pry'
 
+# BUG: Intermittent, seemingly non deterministic reversion of downloads directory
+#      from Capybara.save_path (./tmp/capybara) to project root. See:
+#      https://github.com/sanger/sequencescape/issues/3511
 Capybara.register_driver :headless_chrome do |app|
-  enable_chrome_headless_downloads(Capybara.drivers[:selenium_chrome_headless].call(app))
+  Capybara.drivers[:selenium_chrome_headless].call(app).tap { |driver| enable_chrome_headless_downloads(driver) }
 end
 
 def enable_chrome_headless_downloads(driver)
   driver.options[:options].add_preference(:download, default_directory: Capybara.save_path)
-  driver.browser.download_path = Capybara.save_path
-  driver
 end
 
 Capybara.javascript_driver = ENV.fetch('JS_DRIVER', 'headless_chrome').to_sym

--- a/spec/support/download_helper.rb
+++ b/spec/support/download_helper.rb
@@ -11,7 +11,9 @@ module DownloadHelpers
 
   def self.downloaded_file(file, timeout: TIMEOUT)
     wait_for_download(file, timeout)
-    File.read(path_to(file)).tap { |_| remove_downloads }
+    File.read(path_to(file))
+  ensure
+    remove_downloads
   end
 
   def self.path_to(file)

--- a/spec/support/download_helper.rb
+++ b/spec/support/download_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Contains methods to assist with managing downloads via capybara and chrome
+# BUG: Intermittent, seemingly non deterministic reversion of downloads directory
+#      from Capybara.save_path (./tmp/capybara) to project root. See:
+#      https://github.com/sanger/sequencescape/issues/3511
 module DownloadHelpers
   TIMEOUT = 5
   PATH = Capybara.save_path
@@ -23,7 +27,7 @@ module DownloadHelpers
   def self.wait_for_download(file, timeout = TIMEOUT)
     Timeout.timeout(timeout) { sleep 0.1 until downloaded?(file) }
   rescue Timeout::Error
-    raise StandardError, "Could not open #{file} after #{timeout} seconds"
+    raise StandardError, "Could not open #{file} in #{PATH} after #{timeout} seconds"
   end
 
   def self.downloaded?(file)

--- a/test/unit/submission_template_test.rb
+++ b/test/unit/submission_template_test.rb
@@ -31,7 +31,8 @@ class SubmissionTemplateTest < ActiveSupport::TestCase
 
     context 'without input_field_infos' do
       setup do
-        @test_request_typ_b = create :library_creation_request_type
+        @library_type = create :library_type
+        @test_request_typ_b = create :library_creation_request_type, :with_library_types, library_type: @library_type
         @test_request_type = create :sequencing_request_type
         @order.request_types = [@test_request_typ_b, @test_request_type]
         @order.request_type_ids_list = [[@test_request_typ_b.id], [@test_request_type.id]]
@@ -41,8 +42,8 @@ class SubmissionTemplateTest < ActiveSupport::TestCase
         assert_equal 6, @order.input_field_infos.size
         assert_equal [37, 54, 76, 108], field('Read length').selection
         assert_equal 54, field('Read length').default_value
-        assert_equal ['Standard'], field('Library type').selection
-        assert_equal 'Standard', field('Library type').default_value
+        assert_equal [@library_type.name], field('Library type').selection
+        assert_equal @library_type.name, field('Library type').default_value
       end
     end
   end


### PR DESCRIPTION
Closes #3314

Changes proposed in this pull request:

* Add library type column to Long Read manifests
* Add library type record loader for pacbio library types
* Manifest loader supports parameters for scopes
* Library type has scope for loading from record loader files
*  Remove capybara-selenium - This one was a red herring, but is entirely redundant now. Hasn't been touched for years, isn't needed, and is just a security risk.
* Improve performance of sample manifest pages - This was when I thought the story was simple, and I'd be hitting this page a lot.
* Library type must now have a unique name - This was pretty much always a requirement, and violations were considered bugs. Now enforced.
* Fixed tests resulting from the above.
* Added documentation re: https://github.com/sanger/sequencescape/issues/3511 - I made some slight adjustments here while investigating to remove a few legacy configuration options which supported chrome on old CI setups. 
