### PR TITLE
Y24-107: Fix exceptions in search and other areas that do object deserialisation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -104,21 +104,17 @@ module Sequencescape
     # end Rails 5 #
 
     # Fix for Psych::DisallowedClass: Tried to load unspecified class
-    # this has to be in "after_initialize" because we need custom classes to be loaded already
-    config.after_initialize do
-      ActiveRecord::Base.yaml_column_permitted_classes = [
-        Symbol,
-        ActiveSupport::HashWithIndifferentAccess,
-        HashWithIndifferentAccess, # rubocop:disable Rails/TopLevelHashWithIndifferentAccess
-        RequestType::Validator::ArrayWithDefault,
-        RequestType::Validator::LibraryTypeValidator,
-        RequestType::Validator::FlowcellTypeValidator,
-        ActionController::Parameters,
-        Set,
-        Range,
-        FieldInfo,
-        Time
-      ]
-    end
+    config.active_record.yaml_column_permitted_classes = Array(config.active_record.yaml_column_permitted_classes) + %w[
+      ActiveSupport::HashWithIndifferentAccess
+      HashWithIndifferentAccess
+      RequestType::Validator::ArrayWithDefault
+      RequestType::Validator::LibraryTypeValidator
+      RequestType::Validator::FlowcellTypeValidator
+      ActionController::Parameters
+      Set
+      Range
+      FieldInfo
+      Time
+    ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -105,6 +105,7 @@ module Sequencescape
 
     # Fix for Psych::DisallowedClass: Tried to load unspecified class
     config.active_record.yaml_column_permitted_classes = Array(config.active_record.yaml_column_permitted_classes) + %w[
+      Symbol
       ActiveSupport::HashWithIndifferentAccess
       HashWithIndifferentAccess
       RequestType::Validator::ArrayWithDefault


### PR DESCRIPTION
This resolves in issue where this list wasn't being set properly because it had to be wrapped in an after_initialize block.  My assumption is that we were setting this too late and the app wasn't accepting the values.  We were also bypassing the config object which was potentially going to cause further headaches down the road as it's undocumented.

Closes #4122 

#### Changes proposed in this pull request

- Define YAML column permitted classes as strings instead of classes

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  