### PR TITLE
Remove the URL has changed banner

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -287,6 +287,8 @@ module ApplicationHelper # rubocop:todo Style/Documentation
     end
   end
 
+  # rubocop:enable Metrics/MethodLength
+
   #
   # Ideally we don't want inline script tags, however there is a fair chunk of
   # legacy code, some of which isn't trivial to migrate, as it uses erb to
@@ -305,19 +307,6 @@ module ApplicationHelper # rubocop:todo Style/Documentation
       yield
       concat '})'
     end
-  end
-
-  # rubocop:enable Metrics/MethodLength
-
-  # Used in _header.html.erb. Can be removed after users have been given a time period to switch over.
-  def old_url
-    permitted_urls = %w[
-      https://sequencescape.psd.sanger.ac.uk
-      https://uat.sequencescape.psd.sanger.ac.uk
-      https://uat2.sequencescape.psd.sanger.ac.uk
-      https://training.sequencescape.psd.sanger.ac.uk
-    ]
-    return true unless permitted_urls.include?(request.base_url)
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,16 +40,6 @@
   </div><!-- /.navbar-collapse -->
 </nav>
 
-<% if old_url && !Rails.env.development? %>
-  <!-- This alert can be removed after users have been given a time period to switch over. -->
-  <div>
-    <%= alert(:warning) do %>
-      The Sequencescape URL has changed. Please switch to using the new URL by 9th May:
-      <%= link_to 'https://sequencescape.psd.sanger.ac.uk', 'https://sequencescape.psd.sanger.ac.uk', class: "alert-link" %>
-    <% end %>
-  </div>
-<% end %>
-
 <%- unless custom_text("app_info_box", 1).blank? -%>
     <div id="app-info-box" class="well well-sm">
       <span><%= custom_text("app_info_box", 1) %></span>


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Remove the banner `The Sequencescape URL has changed. Please switch to using the new URL by 9th May: https://sequencescape.psd.sanger.ac.uk/` and related code.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check version_  
