### PR TITLE
3915 dpl 944 js banner not being displayed

### DIFF
--- a/app/controllers/receptacles_controller.rb
+++ b/app/controllers/receptacles_controller.rb
@@ -168,7 +168,9 @@ class ReceptaclesController < ApplicationController # rubocop:todo Metrics/Class
     end
   rescue Submission::ProjectValidation::Error, ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
     respond_to do |format|
-      flash.now[:error] = e.message.truncate(2000, separator: ' ')
+      # Using 'flash' instead of 'flash.now' to ensure the message persists after the redirect.
+      # See: https://guides.rubyonrails.org/action_controller_overview.html#the-flash
+      flash[:error] = e.message.truncate(2000, separator: ' ')
       format.html { redirect_to new_request_for_current_asset }
       format.json { render json: e.message, status: :unprocessable_entity }
     end

--- a/spec/features/assets/asset_submission_spec.rb
+++ b/spec/features/assets/asset_submission_spec.rb
@@ -98,7 +98,7 @@ describe 'Asset submission', :js do
       # of the current asset, with parameters included in the URL.
       redirect_path =
         new_request_receptacle_path(
-          asset,
+          asset.receptacle,
           study_id: study.id,
           project_id: project.id,
           request_type_id: selected_request_type.id

--- a/spec/features/assets/asset_submission_spec.rb
+++ b/spec/features/assets/asset_submission_spec.rb
@@ -81,6 +81,37 @@ describe 'Asset submission', :js do
     end
   end
 
+  shared_examples 'it shows an error message about study' do
+    it 'has error message' do
+      login_user user
+      visit labware_path(asset)
+      click_link 'Request additional sequencing'
+      select(selected_request_type.name, from: 'Request type')
+      select(study.name, from: 'Study')
+      select(project.name, from: 'Project')
+      fill_in 'Fragment size required (from)', with: '100'
+      fill_in 'Fragment size required (to)', with: '200'
+      select(selected_read_length, from: 'Read length')
+      click_button 'Create'
+
+      # If an error occurs, the user is redirected to the 'new request' page
+      # of the current asset, with parameters included in the URL.
+      redirect_path =
+        new_request_receptacle_path(
+          asset,
+          study_id: study.id,
+          project_id: project.id,
+          request_type_id: selected_request_type.id
+        )
+      expect(page).to have_current_path(redirect_path)
+
+      # The redirected page displays an error message detailing the issue
+      # encountered. In this particular case, the study does not have an
+      # accession number.
+      expect(page).to have_content "#{study.name} and all samples must have accession numbers"
+    end
+  end
+
   context 'when an admin' do
     let(:user) { create :admin }
 
@@ -111,5 +142,15 @@ describe 'Asset submission', :js do
     let(:user) { create :user }
 
     it_behaves_like 'it forbids additional sequencing'
+  end
+
+  context 'when study does not have an accession number' do
+    # Create a user that is allowed to request additional sequencing.
+    let(:user) { create :admin }
+
+    # Create a study that requires accessioning, but does not have an accession number.
+    let(:study) { create :open_study, enforce_accessioning: true, accession_number: nil }
+
+    it_behaves_like 'it shows an error message about study'
   end
 end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Page banner displays error messages to inform the user of issues when requesting additional sequencing
- Using 'flash' instead of 'flash.now' to ensure the message persists after the redirect

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
