### PR TITLE
Hotfix - new barcode format for Cardinal

### DIFF
--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -59,7 +59,8 @@ class Barcode < ApplicationRecord
          brants_bridge_v2: 37,
          uk_biocentre_v7: 38,
          east_london_genes_and_health: 39,
-         leamington_spa_v2: 40
+         leamington_spa_v2: 40,
+         east_london_genes_and_health_v2: 41
        }
 
   # Barcode formats which may be submitted via sample manifests
@@ -100,6 +101,7 @@ class Barcode < ApplicationRecord
     uk_biocentre_v7
     east_london_genes_and_health
     leamington_spa_v2
+    east_london_genes_and_health_v2
   ].freeze
 
   validate :barcode_valid?

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -503,4 +503,15 @@ module Barcode::FormatHandlers
   class EastLondonGenesAndHealth < BaseRegExBarcode
     self.format = /\A(?<prefix>S2)-046-(?<number>\d+)\z/
   end
+
+  # Support for East London Genes and Health
+  # As part of the Cardinal pipeline, as above
+  # Expected formats:
+  # S2-nnn-nnnnnn
+  # where n is a digit
+  # This is needed in addition to the above because the middle section represents the study
+  # in ELGH's system, and some participants come in under a different primary study.
+  class EastLondonGenesAndHealthV2 < BaseRegExBarcode
+    self.format = /\A(?<prefix>S2)-\d+-(?<number>\d+)\z/
+  end
 end

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -331,5 +331,19 @@ describe Barcode::FormatHandlers do
     it_has_an_invalid_barcode 'S2-046-_123456  '
     it_has_an_invalid_barcode " 1234567890NBC\na"
   end
+
+  describe Barcode::FormatHandlers::EastLondonGenesAndHealthV2 do
+    it_has_a_valid_barcode 'S2-046-12345', prefix: 'S2', number: 12_345, suffix: nil
+    it_has_a_valid_barcode 'S2-999-123456', prefix: 'S2', number: 123_456, suffix: nil
+    it_has_a_valid_barcode 'S2-044-123456', prefix: 'S2', number: 123_456, suffix: nil
+    it_has_an_invalid_barcode 'S2-123456'
+    it_has_an_invalid_barcode 'S2-046-_123456'
+    it_has_an_invalid_barcode 'INVALID'
+    it_has_an_invalid_barcode '123456789PLY-046-'
+    it_has_an_invalid_barcode 'S2_1234'
+    it_has_an_invalid_barcode ' S2-046-_123456'
+    it_has_an_invalid_barcode 'S2-046-_123456  '
+    it_has_an_invalid_barcode " 1234567890NBC\na"
+  end
   # rubocop:enable RSpec/EmptyExampleGroup
 end


### PR DESCRIPTION
The customer has said that the barcode middle section, previously said to be '046', could be a different number. This is because it denotes the study id (their end), and we could receive some samples that are under a different primary study.

They have said that the best option would be to make the "S2-" prefix fixed and the rest variable.

It looks like the Cardinal team have a workaround for the sample that came in today with an unexpected barcode format (relabelling as a different barcode), but I'm putting this in as a hotfix anyway in case that doesn't work or we get another one tomorrow.