### PR TITLE
Add lanes_of_sequencing to submission resource

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -31,6 +31,7 @@ class Submission < ApplicationRecord # rubocop:todo Metrics/ClassLength
   # Once a submission has requests we REALLY shouldn't be destroying it.
   has_many :requests, inverse_of: :submission, dependent: :restrict_with_exception
   has_many :aliquots, through: :requests, source: :related_aliquots
+  has_many :sequencing_requests, inverse_of: :submission, dependent: :restrict_with_exception
 
   # Items are a legacy item that used to represent libraries which had yet to be made.
   # JG: I don't think we have any behaviour that depends on them. They can probably be removed.

--- a/app/resources/api/v2/order_resource.rb
+++ b/app/resources/api/v2/order_resource.rb
@@ -17,6 +17,7 @@ module Api
 
       # Attributes
       attribute :uuid, readonly: true
+      attribute :request_options, readonly: true
 
       # Filters
 

--- a/app/resources/api/v2/submission_resource.rb
+++ b/app/resources/api/v2/submission_resource.rb
@@ -11,7 +11,7 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
+      default_includes :uuid_object, :sequencing_requests
 
       # Associations:
 
@@ -26,6 +26,7 @@ module Api
       attribute :created_at, readonly: true
       attribute :updated_at, readonly: true
       attribute :used_tags, readonly: true
+      attribute :lanes_of_sequencing, readonly: true
 
       # Filters
       filter :uuid, apply: ->(records, value, _options) { records.with_uuid(value) }
@@ -33,6 +34,9 @@ module Api
       # Custom methods
       # These shouldn't be used for business logic, and a more about
       # I/O and isolating implementation details.
+      def lanes_of_sequencing
+        _model.sequencing_requests.size
+      end
 
       # Class method overrides
     end

--- a/spec/resources/api/v2/submission_resource_spec.rb
+++ b/spec/resources/api/v2/submission_resource_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 require './app/resources/api/v2/submission_resource'
 
 RSpec.describe Api::V2::SubmissionResource, type: :resource do
-  subject { described_class.new(resource_model, {}) }
+  subject(:resource) { described_class.new(resource_model, {}) }
 
-  let(:resource_model) { build_stubbed :submission }
+  let(:sequencing_requests) { build_stubbed_list(:sequencing_request, 3) }
+  let(:resource_model) { build_stubbed :submission, sequencing_requests: sequencing_requests }
 
   # Test attributes
   it 'works', :aggregate_failures do
@@ -16,6 +17,7 @@ RSpec.describe Api::V2::SubmissionResource, type: :resource do
     expect(subject).to have_attribute :state
     expect(subject).to have_attribute :created_at
     expect(subject).to have_attribute :updated_at
+    expect(subject).to have_attribute :lanes_of_sequencing
     expect(subject).not_to have_updatable_field(:id)
     expect(subject).not_to have_updatable_field(:uuid)
     expect(subject).not_to have_updatable_field(:state)
@@ -35,4 +37,9 @@ RSpec.describe Api::V2::SubmissionResource, type: :resource do
 
   # Custom method tests
   # Add tests for any custom methods you've added.
+  describe '#lanes_of_sequencing' do
+    it 'returns the number of sequencing requests in the submission' do
+      expect(resource.lanes_of_sequencing).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
Added to support GPL-239: https://github.com/sanger/limber/issues/375

Returns the number of sequencing requests in the submission. Note:
Does not include requests made via request additional sequencing.

I've not currently excluded cancelled requests, although perhaps should.