### PR TITLE
Add updated_at_gt as a filter for labware resources

### DIFF
--- a/app/resources/api/v2/shared_behaviour/labware.rb
+++ b/app/resources/api/v2/shared_behaviour/labware.rb
@@ -50,6 +50,8 @@ module Api::V2::SharedBehaviour::Labware
     filter :without_children, apply: ->(records, _value, _options) { records.without_children }
     filter :created_at_gt,
            apply: (lambda { |records, value, _options| records.where('labware.created_at > ?', value[0].to_date) })
+    filter :updated_at_gt,
+           apply: (lambda { |records, value, _options| records.where('labware.updated_at > ?', value[0].to_date) })
     filter :include_used, apply: ->(records, value, _options) { records.include_labware_with_children(value) }
   end
 

--- a/spec/resources/api/v2/labware_resource_spec.rb
+++ b/spec/resources/api/v2/labware_resource_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Api::V2::LabwareResource, type: :resource do
     it { is_expected.to filter(:purpose_id) }
     it { is_expected.to filter(:without_children) }
     it { is_expected.to filter(:created_at_gt) }
+    it { is_expected.to filter(:updated_at_gt) }
 
     # Associations
     it { is_expected.to have_one(:purpose).with_class_name('Purpose') }

--- a/spec/resources/api/v2/labware_resource_spec.rb
+++ b/spec/resources/api/v2/labware_resource_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Api::V2::LabwareResource, type: :resource do
     it { is_expected.to filter(:without_children) }
     it { is_expected.to filter(:created_at_gt) }
     it { is_expected.to filter(:updated_at_gt) }
+    it { is_expected.to filter(:include_used) }
 
     # Associations
     it { is_expected.to have_one(:purpose).with_class_name('Purpose') }


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/1220

Changes proposed in this pull request:

* Add a new filter option for labware resources to be filtered by updated_at as well as created_at
