### PR TITLE
Change help message template

### DIFF
--- a/app/views/user_query_mailer/request_for_help.html.erb
+++ b/app/views/user_query_mailer/request_for_help.html.erb
@@ -6,4 +6,4 @@ Dear developer,
   <p>What has happened: <%= @user_query.what_happened %>.</p>
   <p>What user expected to happen: <%= @user_query.what_expected %>.</p>
 
-Please, respond asap
+Thank you

--- a/spec/mailers/user_query_mailer_spec.rb
+++ b/spec/mailers/user_query_mailer_spec.rb
@@ -24,7 +24,7 @@ describe UserQueryMailer, type: :mailer do
           <p>What has happened: it did not work.</p>
           <p>What user expected to happen: it to work.</p>
 
-        Please, respond asap
+        Thank you
       HEREDOC
 
     it 'renders the headers' do


### PR DESCRIPTION
I've always found the 'respond asap'
a bit antagonistic, and I keep having
to remind myself that its our own
template.

Find this a bit friendlier.

Closes #

Changes proposed in this pull request:

*
*
* ...
