### PR TITLE
library plate manifest fix

### DIFF
--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -180,7 +180,6 @@ library_type:
     empty_cell:
     is_error:
 library_type_long_read:
-  name: library_type
   heading: LIBRARY TYPE
   unlocked: true
   validation:


### PR DESCRIPTION
don't think this 'name' is meant to be here
- means that the 'library_type' column on the library plate manifest is filled with only long read library types
- 'name' doesn't appear on the config for any of the other columns
