### PR TITLE
DPL-550 increase supplier name length in sample manifests

### DIFF
--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -267,21 +267,21 @@ supplier_name:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "20"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Supplier Sample Name"
-      prompt: "Please enter a sample name up to a maximum of 20 characters in length. Only include characters A-Z, 0-9 and underscores."
+      prompt: "Please enter a sample name up to a maximum of 40 characters in length. Only include characters A-Z, 0-9 and underscores."
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Supplier Sample Name"
-      error: "Name must be a maximum of 20 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 20
+        operand: 40
 cohort:
   heading: COHORT
   unlocked: true

--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -569,7 +569,7 @@ mother:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Mother - Supplier Sample Name"
@@ -577,13 +577,13 @@ mother:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Mother - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 father:
   heading: FATHER (optional)
@@ -592,7 +592,7 @@ father:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Father - Supplier Sample Name"
@@ -600,13 +600,13 @@ father:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Father - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 sibling:
   heading: SIBLING (optional)
@@ -615,7 +615,7 @@ sibling:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Sibling - Supplier Sample Name"
@@ -623,13 +623,13 @@ sibling:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Sibling - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 gc_content:
   heading: GC CONTENT

--- a/spec/data/sample_manifest_excel/columns.yml
+++ b/spec/data/sample_manifest_excel/columns.yml
@@ -231,21 +231,21 @@ supplier_name:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "20"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Supplier Sample Name"
-      prompt: "Please enter a sample name up to a maximum of 20 characters in length. Only include characters A-Z, 0-9 and underscores."
+      prompt: "Please enter a sample name up to a maximum of 40 characters in length. Only include characters A-Z, 0-9 and underscores."
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Supplier Sample Name"
-      error: "Name must be a maximum of 20 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 20
+        operand: 40
 cohort:
   heading: COHORT
   unlocked: true

--- a/spec/data/sample_manifest_excel/columns.yml
+++ b/spec/data/sample_manifest_excel/columns.yml
@@ -553,7 +553,7 @@ mother:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Mother - Supplier Sample Name"
@@ -561,13 +561,13 @@ mother:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Mother - Supplier Sample Name"
-      error: "Name must be a maximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 father:
   heading: FATHER (optional)
@@ -576,7 +576,7 @@ father:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Father - Supplier Sample Name"
@@ -584,13 +584,13 @@ father:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Father - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 sibling:
   heading: SIBLING (optional)
@@ -599,7 +599,7 @@ sibling:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Sibling - Supplier Sample Name"
@@ -607,13 +607,13 @@ sibling:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Sibling - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 gc_content:
   heading: GC CONTENT

--- a/spec/data/sample_manifest_excel/extract/columns.yml
+++ b/spec/data/sample_manifest_excel/extract/columns.yml
@@ -109,7 +109,7 @@ sibling:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "15"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Sibling - Supplier Sample Name"
@@ -117,13 +117,13 @@ sibling:
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Sibling - Supplier Sample Name"
-      error: "Name must be a miaximum of 15 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 15
+        operand: 40
     is_number:
 donor_id:
   heading: DONOR ID (required for EGA)

--- a/spec/data/sample_manifest_excel/extract/columns.yml
+++ b/spec/data/sample_manifest_excel/extract/columns.yml
@@ -14,21 +14,21 @@ supplier_name:
     options:
       type: :textLength
       operator: :lessThanOrEqual
-      formula1: "20"
+      formula1: "40"
       allowBlank: false
       showInputMessage: true
       promptTitle: "Supplier Sample Name"
-      prompt: "Please enter a sample name up to a maximum of 20 characters in length. Only include characters A-Z, 0-9 and underscores."
+      prompt: "Please enter a sample name up to a maximum of 40 characters in length. Only include characters A-Z, 0-9 and underscores."
       showErrorMessage: true
       errorStyle: :stop
       errorTitle: "Supplier Sample Name"
-      error: "Name must be a maximum of 20 characters in length."
+      error: "Name must be a maximum of 40 characters in length."
   conditional_formattings:
     empty_cell:
     len:
       formula:
         operator: ">"
-        operand: 20
+        operand: 40
 cohort:
   heading: COHORT
   unlocked: true

--- a/spec/sample_manifest_excel/worksheet_spec.rb
+++ b/spec/sample_manifest_excel/worksheet_spec.rb
@@ -634,5 +634,61 @@ RSpec.describe SampleManifestExcel::Worksheet, type: :model, sample_manifest_exc
         expect(SampleManifestAsset.find_by(sanger_sample_id: missing_ss_id)).to be_nil
       end
     end
