### PR TITLE
DPL-925: add new TwinTecOnRedBlockOnAdapter plate type

### DIFF
--- a/config/default_records/plate_types/plate_types.yml
+++ b/config/default_records/plate_types/plate_types.yml
@@ -15,3 +15,5 @@ Bio-Rad_96PCR:
   maximum_volume: 200
 4titude 96:
   maximum_volume: 180
+TwinTecOnRedBlockOnAdapter:
+  maximum_volume: 150


### PR DESCRIPTION
Closes [DPL-925](https://github.com/sanger/sequencescape/issues/3902)

#### Changes proposed in this pull request

- Add new plate type: TwinTecOnRedBlockOnAdapter
  - maximum_volume: 150

#### Deployment:

```
rake record_loader:plate_type  
```

#### Acceptance Criteria

- [x] Generate a new plate type with the name TwinTecOnRedBlockOnAdapter
- [x] Allow selection of the new plate type in the Scan Robot And Worksheet section https://sequencescape.psd.sanger.ac.uk/robot_verifications
- [x] If a maximum volume is required. The maximum volume of the plate type should be 150µl

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
