### PR TITLE
DPL-309 Add lifespan field to the V2 API Purpose resource

### DIFF
--- a/app/resources/api/v2/purpose_resource.rb
+++ b/app/resources/api/v2/purpose_resource.rb
@@ -19,6 +19,7 @@ module Api
       attribute :uuid, readonly: true
       attribute :name, readonly: true
       attribute :size, readonly: true
+      attribute :lifespan, readonly: true
 
       # Filters
       filter :name

--- a/spec/resources/api/v2/purpose_resource_spec.rb
+++ b/spec/resources/api/v2/purpose_resource_spec.rb
@@ -12,8 +12,12 @@ RSpec.describe Api::V2::PurposeResource, type: :resource do
   it 'works', :aggregate_failures do
     expect(subject).to have_attribute :uuid
     expect(subject).to have_attribute :name
+    expect(subject).to have_attribute :size
+    expect(subject).to have_attribute :lifespan
     expect(subject).not_to have_updatable_field(:id)
     expect(subject).not_to have_updatable_field(:uuid)
+    expect(subject).not_to have_updatable_field(:size)
+    expect(subject).not_to have_updatable_field(:lifespan)
   end
 
   # Updatable fields


### PR DESCRIPTION
- so it can be accessed through the V2 API by Asset Audits