### PR TITLE
Add new barcode formats for RVI plates from lighthouse labs

### DIFF
--- a/app/models/barcode.rb
+++ b/app/models/barcode.rb
@@ -61,7 +61,9 @@ class Barcode < ApplicationRecord
          east_london_genes_and_health: 39,
          leamington_spa_v2: 40,
          east_london_genes_and_health_v2: 41,
-         sequencescape22: 42
+         sequencescape22: 42,
+         plymouth_v2: 43,
+         leamington_spa_v3: 44
        }
 
   # Barcode formats which may be submitted via sample manifests
@@ -104,6 +106,8 @@ class Barcode < ApplicationRecord
     leamington_spa_v2
     east_london_genes_and_health_v2
     sequencescape22
+    plymouth_v2
+    leamington_spa_v3
   ].freeze
 
   validate :barcode_valid?

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -502,10 +502,10 @@ module Barcode::FormatHandlers
   # samples to Sanger.
   #
   # Expected formats:
-  # LML_ELUTEnnnnnnnn
+  # ELUTEnnnnnnnn
   # where n is a digit
   class LeamingtonSpaV3 < BaseRegExBarcode
-    self.format = /\A(?<prefix>LML_ELUTE)(?<number>\d{8})\z/
+    self.format = /\A(?<prefix>ELUTE)(?<number>\d{8})\z/
   end
 
   # Support for Newcastle centre

--- a/app/models/barcode/format_handlers.rb
+++ b/app/models/barcode/format_handlers.rb
@@ -438,10 +438,20 @@ module Barcode::FormatHandlers
   end
 
   # Expected formats:
-  # PLY-chp-nnnnnnn.csv
+  # PLY-chp-nnnnnnn
   # where n is a digit
   class PlymouthV1 < BaseRegExBarcode
     self.format = /\A(?<prefix>PLY)-chp-(?<number>\d+)\z/
+  end
+
+  # This format was used by the Plymouth LHL for sending non-cherrypicked
+  # samples to Sanger.
+  #
+  # Expected formats:
+  # BnnnnnnRNAEXT
+  # where n is a digit
+  class PlymouthV2 < BaseRegExBarcode
+    self.format = /\A(?<prefix>B)(?<number>\d{6})(?<suffix>RNAEXT)\z/
   end
 
   # Added to support 3 ad hoc plates from UK Biocentre
@@ -486,6 +496,16 @@ module Barcode::FormatHandlers
   # where n is a digit
   class LeamingtonSpaV2 < BaseRegExBarcode
     self.format = /\A(?<prefix>RFLCP)(?<number>\d{8})\z/
+  end
+
+  # This format was used by the Leamington Spa LHL for sending non-cherrypicked
+  # samples to Sanger.
+  #
+  # Expected formats:
+  # LML_ELUTEnnnnnnnn
+  # where n is a digit
+  class LeamingtonSpaV3 < BaseRegExBarcode
+    self.format = /\A(?<prefix>LML_ELUTE)(?<number>\d{8})\z/
   end
 
   # Support for Newcastle centre

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -316,15 +316,14 @@ describe Barcode::FormatHandlers do
   end
 
   describe Barcode::FormatHandlers::LeamingtonSpaV3 do
