### PR TITLE
Fix long read manifest upload

### DIFF
--- a/app/sequencescape_excel/sequencescape_excel/column.rb
+++ b/app/sequencescape_excel/sequencescape_excel/column.rb
@@ -10,6 +10,7 @@ module SequencescapeExcel
     include Helpers::Attributes
 
     setup_attributes :name,
+                     :updates,
                      :heading,
                      :number,
                      :type,
@@ -39,6 +40,7 @@ module SequencescapeExcel
 
     def initialize(attributes = {})
       super(default_attributes.merge(attributes))
+      self.updates ||= name
     end
 
     ##
@@ -46,7 +48,6 @@ module SequencescapeExcel
     # create a new validation object
     def validation=(validation)
       return if validation.nil?
-
       @validation = validation.is_a?(Hash) ? Validation.new(validation) : validation.dup
     end
 
@@ -79,11 +80,11 @@ module SequencescapeExcel
     end
 
     def metadata_field?
-      @metadata_field ||= Column.sample_metadata_model.respond_to?(name) unless specialised_field?
+      @metadata_field ||= Column.sample_metadata_model.respond_to?(updates) unless specialised_field?
     end
 
     def update_metadata(metadata, value)
-      metadata.send("#{name}=", value) if metadata_field?
+      metadata.send("#{updates}=", value) if metadata_field?
     end
 
     def attribute_value(detail)
@@ -173,7 +174,7 @@ module SequencescapeExcel
     attr_reader :attribute
 
     def classify_name
-      "SpecialisedField::#{name.to_s.delete('?').classify}"
+      "SpecialisedField::#{updates.to_s.delete('?').classify}"
     end
   end
 end

--- a/app/sequencescape_excel/sequencescape_excel/column.rb
+++ b/app/sequencescape_excel/sequencescape_excel/column.rb
@@ -97,7 +97,7 @@ module SequencescapeExcel
     end
 
     def specialised_field
-      @specialised_field ||= SequencescapeExcel.const_get(classify_name, false)
+      @specialised_field ||= SequencescapeExcel::SpecialisedField.const_get(classify_name, false)
     rescue NameError
       nil
     end
@@ -144,7 +144,7 @@ module SequencescapeExcel
       attr_reader :arguments
 
       def initialize(args, key, default_conditional_formattings)
-        @arguments = args.reverse_merge(name: key)
+        @arguments = args.merge(name: key)
         combine_conditional_formattings(default_conditional_formattings)
       end
 
@@ -153,7 +153,7 @@ module SequencescapeExcel
       end
 
       def inspect
-        "<#{self.class}: @name=#{name}, @heading=#{heading}, @number=#{number}, @type=#{type}, " \
+        "<#{self.class}: @name=#{name}, @updates=#{updates}, @heading=#{heading}, @number=#{number}, @type=#{type}, " \
           "@validation#{validation}, @value=#{value}, @unlocked=#{unlocked}, " \
           "@conditional_formattings=#{conditional_formattings}, @attribute=#{attribute}, @range=#{range}>"
       end
@@ -174,7 +174,7 @@ module SequencescapeExcel
     attr_reader :attribute
 
     def classify_name
-      "SpecialisedField::#{updates.to_s.delete('?').classify}"
+      updates.to_s.delete('?').classify
     end
   end
 end

--- a/app/sequencescape_excel/sequencescape_excel/list.rb
+++ b/app/sequencescape_excel/sequencescape_excel/list.rb
@@ -141,7 +141,7 @@ module SequencescapeExcel
     # Find by key and attribute.
     # If it doesn't exist it won't blow up but will return nil
     def find_by(key, value)
-      items.fetch(key).fetch(value.to_s.squish, nil)
+      items.dig(key, value.to_s.squish)
     end
 
     def find(value)

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -784,13 +784,6 @@ disease:
   unlocked: true
   conditional_formattings:
     empty_cell:
-legacy_donor_id:
-  updates: :donor_id
-  heading: DONOR ID (required for cancer samples)
-  unlocked: true
-  conditional_formattings:
-    empty_cell:
-  attribute: :sample_id
 genome_size:
   heading: GENOME SIZE
   unlocked: true
@@ -857,3 +850,14 @@ priority:
   conditional_formattings:
     empty_cell:
     is_number:
