### PR TITLE
Bugfix dpl680 plate volume incorrect filename

### DIFF
--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -91,7 +91,7 @@ class PlateVolume < ApplicationRecord
     def sanitized_filename(file)
       # We need to use the Carrierwave sanitized filename for lookup, else files with spaces are repetedly processed
       # Later versions of carrierwave expose this sanitization better, but for now we are forced to create an object
-      bugfix_dpl369(CarrierWave::SanitizedFile.new(file).filename)
+      bugfix_dpl680(CarrierWave::SanitizedFile.new(file).filename)
     end
 
     def find_for_filename(filename)

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -82,7 +82,9 @@ class PlateVolume < ApplicationRecord
     private :all_plate_volume_file_names
 
     def handle_volume(filename, file)
-      ActiveRecord::Base.transaction { find_for_filename(filename).call(filename, file) }
+      ActiveRecord::Base.transaction { find_for_filename(sanitized_filename(file)).call(filename, file) }
+    rescue => e
+      Rails.logger.warn("Error processing volume file #{filename}: #{e.message}")
     end
 
     private :handle_volume

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -91,14 +91,22 @@ class PlateVolume < ApplicationRecord
     def sanitized_filename(file)
       # We need to use the Carrierwave sanitized filename for lookup, else files with spaces are repetedly processed
       # Later versions of carrierwave expose this sanitization better, but for now we are forced to create an object
-      CarrierWave::SanitizedFile.new(file).filename
+      bugfix_dpl369(CarrierWave::SanitizedFile.new(file).filename)
     end
 
     def find_for_filename(filename)
       find_by(uploaded_file_name: filename) or
-        lambda do |filename, file|
+        lambda do |filename, file|        
           PlateVolume.create!(uploaded_file_name: filename, updated_at: file.stat.mtime, uploaded: file)
         end
+    end
+
+    def bugfix_dpl680(filename)
+      matching_regexp = /\(\d*\)\.CSV/
+      if filename.match(matching_regexp)
+        filename.gsub!(matching_regexp, ".CSV")
+      end
+      filename
     end
   end
 end

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -82,27 +82,40 @@ class PlateVolume < ApplicationRecord
     private :all_plate_volume_file_names
 
     def handle_volume(filename, file)
-      ActiveRecord::Base.transaction { find_for_filename(filename).call(filename, file) }
-    rescue => e
-      Rails.logger.warn("Error processing volume file #{filename}: #{e.message}")
+      vol = nil
+      ActiveRecord::Base.transaction { 
+        vol = find_for_filename(filename).call(filename, file)
+        unless vol.nil?
+          ActiveRecord::Base.connection.execute(
+            %Q{
+              UPDATE plate_volumes
+              SET uploaded_file_name='#{bugfix_filename_dpl680(vol.uploaded_file_name)}'
+              WHERE plate_volumes.id=#{vol.id}
+            }
+          )
+        end
+      }
     end
 
-    #private :handle_volume
+    private :handle_volume
 
     def sanitized_filename(file)
       # We need to use the Carrierwave sanitized filename for lookup, else files with spaces are repetedly processed
       # Later versions of carrierwave expose this sanitization better, but for now we are forced to create an object
-      bugfix_dpl680(CarrierWave::SanitizedFile.new(file).filename)
+      CarrierWave::SanitizedFile.new(file).filename
     end
 
     def find_for_filename(filename)
       find_by(uploaded_file_name: filename) or
         lambda do |filename, file|
+          # TODO: 
+          # After saving, the uploaded_file_name is renamed internally by CarrierWave to (2).CSV 
+          # This should be amended in future.
           PlateVolume.create!(uploaded_file_name: filename, updated_at: file.stat.mtime, uploaded: file)
         end
     end
-
-    def bugfix_dpl680(filename)
+  
+    def bugfix_filename_dpl680(filename)
       matching_regexp = /\(\d*\)\.CSV/i
       filename.gsub!(matching_regexp, '.CSV') if filename.match(matching_regexp)
       filename

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -82,12 +82,11 @@ class PlateVolume < ApplicationRecord
     private :all_plate_volume_file_names
 
     def handle_volume(filename, file)
