### PR TITLE
Fix without_children scope query

### DIFF
--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -153,7 +153,9 @@ class Labware < Asset
   # The use of a sub-query here is a performance optimization. If we join onto the asset_links
   # table instead, rails is unable to paginate the results efficiently, as it needs to use DISTINCT
   # when working out offsets. This is substantially slower.
-  scope :without_children, -> { where.not(id: AssetLink.where(direct: true).select(:ancestor_id)) }
+  # The check that ancestor_id is nil is necessary - a single null value means the query returns empty results.
+  scope :without_children,
+        -> { where.not(id: AssetLink.where(direct: true).where.not(ancestor_id: nil).select(:ancestor_id)) }
   scope :include_labware_with_children, ->(filter) { filter ? all : without_children }
   scope :stock_plates, -> { where(plate_purpose_id: PlatePurpose.considered_stock_plate) }
 


### PR DESCRIPTION
Add a check that ancestor_id is not null to the without_children scope query. If there's a single record with that field as NULL, it breaks the whole query.

This was discovered while looking at the cause for DPL-267 (https://github.com/sanger/limber/issues/994)

See explanation of SQL stuff on stack overflow here - https://stackoverflow.com/questions/1406215/sql-select-where-not-in-subquery-returns-no-results

Run in training on 23/02/2022:
```
SELECT DISTINCT(id)
FROM labware;
-- 2,024,105

SELECT DISTINCT(ancestor_id)
FROM asset_links 
WHERE direct = true;
-- 935,396


SELECT Count(*)
FROM labware
WHERE id NOT IN (
  SELECT DISTINCT(ancestor_id)
  FROM asset_links 
  WHERE direct = true
);
-- Should be 2,024,105 - 935,396 = 1,088,709
-- Actually 0 ???

SELECT Count(*)
FROM labware
WHERE id NOT IN (
  SELECT DISTINCT(ancestor_id)
  FROM asset_links 
  WHERE direct = true
  AND ancestor_id IS NOT NULL
);
-- 1,088,710
```