### PR TITLE
Y24-040 - Custom batch creation validation for NovaseqX

### DIFF
--- a/app/validators/novaseqx_pe_validator.rb
+++ b/app/validators/novaseqx_pe_validator.rb
@@ -6,6 +6,11 @@ class NovaseqxPeValidator < ActiveModel::Validator
     batch_size_for_flowcell_type(record)
   end
 
+  # Used in _pipeline_limit.html to display custom validation warnings
+  def self.validation_info
+    'Requests must be selected in pairs for 1.5B flowcells and in groups of 8 for 10B and 25B flowcells.'
+  end
+
   private
 
   def batch_size_for_flowcell_type(record)

--- a/app/validators/novaseqx_pe_validator.rb
+++ b/app/validators/novaseqx_pe_validator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# A custom batch creation validator for NovaSeqX PE pipeline
+class NovaseqxPeValidator < ActiveModel::Validator
+  def validate(record)
+    batch_size_for_flowcell_type(record)
+  end
+
+  private
+
+  def batch_size_for_flowcell_type(record)
+    if record.requests.empty? || record.requests.first.request_metadata.nil?
+      # No requests selected or the pipeline doesn't contain metadata to check
+      return true
+    end
+
+    flowcell_type_list = record.requests.filter_map { |request| request.request_metadata.requested_flowcell_type }
+
+    return true if flowcell_type_list.empty?
+
+    # There is a flowcell type uniqueness test in batch creation validator so we don't worry about error messages here
+    return false if flowcell_type_list.uniq.size > 1
+
+    flowcells_match_batch_size(record, flowcell_type_list.first)
+  end
+
+  def flowcells_match_batch_size(record, flowcell_type)
+    case flowcell_type
+    when '1.5B'
+      if record.requests.size != 2
+        record.errors.add(:base, 'You must select exactly 2 requests for 1.5B flowcells')
+        false
+      end
+    when '10B', '25B'
+      if record.requests.size != 8
+        record.errors.add(:base, "You must select exactly 8 requests for #{flowcell_type} flowcells")
+        false
+      end
+    end
+  end
+end

--- a/app/views/pipelines/_pipeline_limit.html.erb
+++ b/app/views/pipelines/_pipeline_limit.html.erb
@@ -11,6 +11,11 @@
       <p>This pipeline does not have a limit set on the number of requests in a batch.</p>
     <% end -%>
 
+    <%# Custom validation warnings taken from the pipeline's custom validator %>
+    <% if @pipeline.validator_class_name&.constantize&.validation_info %>
+      <p><%= @pipeline.validator_class_name&.constantize.validation_info %></p>
+    <% end %>
+
     <p>There are <%= requests_waiting %> requests available.</p>
     <p>You have <span id="selection_count">no</span> requests selected.</p>
   </div>

--- a/config/default_records/pipelines/default_records.yml
+++ b/config/default_records/pipelines/default_records.yml
@@ -35,7 +35,8 @@ NovaSeqX PE:
   externally_managed: 0
   group_name: Sequencing
   control_request_type_id: 0
-  min_size: 8
+  min_size: 2
+  validator_class_name: NovaseqxPeValidator
   request_type_keys:
     - illumina_htp_novaseqx_paired_end_sequencing
   workflow:

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -77,28 +77,37 @@ RSpec.describe Batch do
     end
   end
 
-  # It is not clear what the state is that is leaking.
-  # This can be removed with proper classes and tests in Y24-040, as this is a test for a feature that is not yet used.
   describe '::add_dynamic_validations' do
-    let(:pipeline) { create :pipeline, validator_class_name: 'NovaSeq6000Validator' }
+    # Using NovaseqxPeValidator as an example. Specific validator tests can be found in spec/validators
+    let(:pipeline) { create :pipeline, validator_class_name: 'NovaseqxPeValidator' }
     let(:batch) { described_class.new pipeline: pipeline }
 
-    before do
+    it 'fails validation when dynamic validations fail' do
       stub_const(
-        'NovaSeq6000Validator',
+        'NovaseqxPeValidator',
         Class.new(ActiveModel::Validator) do
           def validate(record)
-            record.errors.add :base, 'NovaSeq6000Validator failed'
+            record.errors.add :base, 'NovaseqxPeValidator failed'
           end
         end
       )
+
+      expect(batch.valid?).to be false
+      expect(batch.errors[:base]).to include('NovaseqxPeValidator failed')
     end
 
