### PR TITLE
DPL-377 [DRAFT] 'library_complete' and 'pool_released' events

### DIFF
--- a/app/models/broadcast_event/plate_library_complete.rb
+++ b/app/models/broadcast_event/plate_library_complete.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-class BroadcastEvent::PlateLibraryComplete < BroadcastEvent # rubocop:todo Style/Documentation
+# TODO: is this event type actually fired anywhere?
+# BroadcastEvent::PlateLibraryComplete records are present 2015-2017 only
+class BroadcastEvent::PlateLibraryComplete < BroadcastEvent
   set_event_type 'library_complete'
 
   # Properties takes :order_id

--- a/app/models/broadcast_event/pool_released.rb
+++ b/app/models/broadcast_event/pool_released.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
-# TODO: change the contents of this class - to be fired at 'charge and pass' stage instead.
-class BroadcastEvent::LibraryComplete < BroadcastEvent # rubocop:todo Style/Documentation
-  set_event_type 'library_complete'
+# At time of creation, this event type is fired when multiplexed library tubes are passed.
+# BroadcastEvent::LibraryComplete events used to be fired at this time point, however they were
+# redefined to be fired at the 'charge and pass' stage, because that made more sense to the users.
+class BroadcastEvent::PoolReleased < BroadcastEvent
+  set_event_type 'pool_released'
 
   # Properties takes :order_id
 

--- a/app/models/state_changer/mx_tube.rb
+++ b/app/models/state_changer/mx_tube.rb
@@ -14,7 +14,7 @@ module StateChanger
 
     def generate_events_for(orders)
       orders.each do |order_id|
-        BroadcastEvent::LibraryComplete.create!(seed: labware, user: user, properties: { order_id: order_id })
+        BroadcastEvent::PoolReleased.create!(seed: labware, user: user, properties: { order_id: order_id })
       end
     end
 


### PR DESCRIPTION
Duplicate LibraryComplete event to create new event type, PoolReleased
- Change StateChanger::MxTube to fire PoolReleased event rather than LibraryComplete
- Add 'todos' in LibraryComplete and PlateLibraryComplete event classes

Closes #3607 