### PR TITLE
DPL-815 bug fix - new cherrypick submission page issue

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -114,7 +114,8 @@ module Sequencescape
         RequestType::Validator::FlowcellTypeValidator,
         ActionController::Parameters,
         Set,
-        Range
+        Range,
+        FieldInfo
       ]
     end
   end


### PR DESCRIPTION
add FieldInfo to the list allowed for serialization
- was causing bug in the 'new submission' page, when trying to deserialize submission_parameters on a submission template

Haven't managed to test it locally - will test it in UAT and then try to create a test for it locally, so it doesn't happen again.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
