### PR TITLE
Update development schema from production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,9 +13,10 @@ mysql: &MYSQL
   adapter: mysql2
   username: <%= ENV.fetch('DBUSERNAME','root') %>
   password: <%= ENV['DBPASSWORD'] %>
-  encoding: utf8
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   properties:
-    characterSetResults: utf8
+    characterSetResults: utf8mb4
   pool: 5
   timeout: 5000
   reaping_frequency: 600

--- a/db/migrate/20220331093754_fix_development_encoding_issues.rb
+++ b/db/migrate/20220331093754_fix_development_encoding_issues.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# The default database encoding for the development database was wrong
+# We've fixed it up for newly created databases, but rather than forcing
+# developers to rebuild their database we'll set up a special development
+# only migration to keep things clean. This will:
+# - Update the default encoding
+# - Fix the incorrect encoding on any tables
+# Production and UAT are both correct, so we don't try and do anything there to
+# be safe.
+class FixDevelopmentEncodingIssues < ActiveRecord::Migration[6.0]
+  include MigrationExtensions::EncodingChanges
+
+  def up
+    say 'Checking Environment'
+    if migrate?
+      say "#{Rails.env} found, proceeding"
+      update_encoding
+      update_tables
+    else
+      say "#{Rails.env} found, skipping"
+    end
+  end
+
+  def update_encoding
+    execute("SET  @@character_set_database = 'utf8mb4', @@collation_database = 'utf8mb4_unicode_ci'")
+  end
+
+  def update_tables
+    change_encoding('bkp_lab_events', from: 'utf8', to: 'utf8mb4')
+    change_encoding('isndc_countries', from: 'utf8', to: 'utf8mb4')
+    change_encoding('pick_lists', from: 'utf8', to: 'utf8mb4')
+    change_encoding('racked_tubes', from: 'utf8', to: 'utf8mb4')
+    change_encoding('sample_compounds_components', from: 'utf8', to: 'utf8mb4')
+    change_encoding('tube_rack_statuses', from: 'utf8', to: 'utf8mb4')
+  end
+
+  def down
+    if migrate?
+      raise raise ActiveRecord::IrreversibleMigration, 'This is a remedial migration that shouldnot be reversed'
+    end
+
+    # We've not actually done anything, but something has obviously gone wrong elsewhere and someone is having a
+    # bad day. Lets get out of their way and reverse nothing.
+    say "This migration makes no changes in #{Rails.env}. " \
+          'No schema changes have been made, but the migration has been removed from schema_migrations'
+  end
+
+  def migrate?
+    Rails.env.development? || Rails.env.test?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_08_145114) do
+ActiveRecord::Schema.define(version: 2022_03_31_093754) do
 
   create_table "aliquot_indices", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false
@@ -259,18 +259,18 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.index ["updated_at"], name: "index_batches_on_updated_at"
   end
 
-  create_table "bkp_lab_events", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "bkp_lab_events", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "id", default: 0, null: false
-    t.text "description", size: :medium, collation: "utf8mb4_unicode_ci"
-    t.text "descriptors", size: :medium, collation: "utf8mb4_unicode_ci"
-    t.text "descriptor_fields", size: :medium, collation: "utf8mb4_unicode_ci"
+    t.text "description", size: :medium
+    t.text "descriptors", size: :medium
+    t.text "descriptor_fields", size: :medium
     t.integer "eventful_id"
-    t.string "eventful_type", limit: 50, collation: "utf8mb4_unicode_ci"
+    t.string "eventful_type", limit: 50
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "filename", collation: "utf8mb4_unicode_ci"
+    t.string "filename"
     t.binary "data"
-    t.text "message", size: :medium, collation: "utf8mb4_unicode_ci"
+    t.text "message", size: :medium
     t.integer "user_id"
     t.integer "batch_id"
   end
@@ -495,7 +495,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.string "equipment_type"
   end
 
-  create_table "isndc_countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "isndc_countries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "name", null: false
     t.integer "sort_priority", default: 0, null: false
     t.integer "validation_state", default: 0, null: false
@@ -701,7 +701,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.datetime "updated_at"
   end
 
-  create_table "pick_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "pick_lists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "state", default: 0, null: false
     t.integer "submission_id", null: false
     t.datetime "created_at", null: false
@@ -1036,7 +1036,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.index ["lot_id"], name: "index_lot_id"
   end
 
-  create_table "racked_tubes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "racked_tubes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.bigint "tube_rack_id"
     t.bigint "tube_id"
     t.string "coordinate"
@@ -1248,7 +1248,7 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.index ["user_id"], name: "index_roles_users_on_user_id"
   end
 
-  create_table "sample_compounds_components", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "sample_compounds_components", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "compound_sample_id", null: false
     t.integer "component_sample_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1749,10 +1749,10 @@ ActiveRecord::Schema.define(version: 2022_02_08_145114) do
     t.integer "tube_id", null: false
   end
 
-  create_table "tube_rack_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "tube_rack_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.string "barcode", null: false
     t.integer "status", null: false
-    t.text "messages"
+    t.text "messages", size: :medium
     t.integer "labware_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
We've had some minor issues with different default column types
on production vs development. Production is using the more robust
utf8mb4, which supports emoji. While we don't expect many 4 byte
characters, we should be consistent.

Update default database encoding

Include migration to fix up schema

Closes #

Changes proposed in this pull request:

*
*
* ...
