### PR TITLE
Add required columns to other manifests

### DIFF
--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -102,6 +102,8 @@ plate_rnachip:
     - :volume
     - :concentration
     - :gender
+    - :country_of_origin
+    - :date_of_sample_collection
     - :dna_source
     - :gc_content
     - :sample_public_name
@@ -331,6 +333,8 @@ tube_rnachip:
     - :volume
     - :concentration
     - :gender
+    - :country_of_origin
+    - :date_of_sample_collection
     - :dna_source
     - :gc_content
     - :sample_public_name
@@ -611,6 +615,8 @@ long_read:
     - :donor_id
     - :genome_size
     - :library_type_long_read
+    - :country_of_origin
+    - :date_of_sample_collection
 long_read_plate:
   heading: "Long Read Plate"
   asset_type: "plate"
@@ -629,6 +635,8 @@ long_read_plate:
     - :donor_id
     - :genome_size
     - :library_type_long_read
+    - :country_of_origin
+    - :date_of_sample_collection
 heron:
   heading: "Heron"
   asset_type: "plate"


### PR DESCRIPTION
Added columns:
- :country_of_origin
- :date_of_sample_collection

To any manifests where we will be expected to accession samples.
I have not added them to the control or cardinal manifests
as we do not expect to need to accession these, and I don't
want to break established processes.

Closes #

Changes proposed in this pull request:

*
*
* ...
