### PR TITLE
dpl-942 bug unable to print swipecard id barcode

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,7 +55,8 @@ class UsersController < ApplicationController
         printer,
         LabelPrinter::Label::Swipecard,
         user_login: @user.login.truncate(10, omission: '..'),
-        swipecard: swipecard
+        swipecard: swipecard,
+        label_template_name: configatron.swipecard_pmb_template
       )
     if print_job.execute
       flash[:notice] = print_job.success

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :headless_chrome do |app|
 
   options.add_argument('--headless')
   options.add_argument('--window-size=1600,3200')
-  options.add_preference('download.default_directory', DownloadHelpers::PATH)
+  options.add_preference('download.default_directory', DownloadHelpers::PATH.to_s)
   the_driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 
   # the following is needed to avoid a test failure where the driver would

--- a/lib/label_printer/label_printer/label/swipecard.rb
+++ b/lib/label_printer/label_printer/label/swipecard.rb
@@ -7,8 +7,13 @@ module LabelPrinter
         @user_login = attributes[:user_login]
       end
 
+      # Returns values for the fields of the label. They are used by the
+      # the printmybarcode service to populate the label template.
+      #
+      # @return [Hash] a hash of label field values
+      #
       def build_label
-        { top_left: @user_login, barcode: @swipecard, label_name: 'main_label' }
+        { left_text: @user_login, barcode: @swipecard, label_name: 'main_label' }
       end
 
       def labels

--- a/lib/label_printer/label_printer/print_job.rb
+++ b/lib/label_printer/label_printer/print_job.rb
@@ -42,7 +42,15 @@ module LabelPrinter
       @labels = label_class.new(options.merge(printer_type_class)).labels
     end
 
+    # Returns the name of the label template to use for this print job.
+    # If not specified in the options during initialisation, the label template
+    # name configured for the printer in the database is used.
+    #
+    # @return [String] the name of the label template to use for this print job
+    #
     def label_template_name
+      return options[:label_template_name] if options[:label_template_name]
+
       printer = find_printer
       printer.barcode_printer_type.label_template_name
     end

--- a/spec/lib/label_printer/swipecard_spec.rb
+++ b/spec/lib/label_printer/swipecard_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+context 'printing swipecard' do
+  let(:barcode_printer_type) { create(:plate_barcode_printer_type) }
+  let(:barcode_printer) { create(:barcode_printer, barcode_printer_type: barcode_printer_type) }
+  let(:user) { create(:user) }
+  let(:label_class) { LabelPrinter::Label::Swipecard }
+  let(:label_template_name) { configatron.swipecard_pmb_template }
+  let(:swipecard) { '53a54be5' }
+  let(:print_job) do
+    LabelPrinter::PrintJob.new(
+      barcode_printer.name,
+      label_class,
+      user_login: user.login,
+      swipecard: swipecard,
+      label_template_name: label_template_name
+    )
+  end
+  let(:labels_attribute) { [{ left_text: user.login, barcode: swipecard, label_name: 'main_label' }] }
+  let(:build_attributes) do
+    { printer_name: barcode_printer.name, label_template_name: label_template_name, labels: labels_attribute }
+  end
+
+  it 'builds correct attributes' do
+    # This hash is sent to the printmybarcode service.
+    expect(print_job.build_attributes).to eq(build_attributes)
+  end
+
+  it 'builds correct label' do
+    # The hash in this array is used to populate the label template.
+    expect(print_job.labels_attribute).to eq(labels_attribute)
+  end
+
+  it 'uses correct label template' do
+    # This label template name should be used for printing swipecards.
+    # The users controller sets it during initialisation of the print job.
+    expect(print_job.label_template_name).to eq(label_template_name)
+  end
+
+  it 'uses correct printer' do
+    # Printer name is used by the printmybarcode service to find the correct
+    # printer type (either toshiba or squix). Because the label template name
+    # is specified for the print job for swipecards, barcode printer is not
+    # used to determine the label template name. The following is to make sure,
+    # the specified printer name can be verified.
+    expect(print_job.find_printer).to eq(barcode_printer)
+  end
+end

--- a/spec/lib/label_printer/swipecard_spec.rb
+++ b/spec/lib/label_printer/swipecard_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-context 'printing swipecard' do
+context 'when printing swipecard' do
   let(:barcode_printer_type) { create(:plate_barcode_printer_type) }
   let(:barcode_printer) { create(:barcode_printer, barcode_printer_type: barcode_printer_type) }
   let(:user) { create(:user) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 
   options.add_argument('--headless')
-  options.add_preference('download.default_directory', DownloadHelpers::PATH)
+  options.add_preference('download.default_directory', DownloadHelpers::PATH.to_s)
   the_driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 
   # copied the following over from features/support/capybara.rb because I expect it is also relevant here

--- a/test/lib/label_printer/swipecard_test.rb
+++ b/test/lib/label_printer/swipecard_test.rb
@@ -7,7 +7,7 @@ class SwipecardTest < ActiveSupport::TestCase
 
   def setup
     @options = { swipecard: 'test-swipecard', user_login: 'test-user' }
-    @label = { top_left: options[:user_login], barcode: options[:swipecard], label_name: 'main_label' }
+    @label = { left_text: options[:user_login], barcode: options[:swipecard], label_name: 'main_label' }
     @swipecard_label = LabelPrinter::Label::Swipecard.new(options)
   end
 


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Use swipecard_pmb_template for swipe card printing, instead of 
the sqsc_96plate_label_template_code39 plate template picked based on printer
- Change label_class to return values for swipecard_pmb_template fields instead of the plate template
- Change download directory to string for Chrome Options in order to avoid creating temporary files in the project directory instead of tmp.


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