+# LEGACY COLUMNS
+# If a column heading changes, we still need to map historical manifests back
+# to the correct entry, as manifests may be uploaded, or re-uploaded a long time
+# after originally generated.
+legacy_donor_id:
+  updates: :donor_id
+  heading: DONOR ID (required for cancer samples)
+  unlocked: true
+  conditional_formattings:
+    empty_cell:
+  attribute: :sample_id

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -784,8 +784,8 @@ disease:
   unlocked: true
   conditional_formattings:
     empty_cell:
-donor_id2:
-  name: :donor_id
+legacy_donor_id:
+  updates: :donor_id
   heading: DONOR ID (required for cancer samples)
   unlocked: true
   conditional_formattings:

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -181,6 +181,7 @@ library_type:
     is_error:
 library_type_long_read:
   heading: LIBRARY TYPE
+  updates: library_type
   unlocked: true
   validation:
     options:

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -679,7 +679,6 @@ heron:
     - :subject
     - :disease
     - :sample_ebi_accession_number
-    - :donor_id2
     - :control_type
     - :priority
 cardinal:

--- a/spec/data/sample_manifest_excel/columns.yml
+++ b/spec/data/sample_manifest_excel/columns.yml
@@ -741,8 +741,8 @@ disease:
   unlocked: true
   conditional_formattings:
     empty_cell:
-donor_id2:
-  name: :donor_id
+legacy_donor_id:
+  updates: :donor_id
   heading: DONOR ID (required for cancer samples)
   unlocked: true
   conditional_formattings:

--- a/spec/data/sample_manifest_excel/manifest_types.yml
+++ b/spec/data/sample_manifest_excel/manifest_types.yml
@@ -85,7 +85,7 @@ plate_full:
     - :subject
     - :disease
     - :sample_ebi_accession_number
-    - :donor_id2
+    - :donor_id
     - :control_type
 plate_rnachip:
   heading: "RNA/ChIP Plate"
@@ -113,7 +113,7 @@ plate_rnachip:
     - :immunoprecipitate
     - :organism_part
     - :sample_ebi_accession_number
-    - :donor_id2
+    - :donor_id
 plate_chromium_library:
   heading: "Chromium Library Plate"
   asset_type: "library_plate"
@@ -255,7 +255,7 @@ tube_full:
     - :subject
     - :disease
     - :sample_ebi_accession_number
-    - :donor_id2
+    - :donor_id
 tube_rnachip:
   heading: "RNA/ChIP Tube"
   asset_type: "1dtube"
@@ -281,7 +281,7 @@ tube_rnachip:
     - :immunoprecipitate
     - :organism_part
     - :sample_ebi_accession_number
-    - :donor_id2
+    - :donor_id
 tube_multiplexed_library:
   heading: "Multiplexed Library Tube"
   asset_type: "multiplexed_library"
@@ -610,6 +610,5 @@ heron:
     - :subject
     - :disease
     - :sample_ebi_accession_number
-    - :donor_id2
     - :control_type
     - :priority

--- a/spec/factories/sample_manifest_excel/column_lists.rb
+++ b/spec/factories/sample_manifest_excel/column_lists.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
           build_list(:column, 5)
             .push(build(:sanger_sample_id_column))
             .push(build(:sanger_tube_id_column))
-            .push(build(:donor_id2_column))
+            .push(build(:donor_id_column))
         )
       end
     end

--- a/spec/factories/sample_manifest_excel/columns.rb
+++ b/spec/factories/sample_manifest_excel/columns.rb
@@ -91,12 +91,6 @@ FactoryBot.define do
       value { "DONOR ID #{number}" }
     end
 
-    factory :donor_id2_column do
-      name { :donor_id2 }
-      heading { 'DONOR ID (required for cancer samples)' }
-      value { "DONOR ID2 #{number}" }
-    end
-
     skip_create
   end
 end

--- a/spec/sequencescape_excel/column_spec.rb
+++ b/spec/sequencescape_excel/column_spec.rb
@@ -88,6 +88,13 @@ RSpec.describe SequencescapeExcel::Column, type: :model, sample_manifest_excel: 
     expect(metadata.donor_id).to eq('1234')
   end
 
+  it 'can update the field targets by :updates' do
+    column = described_class.new(options.merge(heading: 'DONOR ID', name: :legacy_donor_id, updates: :donor_id))
+    metadata = Sample::Metadata.new
+    column.update_metadata(metadata, '1234')
+    expect(metadata.donor_id).to eq('1234')
+  end
+
   context 'with no validation' do
     let(:column) { described_class.new(options.except(:validation)) }
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Removes the ability to customize a column 'name' as this results in the later column definitions over-writing earlier ones.
* Add updates: attribute to allow over-riding behaviour instead.
