### PR TITLE
Added validation for data_release_delay_other_comment field

### DIFF
--- a/app/models/study.rb
+++ b/app/models/study.rb
@@ -262,6 +262,8 @@ class Study < ApplicationRecord # rubocop:todo Metrics/ClassLength
     # This excludes supplementary characters, which include emoji and rare kanji
     validates :study_abstract, :study_study_title, :study_description, :s3_email_list, utf8mb3: true
 
+    validates :data_release_delay_other_comment, length: { maximum: 255 }
+
     # These fields are restricted further as they aren't expected to ever contain anything more than ASCII
     validates :study_project_id,
               :ega_dac_accession_number,

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -660,6 +660,17 @@ RSpec.describe Study do
           metadata[:data_release_delay_reason_comment]
         )
       end
+
+      it 'validates the length of data_release_delay_other_comment' do
+        study.study_metadata.data_release_delay_other_comment =
+          'Data Release delay other comment.
+          Data Release delay other comment. Data Release delay other comment. Data Release delay other comment.
+          Data Release delay other comment. Data Release delay other comment. Data Release delay other comment.
+          Data Release delay other comment. Data Release delay other comment. Data Release delay other comment.'
+        expect { study.save! }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(study.valid?).to be false
+        expect(study.errors.messages.length).to eq 1
+      end
     end
 
     context 'delayed for long time' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Added validation for data_release_delay_other_comment field

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
