### PR TITLE
Clean up gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-next_rails = ENV['BUNDLE_GEMFILE']&.end_with?('GemfileNext')
+next_rails = ENV.fetch('BUNDLE_GEMFILE', 'Gemfile')&.end_with?('GemfileNext')
 
 source 'https://rubygems.org'
 
@@ -112,12 +112,13 @@ group :development do
 
   # Automatically generate documentation
   gem 'yard', require: false
+  gem 'yard-activerecord', '~> 0.0.16'
 
   # MiniProfiler allows you to see the speed of a request conveniently on the page.
   # It also shows the SQL queries performed and allows you to profile a specific block of code.
   gem 'rack-mini-profiler'
 
-  # find unused routes and controller actions by runnung `rake traceroute` from CL
+  # find unused routes and controller actions by running `rake traceroute` from CL
   gem 'traceroute'
 
   # Pat of the JS assets pipleine
@@ -133,7 +134,6 @@ group :development, :linting do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'yard-activerecord', '~> 0.0.16'
 end
 
 group :linting, :test do
@@ -208,8 +208,6 @@ end
 group :cucumber do
   gem 'cucumber_github_formatter'
   gem 'cucumber-rails', require: false
-  gem 'mime-types'
-  gem 'rubyzip'
 end
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -192,15 +192,6 @@ group :test, :cucumber do
   gem 'simplecov', require: false
   gem 'timecop', require: false
 
-  # Simplifies shared transactions between server and test threads
-  # See: http://technotes.iangreenleaf.com/posts/the-one-true-guide-to-database-transactions-with-capybara.html
-  # Essentially does two things:
-  # - Patches rails to share a database connection between threads while Testing
-  # - Pathes rspec to ensure capybara has done its stuff before killing the connection
-  # Causing problems in Rails 6. Remove from Rspec, left in place for cucumber, but can
-  # probably be remove there as well.
-  gem 'transactional_capybara'
-
   # Keep webdriver in sync with chrome to prevent frustrating CI failures
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,7 +560,6 @@ DEPENDENCIES
   knapsack_pro
   launchy
   listen
-  mime-types
   minitest
   minitest-profiler
   mocha
@@ -594,7 +593,6 @@ DEPENDENCIES
   rubocop-rspec
   ruby-prof
   ruby-units
-  rubyzip
   sanger_barcode_format!
   sanger_warren
   sass-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,8 +479,6 @@ GEM
     timecop (0.9.5)
     traceroute (0.8.1)
       rails (>= 3.0.0)
-    transactional_capybara (0.2.0)
-      capybara
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -604,7 +602,6 @@ DEPENDENCIES
   test-prof
   timecop
   traceroute
-  transactional_capybara
   uglifier (>= 1.0.3)
   uuidtools
   vite_rails

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,10 +7,10 @@ require 'simplecov'
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
-ENV['RAILS_ENV'] ||= 'cucumber'
+selected_env = ENV['RAILS_ENV'] ||= 'cucumber'
 
-if ENV['RAILS_ENV'] != 'cucumber'
-  puts "You are running the cucumber specs with the #{ENV['RAILS_ENV']} environment."
+if selected_env != 'cucumber'
+  puts "You are running the cucumber specs with the #{selected_env} environment."
   puts "This can cause problems with gem loading. Please use 'cucumber' instead."
 end
 
@@ -55,19 +55,10 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-# We're using a gem to try and improve the robustness of this
-# https://github.com/iangreenleaf/transactional_capybara
 Cucumber::Rails::Database.javascript_strategy = :transaction
-require 'transactional_capybara'
-TransactionalCapybara.share_connection
 
 World(MultiTest::MinitestWorld)
 MultiTest.disable_autorun
-
-After('@javascript') do
-  # See https://github.com/iangreenleaf/transactional_capybara
-  TransactionalCapybara::AjaxHelpers.wait_for_ajax(page)
-end
 
 After() do |scenario|
   if scenario.failed?


### PR DESCRIPTION
- Remove transient dependencies from Gemfile
We had a few transient dependencies which we had to declare explicitly for historic reasons.

- Move yard-activerecord out of lint gemset
- Remove transactional_capybara as rails now handles this natively