### PR TITLE
Fix Create Plate Template page

### DIFF
--- a/app/views/plate_templates/_layout_plate.html.erb
+++ b/app/views/plate_templates/_layout_plate.html.erb
@@ -64,9 +64,9 @@
   function toggleEmptyWell(event) {
     const well = event.target;
     const wellPosition = well.dataset.wellPosition;
-    const row = parseInt(well.dataset.row);
-    const col = parseInt(well.dataset.col);
-    const plateCols = parseInt(well.dataset.plate_cols);
+    const row = parseInt(well.dataset.row, 10);
+    const col = parseInt(well.dataset.col, 10);
+    const plateCols = parseInt(well.dataset.plate_cols, 10);
 
     if(well.classList.contains('empty')) {
       well.classList.remove('empty');


### PR DESCRIPTION
#### Changes proposed in this pull request

The Create Plate Template page no longer works with the error:

> [Content Security Policy “Refused to execute inline event handler” error](https://stackoverflow.com/questions/58652892/content-security-policy-refused-to-execute-inline-event-handler-error)

More info: [Chrome CSP Docs](https://developer.chrome.com/docs/apps/contentSecurityPolicy/)

This PR fixes this by replacing the inline functionality with proper event handlers.
A properly integrated fix would be more desirable, but this will do to just get it working.

#### Related to

#3581 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
