### PR TITLE
Modified label to display valid keys for metadata field attributes

### DIFF
--- a/app/views/shared/metadata/show/_request.html.erb
+++ b/app/views/shared/metadata/show/_request.html.erb
@@ -3,7 +3,7 @@
   <%= form.fields_for(:request_metadata, builder: Metadata::ViewBuilder) do |metadata_fields| %>
     <%- request.request_metadata.field_infos.each do |field_info| %>
       <div class="field">
-       <%= metadata_fields.label(field_info.display_name + ":") %> <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || ' Not specified' %></span> <br/>
+       <%= metadata_fields.label(field_info.display_name) %>: <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || 'Not specified' %></span> <br/>
       </div>
     <% end %>
   <% end %>

--- a/app/views/shared/metadata/show/_request.html.erb
+++ b/app/views/shared/metadata/show/_request.html.erb
@@ -3,7 +3,7 @@
   <%= form.fields_for(:request_metadata, builder: Metadata::ViewBuilder) do |metadata_fields| %>
     <%- request.request_metadata.field_infos.each do |field_info| %>
       <div class="field">
-       <%= metadata_fields.label(field_info.display_name) %>: <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || 'Not specified' %></span> <br/>
+       <%= metadata_fields.label(field_info.display_name + ":") %> <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || ' Not specified' %></span> <br/>
       </div>
     <% end %>
   <% end %>

--- a/app/views/shared/metadata/show/_request.html.erb
+++ b/app/views/shared/metadata/show/_request.html.erb
@@ -1,9 +1,10 @@
-
 <%# NOTE[xxx]: Kind of a hack because we're not actually building a form %>
 <%= fields_for(request) do |form| %>
   <%= form.fields_for(:request_metadata, builder: Metadata::ViewBuilder) do |metadata_fields| %>
     <%- request.request_metadata.field_infos.each do |field_info| %>
-      <%= metadata_fields.label(field_info.key) %>: <%= metadata_fields.object.send(field_info.key) || 'Not specified' %> <br/>
+      <div class="field">
+       <%= metadata_fields.label(field_info.display_name) %>: <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || 'Not specified' %></span> <br/>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/metadata/show/_request.html.erb
+++ b/app/views/shared/metadata/show/_request.html.erb
@@ -3,7 +3,7 @@
 <%= fields_for(request) do |form| %>
   <%= form.fields_for(:request_metadata, builder: Metadata::ViewBuilder) do |metadata_fields| %>
     <%- request.request_metadata.field_infos.each do |field_info| %>
-      <%= metadata_fields.plain_value(field_info.key) %>
+      <%= metadata_fields.label(field_info.key) %>: <%= metadata_fields.object.send(field_info.key) || 'Not specified' %> <br/>
     <% end %>
   <% end %>
 <% end %>

--- a/features/plain/5413994_request_editing_using_legacy_properties.feature
+++ b/features/plain/5413994_request_editing_using_legacy_properties.feature
@@ -19,9 +19,9 @@ Feature: Editing a request as an administrator
     And I press "Save Request"
     Then I should see "Request details have been updated"
     And I should see the following request information:
-      | Still charge on fail          | Not specified |
-      | Read length                   | 76            |
-      | Gigabases expected            | 1.0           |
-      | Fragment size required (from) | 11111111      |
-      | Fragment size required (to)   | 22222222      |
-      | Library type                  | Standard      |
+      | Still charge on fail:          | Not specified |
+      | Read length:                   | 76            |
+      | Gigabases expected:            | 1.0           |
+      | Fragment size required (from): | 11111111      |
+      | Fragment size required (to):   | 22222222      |
+      | Library type:                  | Standard      |

--- a/features/plain/5413994_request_editing_using_legacy_properties.feature
+++ b/features/plain/5413994_request_editing_using_legacy_properties.feature
@@ -19,9 +19,9 @@ Feature: Editing a request as an administrator
     And I press "Save Request"
     Then I should see "Request details have been updated"
     And I should see the following request information:
-      | Still charge on fail:          | Not specified |
-      | Read length:                   | 76            |
-      | Gigabases expected:            | 1.0           |
-      | Fragment size required (from): | 11111111      |
-      | Fragment size required (to):   | 22222222      |
-      | Library type:                  | Standard      |
+      | Still charge on fail          | Not specified |
+      | Read length                   | 76            |
+      | Gigabases expected            | 1.0           |
+      | Fragment size required (from) | 11111111      |
+      | Fragment size required (to)   | 22222222      |
+      | Library type                  | Standard      |

--- a/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
+++ b/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
@@ -101,8 +101,14 @@ Given '{study_name} has an asset group of {int} samples in SampleTubes called {s
 end
 
 Then /^I should see the following request information:$/ do |expected|
-  # The request info is actually a series of tables. fetch_table just grabs the first.
-  # This is silly, but attempting to fix it is probably more hassle than its worth.
-  actual = page.all('.property_group_general tr').to_h { |row| row.all('td').map(&:text) }
+  actual =
+    page
+      .all('.field')
+      .map do |field|
+        label = field.find('label').text
+        value = field.find('.value_identifier', visible: false).text
+        [label, value]
+      end
+      .to_h
   assert_equal expected.rows_hash, actual
 end

--- a/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
+++ b/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
@@ -104,11 +104,10 @@ Then /^I should see the following request information:$/ do |expected|
   actual =
     page
       .all('.field')
-      .map do |field|
+      .each_with_object({}) do |field, hash|
         label = field.find('label').text
         value = field.find('.value_identifier', visible: false).text
-        [label, value]
+        hash[label] = value
       end
-      .to_h
   assert_equal expected.rows_hash, actual
 end


### PR DESCRIPTION
Closes #4047 

#### Changes proposed in this pull request

- No longer uses `plain_value` to render a view with keys and values for the field attributes when viewing requests.
- The key and values for each are joined directly (which makes it easier for this use case).

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
