### PR TITLE
Style change to flash errors

### DIFF
--- a/app/frontend/stylesheets/all/sequencescape.scss
+++ b/app/frontend/stylesheets/all/sequencescape.scss
@@ -134,6 +134,10 @@ h3.card-header-custom {
   }
 }
 
+.alert-error ul {
+  margin: 0;
+}
+
 .alert-notice,
 .alert-passed {
   @extend .alert-success;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,21 +65,21 @@ module ApplicationHelper
     "apple-icon#{icon_suffix}.png"
   end
 
-  def render_flashes # rubocop:disable Metrics/MethodLength
-    flash.each do |key, message|
-      messages = Array(message)
-      concat(
-        alert(key, id: "message_#{key}") do
-          # If there are multiple messages, render them as a list, else render as a single div
-          if messages.size > 1
-            concat(tag.ul(style: 'margin: 0') { messages.each { |m| concat tag.li(m) } })
-          else
-            concat(tag.div(message))
-          end
-        end
-      )
-    end
+  def render_flashes
+    flash.each { |key, message| concat(alert(key, id: "message_#{key}") { render_message(message) }) }
     nil
+  end
+
+  # A helper method for render_flashes - renders a message with the appropriate styling
+  # @param key [String] The type of flash message
+  def render_message(message)
+    messages = Array(message)
+    # If there are multiple messages, render them as a list, else render as a single div
+    if messages.size > 1
+      tag.ul { messages.each { |m| concat tag.li(m) } }
+    else
+      tag.div(messages.first)
+    end
   end
 
   def api_data

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,11 +70,10 @@ module ApplicationHelper
     nil
   end
 
-  # A helper method for render_flashes - renders a message with the appropriate styling
+  # A helper method for render_flashes - If multiple messages, render them as a list, else render as a single div
   # @param key [String] The type of flash message
   def render_message(message)
     messages = Array(message)
-    # If there are multiple messages, render them as a list, else render as a single div
     if messages.size > 1
       tag.ul { messages.each { |m| concat tag.li(m) } }
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,17 +65,19 @@ module ApplicationHelper
     "apple-icon#{icon_suffix}.png"
   end
 
-  def render_flashes
+  def render_flashes # rubocop:disable Metrics/MethodLength
     flash.each do |key, message|
       messages = Array(message)
-      concat(alert(key, id: "message_#{key}") do
-        # If there are multiple messages, render them as a list, else render as a single div  
-        if messages.size > 1
-          concat(tag.ul(style: 'margin: 0') { messages.each { |m| concat tag.li(m) } })
-        else
-          concat tag.div(messages.first)
+      concat(
+        alert(key, id: "message_#{key}") do
+          # If there are multiple messages, render them as a list, else render as a single div
+          if messages > 1
+            concat(tag.ul(style: 'margin: 0') { messages.each { |m| concat tag.li(m) } })
+          else
+            concat(tag.div(message))
+          end
         end
-      end)
+      )
     end
     nil
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,15 @@ module ApplicationHelper
 
   def render_flashes
     flash.each do |key, message|
-      concat(alert(key, id: "message_#{key}") { Array(message).each { |m| concat tag.div(m) } })
+      messages = Array(message)
+      concat(alert(key, id: "message_#{key}") do
+        # If there are multiple messages, render them as a list, else render as a single div  
+        if messages.size > 1
+          concat(tag.ul(style: 'margin: 0') { messages.each { |m| concat tag.li(m) } })
+        else
+          concat tag.div(messages.first)
+        end
+      end)
     end
     nil
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,7 +71,7 @@ module ApplicationHelper
       concat(
         alert(key, id: "message_#{key}") do
           # If there are multiple messages, render them as a list, else render as a single div
-          if messages > 1
+          if messages.size > 1
             concat(tag.ul(style: 'margin: 0') { messages.each { |m| concat tag.li(m) } })
           else
             concat(tag.div(message))


### PR DESCRIPTION
#### Changes proposed in this pull request

- render_flashes displays as a list when there are multiple errors

#### Context
- Based off feedback from Y24-040, when multiple error messages were present they weren't being presented clearly.

Before:
![image](https://github.com/user-attachments/assets/77ed6057-2d77-40ee-8043-7da4af346946)

After: 
<img width="1101" alt="Screenshot 2024-07-22 at 09 30 22" src="https://github.com/user-attachments/assets/2d0fbf1b-6876-4761-86d2-1c1e771b5f99">


