### PR TITLE
Add name for factory intermediate input

### DIFF
--- a/app/models/plate_purpose/additional_input.rb
+++ b/app/models/plate_purpose/additional_input.rb
@@ -2,8 +2,9 @@
 #
 # Class to support a different state machine for inputs added
 # in the middle of a workflow
-class PlatePurpose::IntermediateInput < PlatePurpose
+class PlatePurpose::AdditionalInput < PlatePurpose
   READY_STATE = 'passed'
+  self.state_changer = StateChanger::InputPlate
   def state_of(plate)
     return READY_STATE if valid_intermediate_input?(plate)
     super(plate)

--- a/config/default_records/plate_purposes/009_bioscan_purposes.yml
+++ b/config/default_records/plate_purposes/009_bioscan_purposes.yml
@@ -17,6 +17,6 @@ LILYS-96 Stock:
 # from the LILYS-96 Stock parent.
 # These plates include controls.
 LBSN-96 Lysate:
-  type: PlatePurpose::IntermediateInput
+  type: PlatePurpose::AdditionalInput
   stock_plate: true
   cherrypickable_target: false

--- a/spec/factories/purpose_factories.rb
+++ b/spec/factories/purpose_factories.rb
@@ -15,11 +15,12 @@ FactoryBot.define do
 
       factory :illumina_htp_initial_stock_tube_purpose, class: 'IlluminaHtp::InitialStockTubePurpose'
     end
+  end
 
-    factory(:purpose_intermediate_input, class: 'PlatePurpose::IntermediateInput') do
-      target_type { 'Plate' }
-      size { '96' }
-    end
+  factory(:purpose_additional_input, class: 'PlatePurpose::AdditionalInput') do
+    name { generate(:purpose_name) + rand(9999).to_s }
+    target_type { 'Plate' }
+    size { '96' }
   end
 
   factory :strip_tube_purpose, class: 'PlatePurpose' do

--- a/spec/models/plate_purpose/additional_input_spec.rb
+++ b/spec/models/plate_purpose/additional_input_spec.rb
@@ -4,8 +4,12 @@ require 'rails_helper'
 
 # This behaviour is in use for defining inputs that can be added in
 # the middle of a workflow
-describe PlatePurpose::IntermediateInput do
-  let(:plate_purpose_input) { create(:purpose_intermediate_input) }
+describe PlatePurpose::AdditionalInput do
+  let(:plate_purpose_input) { create(:purpose_additional_input) }
+
+  it 'does not have any errors' do
+    expect(plate_purpose_input.errors.messages.to_a).to eq([])
+  end
 
   describe '#state_of' do
     subject(:state_of) { plate_purpose_input.state_of(plate) }
@@ -14,6 +18,8 @@ describe PlatePurpose::IntermediateInput do
 
     context 'with no requests' do
       it 'is pending' do
+        plate_purpose_input.validate
+        expect(plate_purpose_input.errors.messages.to_a).to eq([])
         expect(state_of).to eq('pending')
       end
     end
@@ -24,6 +30,8 @@ describe PlatePurpose::IntermediateInput do
 
       context 'with no library requests' do
         it 'is pending' do
+          plate_purpose_input.validate
+          expect(plate_purpose_input.errors.messages.to_a).to eq([])
           expect(state_of).to eq('pending')
         end
       end
@@ -35,6 +43,8 @@ describe PlatePurpose::IntermediateInput do
         end
 
         it 'is pending' do
+          plate_purpose_input.validate
+          expect(plate_purpose_input.errors.messages.to_a).to eq([])
           expect(state_of).to eq('pending')
         end
       end
@@ -45,6 +55,8 @@ describe PlatePurpose::IntermediateInput do
 
       context 'with no library requests' do
         it 'is pending' do
+          plate_purpose_input.validate
+          expect(plate_purpose_input.errors.messages.to_a).to eq([])
           expect(state_of).to eq('pending')
         end
       end
@@ -56,6 +68,8 @@ describe PlatePurpose::IntermediateInput do
         end
 
         it 'is passed' do
+          plate_purpose_input.validate
+          expect(plate_purpose_input.errors.messages.to_a).to eq([])
           expect(state_of).to eq('passed')
         end
       end


### PR DESCRIPTION
Use class instead of factory

Generate new name

Test with new

With new (should fail)

With create

Using factory

Add a random string to the factory

Print errors, maybe that will give more clues about the problem

Validating (hum...)

Test the purpose do not have errors before any action

Try with state

Try with alphabetic order

Rename alphabetical

Closes #

Changes proposed in this pull request:

*
*
* ...
