### PR TITLE
DPL-809 manifest tweak

### DIFF
--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -758,7 +758,6 @@ donor_id_mandatory:
   unlocked: true
   conditional_formattings:
     empty_mandatory_cell:
-  attribute: :sample_id
 phenotype:
   heading: PHENOTYPE (required for EGA)
   unlocked: true


### PR DESCRIPTION
don't pre-populate the 'mandatory' version of donor id
- the user should be encouraged to fill it in themselves

Having trouble getting the donor id to be truly mandatory, on upload. Think I will create a new story for this.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
