### PR TITLE
Remove the y24_052_enable_data_release_timing_validation feature flag

### DIFF
--- a/app/models/study/metadata.rb
+++ b/app/models/study/metadata.rb
@@ -64,13 +64,11 @@ class Study
               if: :data_release_timing_must_be_never?
 
     def data_release_timing_must_be_never?
-      Flipper.enabled?(:y24_052_enable_data_release_timing_validation) && data_release_strategy.present? &&
-        strategy_not_applicable?
+      data_release_strategy.present? && strategy_not_applicable?
     end
 
     def data_release_timing_must_not_be_never?
-      Flipper.enabled?(:y24_052_enable_data_release_timing_validation) && data_release_strategy.present? &&
-        !strategy_not_applicable?
+      data_release_strategy.present? && !strategy_not_applicable?
     end
 
     def sanity_check_y_separation

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -2,5 +2,3 @@
 # dpl202_enable_angry_cat_feature: When enabled this will add an angry cat to all pages that will try to catch the mouse pointer
 # The key should be lower case and snake case, and prefixed with the issue number to allow easy identification
 dpl_395_2_enable_advanced_search_tab: Shows the Search tab in the top navigation bar
-# Below is flagged off until some existing data that would violate the rule is fixed. Should be re-enabled in Y24-058.
-y24_052_enable_data_release_timing_validation: Enables server-side validation that enforces a relationship between the values of two study metadata fields

--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -629,28 +629,12 @@ RSpec.describe Study do
         expect(study.study_metadata.dac_policy_title).to eq(metadata[:dac_policy_title])
       end
 
-      context 'when the data_release_timing validation is switched on' do
-        before { Flipper.enable :y24_052_enable_data_release_timing_validation }
-
-        it 'errors if the data_release_timing is invalid' do
-          study.study_metadata.data_release_timing = 'never'
-          expect { study.save! }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-      end
-
-      context 'when the data_release_timing validation is switched off' do
-        before { Flipper.disable :y24_052_enable_data_release_timing_validation }
-
-        it 'does not error if the data_release_timing is invalid' do
-          study.study_metadata.data_release_timing = 'never'
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
+      it 'errors if the data_release_timing is invalid' do
+        study.study_metadata.data_release_timing = 'never'
+        expect { study.save! }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
       end
     end
 
@@ -663,28 +647,12 @@ RSpec.describe Study do
         )
       end
 
-      context 'when the data_release_timing validation is switched on' do
-        before { Flipper.enable :y24_052_enable_data_release_timing_validation }
-
-        it 'errors if the data_release_timing is invalid' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-      end
-
-      context 'when the data_release_timing validation is switched off' do
-        before { Flipper.disable :y24_052_enable_data_release_timing_validation }
-
-        it 'does not error if the data_release_timing is invalid' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
+      it 'errors if the data_release_timing is invalid' do
+        study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
+        expect { study.save! }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
       end
     end
 
@@ -760,82 +728,39 @@ RSpec.describe Study do
         )
       end
 
-      context 'when the data_release_timing validation is switched on' do
-        before { Flipper.enable :y24_052_enable_data_release_timing_validation }
-
-        it 'errors if the data_release_timing is standard' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_STANDARD
-          expect { study.save! }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-
-        it 'errors if the data_release_timing is immediate' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_IMMEDIATE
-          expect { study.save! }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-
-        it 'errors if the data_release_timing is delayed' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_DELAYED
-          study.study_metadata.data_release_delay_reason = Study::DATA_RELEASE_DELAY_REASONS_STANDARD[0]
-          study.study_metadata.data_release_delay_period = Study::DATA_RELEASE_DELAY_PERIODS[0]
-          study.study_metadata.data_release_delay_approval = Study::YES
-          expect { study.save! }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-
-        it 'is valid if the data_release_timing is never' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
+      it 'errors if the data_release_timing is standard' do
+        study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_STANDARD
+        expect { study.save! }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
       end
 
-      context 'when the data_release_timing validation is switched off' do
-        before { Flipper.disable :y24_052_enable_data_release_timing_validation }
+      it 'errors if the data_release_timing is immediate' do
+        study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_IMMEDIATE
+        expect { study.save! }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
+      end
 
-        it 'does not error if the data_release_timing is standard' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_STANDARD
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
+      it 'errors if the data_release_timing is delayed' do
+        study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_DELAYED
+        study.study_metadata.data_release_delay_reason = Study::DATA_RELEASE_DELAY_REASONS_STANDARD[0]
+        study.study_metadata.data_release_delay_period = Study::DATA_RELEASE_DELAY_PERIODS[0]
+        study.study_metadata.data_release_delay_approval = Study::YES
+        expect { study.save! }.to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
+      end
 
-        it 'does not error if the data_release_timing is immediate' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_IMMEDIATE
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-
-        it 'does not error if the data_release_timing is delayed' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_DELAYED
-          study.study_metadata.data_release_delay_reason = Study::DATA_RELEASE_DELAY_REASONS_STANDARD[0]
-          study.study_metadata.data_release_delay_period = Study::DATA_RELEASE_DELAY_PERIODS[0]
-          study.study_metadata.data_release_delay_approval = Study::YES
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
-
-        it 'is still valid if the data_release_timing is never' do
-          study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
-        end
+      it 'is valid if the data_release_timing is never' do
+        study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
+        expect { study.save! }.not_to raise_error(
+          ActiveRecord::RecordInvalid,
+          /Study metadata data release timing is not included in the list/
+        )
       end
     end
   end


### PR DESCRIPTION
- It was introduced in 'Y24-052 [BUG] Dropdown list dependencies', to turn the new server-side validation off until the existing data was fixed
- It can be removed after 'Y24-058 [BUG] Study data release information - data clean up' is done

Closes #

#### Changes proposed in this pull request

- 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
