### PR TITLE
DPL-318 Labwhere location report bug

### DIFF
--- a/config/config.rb
+++ b/config/config.rb
@@ -64,6 +64,8 @@ if Rails.env.development? || Rails.env.profile?
 
   configatron.pipelines_url = 'http://localhost:3000'
 
+  configatron.labwhere_api = 'localhost:3200/api'
+
   configatron.plate_barcode_service = 'http://localhost:3011'
   configatron.plate_volume_files = "#{Rails.root}/data/plate_volume/"
 

--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -192,7 +192,7 @@ module LabWhereClient
 
     def self.labwares(barcode)
       return [] if barcode.blank?
-      
+
       endpoint_name "locations/#{barcode}"
 
       attrs = LabWhere.new.get(self, 'labwares')

--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -182,7 +182,9 @@ module LabWhereClient
     def self.children(barcode)
       return [] if barcode.blank?
 
-      attrs = LabWhere.new.get(self, "#{barcode}/children")
+      endpoint_name "locations/#{barcode}"
+
+      attrs = LabWhere.new.get(self, 'children')
       return [] if attrs.nil?
 
       attrs.map { |locn_params| new(locn_params) }
@@ -190,8 +192,10 @@ module LabWhereClient
 
     def self.labwares(barcode)
       return [] if barcode.blank?
+      
+      endpoint_name "locations/#{barcode}"
 
-      attrs = LabWhere.new.get(self, "#{barcode}/labwares")
+      attrs = LabWhere.new.get(self, 'labwares')
       return [] if attrs.nil?
 
       attrs.map { |labware_params| Labware.new(labware_params) }


### PR DESCRIPTION
Closes #3558 

Changes proposed in this pull request:

* Fixed endpoints being called by LabWhereClient for Location children and labwares
* Added default labwhere url for local (probably some clever abstracted place where this exists but I couldn't find it)