+
+    context 'supplier sample name' do
+      let(:data1) do
+        hash = {supplier_name: 'N' * 40, mother: 'M' * 40, father: 'F' * 40, sibling: 'S' * 40}
+        data.merge(hash)
+      end
+      let(:attributes1) do
+        attributes.merge(data:data1)
+      end
+
+      it 'allows supplier sample name upto 40 characters' do
+        worksheet = SampleManifestExcel::Worksheet::TestWorksheet.new(attributes1)
+        save_file
+        column = worksheet.columns.find_by(:name, :supplier_name)
+        options = column.validation.options
+        expect(options[:type]).to eq(:textLength)
+        expect(options[:formula1]).to eq('40')
+        expect(options[:prompt]).to include('sample name up to a maximum of 40 characters')
+        expect(options[:error]).to include('must be a maximum of 40 characters')
+        expect(spreadsheet.sheet(0).cell(worksheet.first_row, column.number)).to eq(data1[:supplier_name])
+      end
+
+      it 'allows mother reference to an existing supplier sample name upto 40 characters' do
+        worksheet = SampleManifestExcel::Worksheet::TestWorksheet.new(attributes1)
+        save_file
+        column = worksheet.columns.find_by(:name, :mother)
+        options = column.validation.options
+        expect(options[:type]).to eq(:textLength)
+        expect(options[:formula1]).to eq('40')
+        expect(options[:prompt]).to include('existing supplier sample name')
+        expect(options[:error]).to include('must be a maximum of 40 characters')
+        expect(spreadsheet.sheet(0).cell(worksheet.first_row, column.number)).to eq(data1[:mother])
+      end
+
+      it 'allows father reference to an existing supplier sample name upto 40 characters' do
+        worksheet = SampleManifestExcel::Worksheet::TestWorksheet.new(attributes1)
+        save_file
+        column = worksheet.columns.find_by(:name, :father)
+        options = column.validation.options
+        expect(options[:formula1]).to eq('40')
+        expect(options[:prompt]).to include('existing supplier sample name')
+        expect(options[:error]).to include('must be a maximum of 40 characters')
+        expect(spreadsheet.sheet(0).cell(worksheet.first_row, column.number)).to eq(data1[:father])
+      end
+
+      it 'allows sibling reference to an existing supplier sample name upto 40 characters' do
+        worksheet = SampleManifestExcel::Worksheet::TestWorksheet.new(attributes1)
+        save_file
+        column = worksheet.columns.find_by(:name, :sibling)
+        options = column.validation.options
+        expect(options[:formula1]).to eq('40')
+        expect(options[:prompt]).to include('existing supplier sample name')
+        expect(options[:error]).to include('must be a maximum of 40 characters')
+        expect(spreadsheet.sheet(0).cell(worksheet.first_row, column.number)).to eq(data1[:sibling])
+      end
+    end
   end
 end

--- a/spec/sample_manifest_excel/worksheet_spec.rb
+++ b/spec/sample_manifest_excel/worksheet_spec.rb
@@ -636,13 +636,8 @@ RSpec.describe SampleManifestExcel::Worksheet, type: :model, sample_manifest_exc
     end
 
     context 'supplier sample name' do
-      let(:data1) do
-        hash = {supplier_name: 'N' * 40, mother: 'M' * 40, father: 'F' * 40, sibling: 'S' * 40}
-        data.merge(hash)
-      end
-      let(:attributes1) do
-        attributes.merge(data:data1)
-      end
+      let(:data1) { data.merge({ supplier_name: 'N' * 40, mother: 'M' * 40, father: 'F' * 40, sibling: 'S' * 40 }) }
+      let(:attributes1) { attributes.merge(data: data1) }
 
       it 'allows supplier sample name upto 40 characters' do
         worksheet = SampleManifestExcel::Worksheet::TestWorksheet.new(attributes1)


### PR DESCRIPTION
Closes #3695

**User story**

As a cellular SSR (Rich C) my customers would like to add more meaning to the sample supplier name. At present this is limited in the sample manifest to 20 characters and I would like this increased to 40.

**Who are the primary contacts for this story**
Rich C, Neil S

**
Supplier name fields are constrained in https://github.com/sanger/sequencescape/blob/bc7650296f98e8cbcd81bc521a656b68c5b7fde5/config/sample_manifest_excel/columns.yml
downstream databases  (prod/mlwh) are VARCHAR 255
NPG/SAM approached regarding their opinion in [RT](https://rt.sanger.ac.uk/Ticket/Display.html?id=764192) and they are OK with this increase

Tasks::

- [x] Increase supplier sample name length to 40
- [x] Increase mother length to 40 
- [x] Increase father length to 40
- [x] Increase sibling length to 40