-      ActiveRecord::Base.transaction do
-        find_for_filename(filename).call(filename, file)
-      end
+      ActiveRecord::Base.transaction { find_for_filename(filename).call(filename, file) }
     rescue => e
       Rails.logger.warn("Error processing volume file #{filename}: #{e.message}")
     end
+
     #private :handle_volume
 
     def sanitized_filename(file)

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -119,7 +119,13 @@ class PlateVolume < ApplicationRecord
 
     # rubocop:enable Metrics/MethodLength
 
-    def bugfix_filename_dpl680(filename)
+    #
+    # Given a .csv filename it removes the characters (2) that were appended to indicate the file was
+    # a duplicate. This is currently happening to files handled by CarrierWave during the save() action.
+    #
+    # An example of this method, suppose file1.csv --> file1(2).csv then the action of this method
+    # would revert file1(2).csv into file1.csv
+    def bugfix_filename_duplicate_back_to_normal(filename)
       matching_regexp = /\(\d*\)\.CSV/i
       filename.gsub!(matching_regexp, '.csv') if filename.match(matching_regexp)
       filename

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -96,16 +96,14 @@ class PlateVolume < ApplicationRecord
 
     def find_for_filename(filename)
       find_by(uploaded_file_name: filename) or
-        lambda do |filename, file|        
+        lambda do |filename, file|
           PlateVolume.create!(uploaded_file_name: filename, updated_at: file.stat.mtime, uploaded: file)
         end
     end
 
     def bugfix_dpl680(filename)
       matching_regexp = /\(\d*\)\.CSV/
-      if filename.match(matching_regexp)
-        filename.gsub!(matching_regexp, ".CSV")
-      end
+      filename.gsub!(matching_regexp, '.CSV') if filename.match(matching_regexp)
       filename
     end
   end

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -109,7 +109,7 @@ class PlateVolume < ApplicationRecord
             ActiveRecord::Base.connection.execute(
               "
                   UPDATE plate_volumes
-                  SET uploaded_file_name='#{bugfix_filename_dpl680(instance.uploaded_file_name)}'
+                  SET uploaded_file_name='#{bugfix_filename_duplicate_back_to_normal(instance.uploaded_file_name)}'
                   WHERE plate_volumes.id=#{instance.id}
                 "
             )

--- a/app/models/plate_volume.rb
+++ b/app/models/plate_volume.rb
@@ -82,11 +82,13 @@ class PlateVolume < ApplicationRecord
     private :all_plate_volume_file_names
 
     def handle_volume(filename, file)
-      ActiveRecord::Base.transaction { find_for_filename(sanitized_filename(file)).call(filename, file) }
+      ActiveRecord::Base.transaction do
+        find_for_filename(filename).call(filename, file)
+      end
     rescue => e
       Rails.logger.warn("Error processing volume file #{filename}: #{e.message}")
     end
-    private :handle_volume
+    #private :handle_volume
 
     def sanitized_filename(file)
       # We need to use the Carrierwave sanitized filename for lookup, else files with spaces are repetedly processed
@@ -102,7 +104,7 @@ class PlateVolume < ApplicationRecord
     end
 
     def bugfix_dpl680(filename)
-      matching_regexp = /\(\d*\)\.CSV/
+      matching_regexp = /\(\d*\)\.CSV/i
       filename.gsub!(matching_regexp, '.CSV') if filename.match(matching_regexp)
       filename
     end

--- a/spec/models/plate_volume_spec.rb
+++ b/spec/models/plate_volume_spec.rb
@@ -108,14 +108,12 @@ describe PlateVolume do
     end
 
     context 'when carrierwave returns a wrong filename' do
