### PR TITLE
DPL-1081 - Added validation for checking target purposes

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -366,7 +366,7 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   # Remove a request from the batch and reset it to a point where it can be put back into
-  # the pending queue.ƒ
+  # the pending queue.
   def detach_request(request, current_user = nil)
     ActiveRecord::Base.transaction do
       unless current_user.nil?

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -139,10 +139,12 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   end
 
   def requests_have_same_target_purpose
-    if (pipeline.is_a? CherrypickingPipeline) && requests.map { |request| request.request_metadata.target_purpose_id }.uniq.size > 1
-      errors.add :base, 'The selected requests must have the same target purpose (Pick To) values'
+    if pipeline.is_a?(CherrypickingPipeline) &&
+       requests.map { |request| request.request_metadata.target_purpose_id }.uniq.size > 1
+  
+      errors.add(:base, 'The selected requests must have the same target purpose (Pick To) values')
     end
-  end
+  end  
 
   def requests_have_same_read_length
     unless pipeline.is_read_length_consistent_for_batch?(self)

--- a/spec/features/pipelines/cherrypick/cherrypick_for_fluidigm_pipeline_micro_litre_spec.rb
+++ b/spec/features/pipelines/cherrypick/cherrypick_for_fluidigm_pipeline_micro_litre_spec.rb
@@ -19,6 +19,7 @@ describe 'cherrypick for fluidigm pipeline - micro litre', :js do
   let(:request_types) { pipeline.request_types.map(&:key) }
 
   before do
+    target_purpose = create :plate_purpose, name: 'Fluidigm'
     assets =
       plates.each_with_object([]) do |plate, assets|
         assets.concat(plate.wells)
@@ -30,7 +31,8 @@ describe 'cherrypick for fluidigm pipeline - micro litre', :js do
              request_type: pipeline.request_types.first,
              submission: submission,
              study: study,
-             project: project
+             project: project,
+             target_purpose: target_purpose
     end
 
     allow(PlateBarcode).to receive(:create_barcode).and_return(build(:plate_barcode, barcode: 'SQPD-2'))


### PR DESCRIPTION
Closes #4012 

#### Changes proposed in this pull request

- When cherrypicking plates that have requests with more than one type of plate purpose, a warning is now shown. This will prevent users from seeing multiple output purpose plates in the final screen which will cause an error due to incompatible plate types. 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
