### PR TITLE
Y24-071 - Modified localisation heirarchy to find valid labels

### DIFF
--- a/app/views/shared/metadata/show/_request.html.erb
+++ b/app/views/shared/metadata/show/_request.html.erb
@@ -2,9 +2,7 @@
 <%= fields_for(request) do |form| %>
   <%= form.fields_for(:request_metadata, builder: Metadata::ViewBuilder) do |metadata_fields| %>
     <%- request.request_metadata.field_infos.each do |field_info| %>
-      <div class="field">
-       <%= metadata_fields.label(field_info.display_name) %>: <span class="value_identifier"><%= metadata_fields.object.send(field_info.key) || 'Not specified' %></span> <br/>
-      </div>
+      <%= metadata_fields.plain_value(field_info.key) %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/metadata/en.yml
+++ b/config/locales/metadata/en.yml
@@ -100,6 +100,8 @@ en:
           <<: *REQUEST
         library_completion:
           <<: *REQUEST
+        std_library_request:
+          <<: *REQUEST
 
     illuminaC:
       requests:

--- a/features/plain/5413994_request_editing_using_legacy_properties.feature
+++ b/features/plain/5413994_request_editing_using_legacy_properties.feature
@@ -19,9 +19,9 @@ Feature: Editing a request as an administrator
     And I press "Save Request"
     Then I should see "Request details have been updated"
     And I should see the following request information:
-      | Still charge on fail          | Not specified |
-      | Read length                   | 76            |
-      | Gigabases expected            | 1.0           |
-      | Fragment size required (from) | 11111111      |
-      | Fragment size required (to)   | 22222222      |
-      | Library type                  | Standard      |
+      | Still charge on fail:          | Not specified |
+      | Read length:                   | 76            |
+      | Gigabases expected:            | 1.0           |
+      | Fragment size required (from): | 11111111      |
+      | Fragment size required (to):   | 22222222      |
+      | Library type:                  | Standard      |

--- a/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
+++ b/features/support/step_definitions/4560014_refactoring_properties_descriptors_etc_to_table_columns_steps.rb
@@ -101,13 +101,8 @@ Given '{study_name} has an asset group of {int} samples in SampleTubes called {s
 end
 
 Then /^I should see the following request information:$/ do |expected|
-  actual =
-    page
-      .all('.field')
-      .each_with_object({}) do |field, hash|
-        label = field.find('label').text
-        value = field.find('.value_identifier', visible: false).text
-        hash[label] = value
-      end
+  # The request info is actually a series of tables. fetch_table just grabs the first.
+  # This is silly, but attempting to fix it is probably more hassle than its worth.
+  actual = page.all('.property_group_general tr').to_h { |row| row.all('td').map(&:text) }
   assert_equal expected.rows_hash, actual
 end


### PR DESCRIPTION
Closes #4098 

#### Changes proposed in this pull request

- This fixes #4098 and #4047 where metadata field labels wouldn't properly display the names. The localisation file wasn't complete so the values were being returned as "Unlabelled field".
- The fix for #4047 was reverted as this PR resolves it too.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
