### PR TITLE
BUGFIX - add includes statement to ensure class loaded

### DIFF
--- a/lib/acts_as_descriptable.rb
+++ b/lib/acts_as_descriptable.rb
@@ -29,6 +29,9 @@
 #   author_name: 'Matt Wood'
 
 module ActsAsDescriptable # :nodoc:
+  # added as getting 'Tried to load unspecified class: HashWithIndifferentAccess' errors in Production and UAT
+  require 'active_support/hash_with_indifferent_access'
+
   def self.included(base)
     base.class_eval { serialize :descriptors }
   end


### PR DESCRIPTION
Fix for bug in search when get HashWithIndifferentAccess class unrecognised (unloaded)