### PR TITLE
Bug fix for location report

### DIFF
--- a/app/models/location_report.rb
+++ b/app/models/location_report.rb
@@ -89,7 +89,7 @@ class LocationReport < ApplicationRecord
 
     ActiveRecord::Base.transaction do
       Tempfile.open(filename) do |tempfile|
-        generate_report_rows { |fields| tempfile << CSV.generate_line(fields, csv_options) }
+        generate_report_rows { |fields| tempfile << CSV.generate_line(fields, **csv_options) }
         tempfile.rewind
         update!(report: tempfile)
       end

--- a/spec/models/location_report_spec.rb
+++ b/spec/models/location_report_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe LocationReport do
         end
 
         it 'generates the report' do
-          expect(location_report.generate!).not_to raise_error
+          expect{ location_report.generate! }.not_to raise_error
         end
       end
 

--- a/spec/models/location_report_spec.rb
+++ b/spec/models/location_report_spec.rb
@@ -174,6 +174,10 @@ RSpec.describe LocationReport do
 
           expect(lines).to match_array(expected_lines)
         end
+
+        it 'generates the report' do
+          expect(location_report.generate!).not_to raise_error
+        end
       end
 
       context 'by selection on' do

--- a/spec/models/location_report_spec.rb
+++ b/spec/models/location_report_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe LocationReport do
         end
 
         it 'generates the report' do
-          expect{ location_report.generate! }.not_to raise_error
+          expect { location_report.generate! }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
#### Changes proposed in this pull request

- Fix report generation & add unit test
    - It has been broken ever since the Ruby 3 upgrade in Sequencescape version 14.26.0, released in Nov 2023
    - Due to https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
    - Use double splat operator to explicitly pass keyword arguments instead of a Hash object

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
