### PR TITLE
Fixing build issue again

### DIFF
--- a/compile-build
+++ b/compile-build
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e # Exit immediately if something fails
 export NODE_ENV=production
-export RAILS_ENV=development
+export RAILS_ENV=production
 export BUILDING_APP=true
+export SECRET_KEY_BASE=to_be_replaced
 echo 'Compiling assets'
 bundle exec rake vite:build
 echo 'Generating sha'

--- a/config/database.yml
+++ b/config/database.yml
@@ -52,6 +52,12 @@ cucumber:
   <<: *test
   database: sequencescape_test<%= ENV['TEST_ENV_NUMBER'] %><%= suffix %>_cuke
 
+# We need to have some dummy configuration here when the app is being packaged up (vite:build),
+# because the initializers are run.
+# The config will be overwritten when the app is deployed.
+production:
+  <<: *MYSQL
+
 # These other connections are exported during deploy, from:
 # ssh://git/repos/git/psd/config/private.git/
 ### Staging

--- a/config/warren.yml
+++ b/config/warren.yml
@@ -40,7 +40,6 @@ cucumber:
 # The value will be overwritten when the app is deployed.
 production:
   type: test
-
 # You are encouraged to use the WARREN_CONNECTION_URI environmental
 # variable to configure your production environment. Under no
 # circumstances should you commit sensitive information in the file.

--- a/config/warren.yml
+++ b/config/warren.yml
@@ -34,6 +34,13 @@ cucumber:
   type: test
   config:
     routing_key_prefix: test
+
+# We need to pass some value to Warren when the app is being packaged up (vite:build),
+# because the initializers are run.
+# The value will be overwritten when the app is deployed.
+production:
+  type: test
+
 # You are encouraged to use the WARREN_CONNECTION_URI environmental
 # variable to configure your production environment. Under no
 # circumstances should you commit sensitive information in the file.


### PR DESCRIPTION
change RAILS_ENV back to  during build
- having as  didn't work because vite:built created a  folder instead of a  folder, but then in UAT it was looking for a  folder


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
