### PR TITLE
DPL-823 Import PBMC pool plates into Sequencescape (simple version)

### DIFF
--- a/config/default_records/plate_purposes/011_scrna_core_cdna_prep_plate_purposes.wip.yml
+++ b/config/default_records/plate_purposes/011_scrna_core_cdna_prep_plate_purposes.wip.yml
@@ -1,7 +1,15 @@
+# scRNA Core pipeline purposes
+# Most are defined in the Limber config, but the below also need to be defined in Sequencescape.
+# They are in a separate file so it can be 'feature flagged off' until needed.
+---
 # The 'LRC PBMC Pools' purpose is controlled by Limber. However, it has been
 # added here to create submission and request type records for scRNA Core cDNA
 # Prep stage.
----
 LRC PBMC Pools:
   stock_plate: false
+  cherrypickable_target: false
+# The 'LRC PBMC Pools Input' purpose is included here so that it's available for
+# sample manifests.
+LRC PBMC Pools Input:
+  stock_plate: true
   cherrypickable_target: false

--- a/config/sample_manifest_excel/manifest_types.yml
+++ b/config/sample_manifest_excel/manifest_types.yml
@@ -255,6 +255,14 @@ plate_bioscan:
     - :sample_type
     - :donor_id
     - :bioscan_control_type
+plate_scrna_core_pools:
+  heading: "scRNA Core Pools Plate"
+  asset_type: "plate"
+  columns:
+    - :sanger_plate_id
+    - :well
+    - :sanger_sample_id
+    - :supplier_name
 tube_default:
   heading: "Default Tube"
   asset_type: "1dtube"


### PR DESCRIPTION
Closes #3857 

#### Changes proposed in this pull request

- Create simple manifest for importing pool plates for scRNA Core pipeline
    - represents a pool as a single row in the spreadsheet / sample in the database (makeup of the pool is not included)
- Add LRC PBMC Pools Input purpose to record loader
    - it should be defined in Sequencescape, not just Limber, as it is needed to create a sample manifest using that purpose

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