-    it_has_a_valid_barcode 'LML_ELUTE12345678', prefix: 'LML_ELUTE', number: 12_345_678, suffix: nil
-    it_has_a_valid_barcode 'LML_ELUTE00001234', prefix: 'LML_ELUTE', number: 1_234, suffix: nil
-    it_has_an_invalid_barcode 'LML_ELUTE000001234'
-    it_has_an_invalid_barcode 'LML_ELUTE0001234'
-    it_has_an_invalid_barcode 'MLM_ELUTE00001234'
-    it_has_an_invalid_barcode 'LML_ETULE00001234'
-    it_has_an_invalid_barcode "LML_ETULE\n00001234"
-    it_has_an_invalid_barcode 'LML_ETULE00001234  '
-    it_has_an_invalid_barcode '  LML_ETULE00001234'
+    it_has_a_valid_barcode 'ELUTE12345678', prefix: 'ELUTE', number: 12_345_678, suffix: nil
+    it_has_a_valid_barcode 'ELUTE00001234', prefix: 'ELUTE', number: 1_234, suffix: nil
+    it_has_an_invalid_barcode 'ELUTE000001234'
+    it_has_an_invalid_barcode 'ELUTE0001234'
+    it_has_an_invalid_barcode 'ETULE00001234'
+    it_has_an_invalid_barcode "ELUTE\n00001234"
+    it_has_an_invalid_barcode 'ELUTE00001234  '
+    it_has_an_invalid_barcode '  ELUTE00001234'
     it_has_an_invalid_barcode 'INVALID'
   end
 

--- a/spec/models/barcode/format_handlers_spec.rb
+++ b/spec/models/barcode/format_handlers_spec.rb
@@ -261,6 +261,21 @@ describe Barcode::FormatHandlers do
     it_has_an_invalid_barcode " 1234567890NBC\na"
   end
 
+  describe Barcode::FormatHandlers::PlymouthV2 do
+    it_has_a_valid_barcode 'B012345RNAEXT', prefix: 'B', number: 12_345, suffix: 'RNAEXT'
+    it_has_a_valid_barcode 'B123456RNAEXT', prefix: 'B', number: 123_456, suffix: 'RNAEXT'
+    it_has_an_invalid_barcode 'C012345RNAEXT'
+    it_has_an_invalid_barcode 'B1234RNAEXT'
+    it_has_an_invalid_barcode 'B012345DNAEXT'
+    it_has_an_invalid_barcode 'BB012345RNAEXT'
+    it_has_an_invalid_barcode '012345RNAEXT'
+    it_has_an_invalid_barcode "B012345RNA\nEXT"
+    it_has_an_invalid_barcode 'B-012345-RNAEXT'
+    it_has_an_invalid_barcode '  B012345RNAEXT'
+    it_has_an_invalid_barcode 'B012345RNAEXT  '
+    it_has_an_invalid_barcode 'INVALID'
+  end
+
   describe Barcode::FormatHandlers::UkBiocentreV6 do
     it_has_a_valid_barcode 'RNAsst10088', prefix: 'RNAsst', number: 10_088, suffix: nil
     it_has_a_valid_barcode 'RNAsst0539473', prefix: 'RNAsst', number: 539_473, suffix: nil
@@ -298,6 +313,19 @@ describe Barcode::FormatHandlers do
     it_has_an_invalid_barcode '12345678912'
     it_has_an_invalid_barcode 'AB123456700000001'
     it_has_an_invalid_barcode '00210783400000001 '
+  end
+
+  describe Barcode::FormatHandlers::LeamingtonSpaV3 do
+    it_has_a_valid_barcode 'LML_ELUTE12345678', prefix: 'LML_ELUTE', number: 12_345_678, suffix: nil
+    it_has_a_valid_barcode 'LML_ELUTE00001234', prefix: 'LML_ELUTE', number: 1_234, suffix: nil
+    it_has_an_invalid_barcode 'LML_ELUTE000001234'
+    it_has_an_invalid_barcode 'LML_ELUTE0001234'
+    it_has_an_invalid_barcode 'MLM_ELUTE00001234'
+    it_has_an_invalid_barcode 'LML_ETULE00001234'
+    it_has_an_invalid_barcode "LML_ETULE\n00001234"
+    it_has_an_invalid_barcode 'LML_ETULE00001234  '
+    it_has_an_invalid_barcode '  LML_ETULE00001234'
+    it_has_an_invalid_barcode 'INVALID'
   end
 
   describe Barcode::FormatHandlers::Newcastle do


### PR DESCRIPTION
Closes #3845 

Changes proposed in this pull request:

* Add barcode formats for lighthouse labs that sent non-cherrypicked plates to Sanger.
