### PR TITLE
DPL-936-5 Freeze jsonapi resources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :default do
   # - Create a branch off version 0.9.0
   # - Remove the ActionController::ForceSSL module
   # - Load the gem from the branch
-  gem 'jsonapi-resources', github: 'yoldas/jsonapi-resources', branch: 'develop'
+  gem 'jsonapi-resources', github: 'sanger/jsonapi-resources', branch: 'develop'
 
   # Wraps bunny with connection pooling ad consumer process handling
   gem 'sanger_warren'

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,17 @@ group :default do
   # https://github.com/JamesGlover/sequencescape/tree/depfu/update/jsonapi-resources-0.9.5
   # but not only is there a failing test, but performance was tanking in a few places
   # due to not correctly eager loading dependencies on nested resources.
-  gem 'jsonapi-resources', '0.9.0'
+
+  # Versions above 0.9.0 are incompatible and it is too much work to upgrade at
+  # this time. Implementing new patches for updates is not a long term solution
+  # as the internals keep changing. However, version 0.9.0 is blocking us from
+  # updating rails to version 6.1 . The following steps show the process for an
+  # alternative solution:
+  # - Fork jsonpi-resources repository
+  # - Create a branch off version 0.9.0
+  # - Remove the ActionController::ForceSSL module
+  # - Load the gem from the branch
+  gem 'jsonapi-resources', github: 'yoldas/jsonapi-resources', branch: 'develop'
 
   # Wraps bunny with connection pooling ad consumer process handling
   gem 'sanger_warren'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,16 @@ GIT
   specs:
     sanger_barcode_format (0.2.0)
 
+GIT
+  remote: https://github.com/yoldas/jsonapi-resources.git
+  revision: db2c5cd3f0d6bdddf990eee705b3d9efe79de2bb
+  branch: develop
+  specs:
+    jsonapi-resources (0.9.0)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -227,10 +237,6 @@ GEM
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     json (2.6.3)
-    jsonapi-resources (0.9.0)
-      activerecord (>= 4.1)
-      concurrent-ruby
-      railties (>= 4.1)
     jsonapi-resources-matchers (1.0.0)
       jsonapi-resources (>= 0.9.0)
     knapsack_pro (5.7.0)
@@ -555,7 +561,7 @@ DEPENDENCIES
   flipper-ui (~> 0.25.0)
   formtastic
   json
-  jsonapi-resources (= 0.9.0)
+  jsonapi-resources!
   jsonapi-resources-matchers
   knapsack_pro
   launchy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,16 @@ GIT
       activerecord (>= 4.0.0)
 
 GIT
+  remote: https://github.com/sanger/jsonapi-resources.git
+  revision: be2fb43f5f8da2e632fb5f48200928b2dd3d8bf9
+  branch: develop
+  specs:
+    jsonapi-resources (0.9.0)
+      activerecord (>= 4.1)
+      concurrent-ruby
+      railties (>= 4.1)
+
+GIT
   remote: https://github.com/sanger/record_loader
   revision: 9e7481f4d2342f042ab13465962e5d6689863198
   specs:
@@ -19,16 +29,6 @@ GIT
   branch: development
   specs:
     sanger_barcode_format (0.2.0)
-
-GIT
-  remote: https://github.com/yoldas/jsonapi-resources.git
-  revision: db2c5cd3f0d6bdddf990eee705b3d9efe79de2bb
-  branch: develop
-  specs:
-    jsonapi-resources (0.9.0)
-      activerecord (>= 4.1)
-      concurrent-ruby
-      railties (>= 4.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Updating the Gemfile to use sanger group's forked `jsonapi` gem.
- This solves the following error `NameError: uninitialized constant ActionController::ForceSSL`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
