### PR TITLE
Fix for DPL-812 - scRNA Core Cell Extraction report - missing donor id

### DIFF
--- a/app/models/submission_template.rb
+++ b/app/models/submission_template.rb
@@ -102,10 +102,13 @@ class SubmissionTemplate < ApplicationRecord
 
   private
 
+  # Retrieves the request types that are associated with this submission template,
+  # from the ids that are specified in the submission_parameters field.
   def request_types
     @request_types ||= RequestType.where(id: request_type_ids)
   end
 
+  # Returns the request types in the order that they are specified in the submission_parameters field.
   def sorted_request_types
     request_types.sort_by { |rt| request_type_ids.index(rt.id) }
   end

--- a/app/resources/api/v2/sample_metadata_resource.rb
+++ b/app/resources/api/v2/sample_metadata_resource.rb
@@ -9,6 +9,7 @@ module Api
       attribute :collected_by
       attribute :cohort
       attribute :sample_description
+      attribute :donor_id
 
       # set add_model_hint true to allow updates from Limber, otherwise get a
       # 500 error as it looks for resource Api::V2::MetadatumResource

--- a/spec/factories/sample_metadata.rb
+++ b/spec/factories/sample_metadata.rb
@@ -47,6 +47,7 @@ FactoryBot.define do
       disease { 'disease' }
       subject { 'subject' }
       collected_by { 'collected_by' }
+      donor_id { 'donor_id' }
 
       consent_withdrawn { false }
 

--- a/spec/resources/api/v2/sample_metadata_resource_spec.rb
+++ b/spec/resources/api/v2/sample_metadata_resource_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V2::SampleMetadataResource, type: :resource do
       expect(subject).to have_attribute :sample_common_name
       expect(subject).to have_attribute :supplier_name
       expect(subject).to have_attribute :collected_by
+      expect(subject).to have_attribute :donor_id
     end
   end
 end


### PR DESCRIPTION
#### Changes proposed in this pull request

- Add donor_id to the sample metadata that SS passes over the V2 API
- needed for Limber scRNA Core Cell Extraction pipeline

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