-      let(:double_file_carrier) { double('file', filename: 'SQPD-111.csv(2).CSV')}
+      let(:double_file_carrier) { double('file', filename: 'SQPD-111.csv(2).CSV') }
       let(:bad_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv(2).CSV') }
       let(:good_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
       let(:file) { File.open(good_filename, 'r') }
 
-      before do
-        described_class.handle_volume(bad_filename, file)  
-      end
+      before { described_class.handle_volume(bad_filename, file) }
 
       it 'updates measured and current volumes' do
         wells = plate_with_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
@@ -124,7 +122,7 @@ describe PlateVolume do
           expect(well_attribute.measured_volume).to eq volume
           expect(well_attribute.current_volume).to eq volume
         end
-      end  
+      end
 
       it 'updates measured and current volumes for plate_without_barcodes_in_csv' do
         wells = plate_without_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
@@ -134,7 +132,7 @@ describe PlateVolume do
           expect(well_attribute.current_volume).to eq volume
         end
       end
-  
+
       it 'generates a QcResult for each well' do
         plate_with_barcodes_in_csv
           .wells
@@ -145,8 +143,6 @@ describe PlateVolume do
             expect(well.qc_results.first.assay_type).to eq('Volume Check')
           end
       end
-  
-
     end
   end
 end

--- a/spec/models/plate_volume_spec.rb
+++ b/spec/models/plate_volume_spec.rb
@@ -108,7 +108,6 @@ describe PlateVolume do
     end
 
     context 'when carrierwave returns a wrong filename' do
-      let(:double_file_carrier) { double('file', filename: 'SQPD-111.csv(2).CSV') }
       let(:bad_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv(2).CSV') }
       let(:good_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
       let(:file) { File.open(good_filename, 'r') }

--- a/spec/models/plate_volume_spec.rb
+++ b/spec/models/plate_volume_spec.rb
@@ -107,55 +107,9 @@ describe PlateVolume do
         end
     end
 
-    context 'when carrierwave returns a wrong filename' do
-      let(:bad_filename) { "SQPD-111.csv(2).CSV" }
-      let(:bad_filename_path) { Rails.root.join("test/data/plate_volume/#{bad_filename}") }
-      let(:good_filename_path) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
-      let(:file) { File.open(good_filename_path, 'r') }
-
-      before { 
-        #PlateVolume.all.each do |vol|
-        #  vol.touch
-        #end
-        #described_class.process_all_volume_check_files(Rails.root.join('test/data/plate_volume'))
-        #described_class.handle_volume(bad_filename, file) 
-      }
-
-      it 'updates measured and current volumes' do
-        wells = plate_with_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
-        plate_a_expected_volumes.each do |well_name, volume|
-          well_attribute = wells[well_name].well_attribute
-          expect(well_attribute.measured_volume).to eq volume
-          expect(well_attribute.current_volume).to eq volume
-        end
-      end
-
-      it 'updates measured and current volumes for plate_without_barcodes_in_csv' do
-        wells = plate_without_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
-        plate_b_expected_volumes.each do |well_name, volume|
-          well_attribute = wells[well_name].well_attribute
-          expect(well_attribute.measured_volume).to eq volume
-          expect(well_attribute.current_volume).to eq volume
-        end
-      end
-
-      it 'generates a QcResult for each well' do
-        plate_with_barcodes_in_csv
-          .wells
-          .includes(:well_attribute, :map)
-          .find_each do |well|
-            expect(well.qc_results).to be_one
-            expect(well.qc_results.first.key).to eq('volume')
-            expect(well.qc_results.first.assay_type).to eq('Volume Check')
-          end
-      end
-
-      it 'creates a record in the database with the right value in uploaded_file_name' do
-        expect(PlateVolume.all.count > 0).to be_truthy
-        PlateVolume.all.each do |volume|
-          expect(volume.uploaded_file_name).to eq("#{volume.barcode}.csv")
-        end
-      end
+    it 'creates a record in the database with the right value in uploaded_file_name' do
+      expect(described_class.count).to be_positive
+      described_class.find_each { |volume| expect(volume.uploaded_file_name).to eq("#{volume.barcode}.csv") }
     end
   end
 end

--- a/spec/models/plate_volume_spec.rb
+++ b/spec/models/plate_volume_spec.rb
@@ -106,5 +106,47 @@ describe PlateVolume do
           expect(well.qc_results.first.assay_type).to eq('Volume Check')
         end
     end
+
+    context 'when carrierwave returns a wrong filename' do
+      let(:double_file_carrier) { double('file', filename: 'SQPD-111.csv(2).CSV')}
+      let(:bad_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv(2).CSV') }
+      let(:good_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
+      let(:file) { File.open(good_filename, 'r') }
+
+      before do
+        described_class.handle_volume(bad_filename, file)  
+      end
+
+      it 'updates measured and current volumes' do
+        wells = plate_with_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
+        plate_a_expected_volumes.each do |well_name, volume|
+          well_attribute = wells[well_name].well_attribute
+          expect(well_attribute.measured_volume).to eq volume
+          expect(well_attribute.current_volume).to eq volume
+        end
+      end  
+
+      it 'updates measured and current volumes for plate_without_barcodes_in_csv' do
+        wells = plate_without_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
+        plate_b_expected_volumes.each do |well_name, volume|
+          well_attribute = wells[well_name].well_attribute
+          expect(well_attribute.measured_volume).to eq volume
+          expect(well_attribute.current_volume).to eq volume
+        end
+      end
+  
+      it 'generates a QcResult for each well' do
+        plate_with_barcodes_in_csv
+          .wells
+          .includes(:well_attribute, :map)
+          .find_each do |well|
+            expect(well.qc_results).to be_one
+            expect(well.qc_results.first.key).to eq('volume')
+            expect(well.qc_results.first.assay_type).to eq('Volume Check')
+          end
+      end
+  
+
+    end
   end
 end

--- a/spec/models/plate_volume_spec.rb
+++ b/spec/models/plate_volume_spec.rb
@@ -108,11 +108,18 @@ describe PlateVolume do
     end
 
     context 'when carrierwave returns a wrong filename' do
-      let(:bad_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv(2).CSV') }
-      let(:good_filename) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
-      let(:file) { File.open(good_filename, 'r') }
+      let(:bad_filename) { "SQPD-111.csv(2).CSV" }
+      let(:bad_filename_path) { Rails.root.join("test/data/plate_volume/#{bad_filename}") }
+      let(:good_filename_path) { Rails.root.join('test/data/plate_volume/SQPD-111.csv') }
+      let(:file) { File.open(good_filename_path, 'r') }
 
-      before { described_class.handle_volume(bad_filename, file) }
+      before { 
+        #PlateVolume.all.each do |vol|
+        #  vol.touch
+        #end
+        #described_class.process_all_volume_check_files(Rails.root.join('test/data/plate_volume'))
+        #described_class.handle_volume(bad_filename, file) 
+      }
 
       it 'updates measured and current volumes' do
         wells = plate_with_barcodes_in_csv.wells.includes(:well_attribute, :map).index_by(&:map_description)
@@ -141,6 +148,13 @@ describe PlateVolume do
             expect(well.qc_results.first.key).to eq('volume')
             expect(well.qc_results.first.assay_type).to eq('Volume Check')
           end
+      end
+
+      it 'creates a record in the database with the right value in uploaded_file_name' do
+        expect(PlateVolume.all.count > 0).to be_truthy
+        PlateVolume.all.each do |volume|
+          expect(volume.uploaded_file_name).to eq("#{volume.barcode}.csv")
+        end
       end
     end
   end


### PR DESCRIPTION
Bugfix PROD problem:

#### Changes proposed in this pull request

New PlateVolume instances created after upgrading to ruby 3 are creating the upload_file_name like (2).csv (check database) and because that is not the right name, in next scheduled rub the process cannot find the files and detect they have already been created before, and so it creates again a new record. This fixes the name of the file in the table after creating it.



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
