### PR TITLE
Fix task loading for rake test

### DIFF
--- a/spec/tasks/support/add_stock_rna_plate_to_working_dilution_parents_spec.rb
+++ b/spec/tasks/support/add_stock_rna_plate_to_working_dilution_parents_spec.rb
@@ -16,7 +16,7 @@ describe 'support:add_stock_rna_plate_to_working_dilution_parents', type: :task 
   let(:task_invoke) { Rake::Task[self.class.top_level_description].invoke }
 
   before do
-    load_tasks # Load tasks directly in the test
+    load_tasks # Load tasks directly in the test to avoid intermittent CI failures
     task_reenable # Allows the task to be invoked again
     plate_creator # The task assumes the plate creator already exists
     target_purpose # The task assumes the target purpose already exists

--- a/spec/tasks/support/add_stock_rna_plate_to_working_dilution_parents_spec.rb
+++ b/spec/tasks/support/add_stock_rna_plate_to_working_dilution_parents_spec.rb
@@ -2,8 +2,6 @@
 
 require 'rails_helper'
 
-Rails.application.load_tasks
-
 describe 'support:add_stock_rna_plate_to_working_dilution_parents', type: :task do
   let(:source_purpose_name) { 'Stock RNA Plate' }
   let(:target_purpose_name) { 'Working Dilution' }
@@ -13,10 +11,12 @@ describe 'support:add_stock_rna_plate_to_working_dilution_parents', type: :task 
   let(:target_purpose) { create(:plate_purpose, name: target_purpose_name, stock_plate: false) }
   let(:plate_creator) { create(:plate_creator, name: plate_creator_name) }
 
+  let(:load_tasks) { Rails.application.load_tasks }
   let(:task_reenable) { Rake::Task[self.class.top_level_description].reenable }
   let(:task_invoke) { Rake::Task[self.class.top_level_description].invoke }
 
   before do
+    load_tasks # Load tasks directly in the test
     task_reenable # Allows the task to be invoked again
     plate_creator # The task assumes the plate creator already exists
     target_purpose # The task assumes the target purpose already exists


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

Load rake tasks (for the support task itself and the environment dependency) within the test to avoid intermittent CI errors. 

The test was passing locally and failing on CI. Knapsack pro could not find the task although it was loaded. By moving the task loading into the test seems to fix this issue. I think it is because the loading happens in the process running the test now.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