-    context 'when added, includes the dynamic validations' do
-      it 'adds dynamic validations' do
-        expect(batch.valid?).to be false
-        expect(batch.errors[:base]).to include('NovaSeq6000Validator failed')
-      end
+    it 'passes validation when dynamic validations pass' do
+      stub_const(
+        'NovaseqxPeValidator',
+        Class.new(ActiveModel::Validator) do
+          def validate(_record)
+            true
+          end
+        end
+      )
+
+      expect(batch.valid?).to be true
+      expect(batch.errors[:base]).to be_empty
     end
   end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -78,27 +78,27 @@ RSpec.describe Batch do
   end
 
   describe '::add_dynamic_validations' do
-    # Using NovaseqxPeValidator as an example. Specific validator tests can be found in spec/validators
-    let(:pipeline) { create :pipeline, validator_class_name: 'NovaseqxPeValidator' }
+    # Specific validator tests can be found in spec/validators
+    let(:pipeline) { create :pipeline, validator_class_name: 'TestPipelineValidator' }
     let(:batch) { described_class.new pipeline: pipeline }
 
     it 'fails validation when dynamic validations fail' do
       stub_const(
-        'NovaseqxPeValidator',
+        'TestPipelineValidator',
         Class.new(ActiveModel::Validator) do
           def validate(record)
-            record.errors.add :base, 'NovaseqxPeValidator failed'
+            record.errors.add :base, 'TestPipelineValidator failed'
           end
         end
       )
 
       expect(batch.valid?).to be false
-      expect(batch.errors[:base]).to include('NovaseqxPeValidator failed')
+      expect(batch.errors[:base]).to include('TestPipelineValidator failed')
     end
 
     it 'passes validation when dynamic validations pass' do
       stub_const(
-        'NovaseqxPeValidator',
+        'TestPipelineValidator',
         Class.new(ActiveModel::Validator) do
           def validate(_record)
             true

--- a/spec/validators/novaseqx_pe_validator_spec.rb
+++ b/spec/validators/novaseqx_pe_validator_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe NovaseqxPeValidator do
+  describe '#validate' do
+    context 'with batch_size_for_flowcell_type validations' do
+      let(:record) { create :batch, request_count: 2 }
+
+      it 'returns true if no requests are selected' do
+        record.requests = []
+        expect(described_class.new.validate(record)).to be true
+      end
+
+      it 'returns true if there are no flowcell_types' do
+        record.requests.each { |request| request.request_metadata.requested_flowcell_type = nil }
+        expect(described_class.new.validate(record)).to be true
+      end
+
+      it 'returns false if there are multiple flowcell_types' do
+        record.requests.each { |request| request.request_metadata.requested_flowcell_type = '1.5B' }
+        record.requests.first.request_metadata.requested_flowcell_type = '10B'
+
+        expect(described_class.new.validate(record)).to be false
+      end
+
+      context 'with flowcells_match_batch_size validations' do
+        [
+          { flowcell_type: '1.5B', request_count: 2, result: nil },
+          { flowcell_type: '1.5B', request_count: 8, result: false },
+          { flowcell_type: '10B', request_count: 8, result: nil },
+          { flowcell_type: '10B', request_count: 2, result: false },
+          { flowcell_type: '10B', request_count: 8, result: nil },
+          { flowcell_type: '10B', request_count: 2, result: false }
+        ].each do |batch_data|
+          it "returns #{batch_data[:result].nil? ? 'nil' : batch_data[:result]} if the flowcell_type is 
+              #{batch_data[:flowcell_type]} and the request count is #{batch_data[:request_count]}" do
+            record = create :batch, request_count: batch_data[:request_count]
+            record.requests.each do |request|
+              request.request_metadata.requested_flowcell_type = batch_data[:flowcell_type]
+            end
+            expect(described_class.new.validate(record)).to be batch_data[:result]
+          end
+        end
+
+        # We want to check we don't flag anything here as its handled by batch creation validator
+        it 'returns nil if the flowcell_type is not 1.5B, 10B, or 25B' do
+          record.requests.each { |request| request.request_metadata.requested_flowcell_type = 'Not a flowcell type' }
+          expect(described_class.new.validate(record)).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #4068

#### Changes proposed in this pull request

-  Adds custom batch creation validator (NovaseqxPeValidator) with methods for handling batch size and flowcell_type shared validation

#### Notes

- If you are testing this you will need to regenerate the pipeline config or manually edit the NovaseqX PE pipeline in the rails console to match the updated record. There is no automatic script to do this as I plan to do it manually for each environment.

```
bundle exec rails c
p = Pipeline.find_by(name: "NovaSeqX PE")
p.min_size = 2
p.validator_class_name = 'NovaseqxPeValidator'
p.save
```


