### PR TITLE
Y24-190-1: Support Limber `config:generate` on v2 API

### DIFF
--- a/app/controllers/api/v2/plate_purposes_controller.rb
+++ b/app/controllers/api/v2/plate_purposes_controller.rb
@@ -2,10 +2,10 @@
 
 module Api
   module V2
-    # Provides a JSON API controller for receptacle
+    # Provides a JSON API controller for plate purposes.
     # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
     class PlatePurposesController < JSONAPI::ResourceController
-      # By default JSONAPI::ResourceController provides most the standard
+      # By default JSONAPI::ResourceController provides most of the standard
       # behaviour, and in many cases this file may be left empty.
     end
   end

--- a/app/controllers/api/v2/submission_templates_controller.rb
+++ b/app/controllers/api/v2/submission_templates_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API controller for submission templates.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation.
+    class SubmissionTemplatesController < JSONAPI::ResourceController
+      # By default JSONAPI::ResourceController provides most of the standard
+      # behaviour, and in many cases this file may be left empty.
+    end
+  end
+end

--- a/app/controllers/api/v2/transfer_templates_controller.rb
+++ b/app/controllers/api/v2/transfer_templates_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API controller for transfer templates.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation.
+    class TransferTemplatesController < JSONAPI::ResourceController
+      # By default JSONAPI::ResourceController provides most of the standard
+      # behaviour, and in many cases this file may be left empty.
+    end
+  end
+end

--- a/app/controllers/api/v2/tube_purposes_controller.rb
+++ b/app/controllers/api/v2/tube_purposes_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API controller for tube purposes.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
+    class TubePurposesController < JSONAPI::ResourceController
+      # By default JSONAPI::ResourceController provides most of the standard
+      # behaviour, and in many cases this file may be left empty.
+    end
+  end
+end

--- a/app/models/tube/purpose.rb
+++ b/app/models/tube/purpose.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 # Base class for the all tube purposes, describes the role the associated
-# {Tube} is playing within the lab, and my modify its behaviour.
+# {Tube} is playing within the lab, and modifies its behaviour.
 # This is not an abstract class, and can be used directly.
 # @see Purpose
 class Tube::Purpose < Purpose

--- a/app/resources/api/v2/plate_purpose_resource.rb
+++ b/app/resources/api/v2/plate_purpose_resource.rb
@@ -13,34 +13,34 @@ module Api
 
       # The following attributes are sent by Limber for a new plate purpose.
 
-      # @!attribute name
-      #  @return [String] gets or sets the name of the plate purpose
+      # @!attribute [rw]
+      # @return [String] The name of the plate purpose.
       attribute :name
 
-      # @!attribute stock_plate
-      #  @return [Boolean] gets or sets whether the plates of this purpose are stock plates
+      # @!attribute [rw]
+      # @return [Boolean] Whether the plates of this purpose are stock plates.
       attribute :stock_plate
 
-      # @!attribute cherrypickable_target
-      #  @return [Boolean] gets or sets whether the plates of this purpose are cherrypickable
+      # @!attribute [rw]
+      # @return [Boolean] Whether the plates of this purpose are cherrypickable.
       attribute :cherrypickable_target
 
-      # @!attribute input_plate
-      #  @return [Boolean] gets or sets whether the plates of this purpose are input plates
+      # @!attribute [rw]
+      # @return [Boolean] Whether the plates of this purpose are input plates.
       attribute :input_plate
 
-      # @!attribute size
-      #  @return [Integer] gets or sets the size of the plates of this purpose
+      # @!attribute [rw]
+      # @return [Integer] The size of the plates of this purpose.
       attribute :size
 
-      # @!attribute asset_shape
-      #  @return [String] gets or sets the name of the shape of the plates of this purpose
+      # @!attribute [rw]
+      # @return [String] The name of the shape of the plates of this purpose.
       attribute :asset_shape
 
       # The following attribute is required by Limber to store purposes.
 
-      # @!attribute [r] uuid
-      #  @return [String] gets the UUID of the plate purpose
+      # @!attribute [r]
+      # @return [String] gets the UUID of the plate purpose.
       attribute :uuid
 
       # Sets the asset shape of the plate purpose by name if given.

--- a/app/resources/api/v2/submission_template_resource.rb
+++ b/app/resources/api/v2/submission_template_resource.rb
@@ -19,7 +19,7 @@ module Api
 
       # @!attribute [r]
       # @return [String] The UUID of the submission template.
-      attribute :uuid
+      attribute :uuid, readonly: true
     end
   end
 end

--- a/app/resources/api/v2/submission_template_resource.rb
+++ b/app/resources/api/v2/submission_template_resource.rb
@@ -5,27 +5,21 @@ module Api
     # Provides a JSON API representation of a submission template.
     # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
     class SubmissionTemplateResource < BaseResource
-      # Constants...
-
-      immutable # uncomment to make the resource immutable
-
-      # model_name / model_hint if required
+      immutable
 
       default_includes :uuid_object
 
-      # Associations:
-
+      ###
       # Attributes
+      ###
+
+      # @!attribute [r]
+      # @return [String] The name of the submission template.
       attribute :name
+
+      # @!attribute [r]
+      # @return [String] The UUID of the submission template.
       attribute :uuid
-
-      # Filters
-
-      # Custom methods
-      # These shouldn't be used for business logic, and are more about
-      # I/O and isolating implementation details.
-
-      # Class method overrides
     end
   end
 end

--- a/app/resources/api/v2/submission_template_resource.rb
+++ b/app/resources/api/v2/submission_template_resource.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API representation of a submission template.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
+    class SubmissionTemplateResource < BaseResource
+      # Constants...
+
+      immutable # uncomment to make the resource immutable
+
+      # model_name / model_hint if required
+
+      default_includes :uuid_object
+
+      # Associations:
+
+      # Attributes
+      attribute :name
+      attribute :uuid
+
+      # Filters
+
+      # Custom methods
+      # These shouldn't be used for business logic, and are more about
+      # I/O and isolating implementation details.
+
+      # Class method overrides
+    end
+  end
+end

--- a/app/resources/api/v2/transfer_template_resource.rb
+++ b/app/resources/api/v2/transfer_template_resource.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API representation of a transfer template.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
+    class TransferTemplateResource < BaseResource
+      immutable
+
+      default_includes :uuid_object
+
+      ###
+      # Attributes
+      ###
+
+      # @!attribute [r]
+      # @return [String] The name of the transfer template.
+      attribute :name
+
+      # @!attribute [r]
+      # @return [String] The UUID of the transfer template.
+      attribute :uuid
+    end
+  end
+end

--- a/app/resources/api/v2/transfer_template_resource.rb
+++ b/app/resources/api/v2/transfer_template_resource.rb
@@ -19,7 +19,7 @@ module Api
 
       # @!attribute [r]
       # @return [String] The UUID of the transfer template.
-      attribute :uuid
+      attribute :uuid, readonly: true
     end
   end
 end

--- a/app/resources/api/v2/tube_purpose_resource.rb
+++ b/app/resources/api/v2/tube_purpose_resource.rb
@@ -17,28 +17,11 @@ module Api
 
       # @!attribute [rw]
       # @return [String] The purpose type. This is mapped to the type attribute on the model.
-      attribute :purpose_type
+      attribute :purpose_type, delegate: :type
 
       # @!attribute [rw]
       # @return [String] The target type.
       attribute :target_type
-
-      #####
-      # Custom getters and setters
-      #####
-
-      # Gets the purpose type from the model.
-      # @return [String] The purpose type.
-      def purpose_type
-        @model.type
-      end
-
-      # Set the purpose type on the model.
-      # @param [String] value The purpose type to set.
-      # @return [void]
-      def purpose_type=(value)
-        @model.type = value
-      end
     end
   end
 end

--- a/app/resources/api/v2/tube_purpose_resource.rb
+++ b/app/resources/api/v2/tube_purpose_resource.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API representation of a tube purpose.
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
+    class TubePurposeResource < BaseResource
+      model_name 'Tube::Purpose'
+
+      #####
+      # Attributes
+      #####
+
+      # @!attribute [rw]
+      # @return [String] The name of the tube purpose.
+      attribute :name
+
+      # @!attribute [rw]
+      # @return [String] The purpose type. This is mapped to the type attribute on the model.
+      attribute :purpose_type
+
+      # @!attribute [rw]
+      # @return [String] The target type.
+      attribute :target_type
+
+      #####
+      # Custom getters and setters
+      #####
+
+      # Gets the purpose type from the model.
+      # @return [String] The purpose type.
+      def purpose_type
+        @model.type
+      end
+
+      # Set the purpose type on the model.
+      # @param [String] value The purpose type to set.
+      # @return [void]
+      def purpose_type=(value)
+        @model.type = value
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
       jsonapi_resources :tag_groups
       jsonapi_resources :tag_layout_templates
       jsonapi_resources :transfer_requests
+      jsonapi_resources :transfer_templates
       jsonapi_resources :tube_purposes
       jsonapi_resources :tube_rack_statuses
       jsonapi_resources :tube_racks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     end
   end
 
-  mount Api::RootService.new => '/api/1'
+  mount Api::RootService.new => '/api/1' unless ENV['DISABLE_V1_API']
 
   namespace :api do
     namespace :v2 do
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
       jsonapi_resources :sample_manifests
       jsonapi_resources :sample_metadata
       jsonapi_resources :studies
+      jsonapi_resources :submission_templates
       jsonapi_resources :submissions
       jsonapi_resources :tag_groups
       jsonapi_resources :tag_layout_templates

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
       jsonapi_resources :tag_groups
       jsonapi_resources :tag_layout_templates
       jsonapi_resources :transfer_requests
+      jsonapi_resources :tube_purposes
       jsonapi_resources :tube_rack_statuses
       jsonapi_resources :tube_racks
       jsonapi_resources :tubes

--- a/spec/requests/api/v2/submission_templates_spec.rb
+++ b/spec/requests/api/v2/submission_templates_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './spec/requests/api/v2/shared_examples/api_key_authenticatable'
+
+describe 'Submission Templates API', with: :api_v2 do
+  let(:base_endpoint) { '/api/v2/submission_templates' }
+
+  it_behaves_like 'ApiKeyAuthenticatable'
+
+  describe '#get all Submission Templates' do
+    before { create_list(:submission_template, 5) }
+
+    it 'returns the list of Submission Templates' do
+      api_get base_endpoint
+
+      expect(response).to have_http_status(:success)
+      expect(json['data'].length).to eq(5)
+    end
+  end
+
+  describe '#get a specific Submission Template' do
+    let(:resource_model) { create(:submission_template) }
+
+    it 'returns the template' do
+      api_get "#{base_endpoint}/#{resource_model.id}"
+      expect(response).to have_http_status(:success)
+      expect(json.dig('data', 'type')).to eq('submission_templates')
+      expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
+    end
+  end
+
+  describe '#patch a specific Submission Template' do
+    let(:resource_model) { create(:submission_template) }
+    let(:payload) do
+      {
+        'data' => {
+          'id' => resource_model.id,
+          'type' => 'submission_templates',
+          'attributes' => {
+            'name' => 'Updated Name'
+          }
+        }
+      }
+    end
+
+    it 'finds no route for the method' do
+      expect { api_patch "#{base_endpoint}/#{resource_model.id}", payload }.to raise_error(
+        ActionController::RoutingError
+      )
+    end
+  end
+
+  describe '#post a new Submission Template' do
+    let(:payload) { { 'data' => { 'type' => 'submission_templates', 'attributes' => { 'name' => 'New Name' } } } }
+
+    it 'finds no routes for the method' do
+      expect { api_post base_endpoint, payload }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/requests/api/v2/transfer_templates_spec.rb
+++ b/spec/requests/api/v2/transfer_templates_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './spec/requests/api/v2/shared_examples/api_key_authenticatable'
+
+describe 'Transfer Templates API', with: :api_v2 do
+  let(:base_endpoint) { '/api/v2/transfer_templates' }
+
+  it_behaves_like 'ApiKeyAuthenticatable'
+
+  describe '#get all Transfer Templates' do
+    before { create_list(:transfer_template, 5) }
+
+    it 'returns the list of Transfer Templates' do
+      api_get base_endpoint
+
+      expect(response).to have_http_status(:success)
+      expect(json['data'].length).to eq(5)
+    end
+  end
+
+  describe '#get a specific Transfer Template' do
+    let(:resource_model) { create(:transfer_template) }
+
+    it 'returns the template' do
+      api_get "#{base_endpoint}/#{resource_model.id}"
+      expect(response).to have_http_status(:success)
+      expect(json.dig('data', 'type')).to eq('transfer_templates')
+      expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
+    end
+  end
+
+  describe '#patch a specific Transfer Template' do
+    let(:resource_model) { create(:transfer_template) }
+    let(:payload) do
+      {
+        'data' => {
+          'id' => resource_model.id,
+          'type' => 'transfer_templates',
+          'attributes' => {
+            'name' => 'Updated Name'
+          }
+        }
+      }
+    end
+
+    it 'finds no route for the method' do
+      expect { api_patch "#{base_endpoint}/#{resource_model.id}", payload }.to raise_error(
+        ActionController::RoutingError
+      )
+    end
+  end
+
+  describe '#post a new Transfer Template' do
+    let(:payload) { { 'data' => { 'type' => 'transfer_templates', 'attributes' => { 'name' => 'New Name' } } } }
+
+    it 'finds no routes for the method' do
+      expect { api_post base_endpoint, payload }.to raise_error(ActionController::RoutingError)
+    end
+  end
+end

--- a/spec/requests/api/v2/tube_purposes_spec.rb
+++ b/spec/requests/api/v2/tube_purposes_spec.rb
@@ -35,7 +35,7 @@ describe 'Tube Purposes API', with: :api_v2 do
   describe '#patch a specific Tube Purpose' do
     let(:resource_model) { create(:tube_purpose) }
 
-    context 'patching the name' do
+    context 'when patching the name' do
       let(:updated_name) { 'Updated Name' }
       let(:payload) do
         {
@@ -59,7 +59,7 @@ describe 'Tube Purposes API', with: :api_v2 do
       end
     end
 
-    context 'patching the purpose_type' do
+    context 'when patching the purpose_type' do
       let(:updated_purpose_type) { 'Updated Purpose Type' }
       let(:payload) do
         {
@@ -83,7 +83,7 @@ describe 'Tube Purposes API', with: :api_v2 do
       end
     end
 
-    context 'patching the target_type' do
+    context 'when patching the target_type' do
       let(:updated_target_type) { 'SampleTube' }
       let(:payload) do
         {

--- a/spec/requests/api/v2/tube_purposes_spec.rb
+++ b/spec/requests/api/v2/tube_purposes_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './spec/requests/api/v2/shared_examples/api_key_authenticatable'
+
+describe 'Tube Purposes API', with: :api_v2 do
+  let(:base_endpoint) { '/api/v2/tube_purposes' }
+
+  it_behaves_like 'ApiKeyAuthenticatable'
+
+  describe '#get all Tube Purposes' do
+    before { create_list(:tube_purpose, 5) }
+
+    it 'returns the list of Tube Purposes' do
+      api_get base_endpoint
+
+      expect(response).to have_http_status(:success)
+      expect(json['data'].length).to eq(5)
+    end
+  end
+
+  describe '#get a specific Tube Purpose' do
+    let(:resource_model) { create(:tube_purpose) }
+
+    it 'returns the template' do
+      api_get "#{base_endpoint}/#{resource_model.id}"
+      expect(response).to have_http_status(:success)
+      expect(json.dig('data', 'type')).to eq('tube_purposes')
+      expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
+      expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
+      expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+    end
+  end
+
+  describe '#patch a specific Tube Purpose' do
+    let(:resource_model) { create(:tube_purpose) }
+
+    context 'patching the name' do
+      let(:updated_name) { 'Updated Name' }
+      let(:payload) do
+        {
+          'data' => {
+            'id' => resource_model.id,
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'name' => updated_name
+            }
+          }
+        }
+      end
+
+      it 'patches correctly' do
+        api_patch "#{base_endpoint}/#{resource_model.id}", payload
+        expect(response).to have_http_status(:success)
+        expect(json.dig('data', 'type')).to eq('tube_purposes')
+        expect(json.dig('data', 'attributes', 'name')).to eq(updated_name)
+        expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
+        expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+      end
+    end
+
+    context 'patching the purpose_type' do
+      let(:updated_purpose_type) { 'Updated Purpose Type' }
+      let(:payload) do
+        {
+          'data' => {
+            'id' => resource_model.id,
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'purpose_type' => updated_purpose_type
+            }
+          }
+        }
+      end
+
+      it 'patches correctly' do
+        api_patch "#{base_endpoint}/#{resource_model.id}", payload
+        expect(response).to have_http_status(:success)
+        expect(json.dig('data', 'type')).to eq('tube_purposes')
+        expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
+        expect(json.dig('data', 'attributes', 'purpose_type')).to eq(updated_purpose_type)
+        expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+      end
+    end
+
+    context 'patching the target_type' do
+      let(:updated_target_type) { 'SampleTube' }
+      let(:payload) do
+        {
+          'data' => {
+            'id' => resource_model.id,
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'target_type' => updated_target_type
+            }
+          }
+        }
+      end
+
+      it 'patches correctly' do
+        api_patch "#{base_endpoint}/#{resource_model.id}", payload
+        expect(response).to have_http_status(:success)
+        expect(json.dig('data', 'type')).to eq('tube_purposes')
+        expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
+        expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
+        expect(json.dig('data', 'attributes', 'target_type')).to eq(updated_target_type)
+      end
+    end
+  end
+
+  describe '#post a new Tube Purpose' do
+    context 'with a valid payload' do
+      let(:payload) do
+        {
+          'data' => {
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'name' => 'New Name',
+              'purpose_type' => 'Test Purpose Type',
+              'target_type' => 'MultiplexedLibraryTube'
+            }
+          }
+        }
+      end
+
+      it 'creates the Tube Purpose' do
+        api_post base_endpoint, payload
+        expect(response).to have_http_status(:created)
+        expect(json.dig('data', 'type')).to eq('tube_purposes')
+        expect(json.dig('data', 'attributes', 'name')).to eq('New Name')
+        expect(json.dig('data', 'attributes', 'purpose_type')).to eq('Test Purpose Type')
+        expect(json.dig('data', 'attributes', 'target_type')).to eq('MultiplexedLibraryTube')
+      end
+    end
+
+    context 'with an invalid payload (missing target_type)' do
+      let(:payload) do
+        {
+          'data' => {
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'name' => 'New Name',
+              'purpose_type' => 'Test Purpose Type'
+            }
+          }
+        }
+      end
+
+      it 'responds with 422 unprocessable entity' do
+        api_post base_endpoint, payload
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end

--- a/spec/resources/api/v2/submission_template_resource_spec.rb
+++ b/spec/resources/api/v2/submission_template_resource_spec.rb
@@ -1,20 +1,25 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './app/resources/api/v2/plate_template_resource'
+require './app/resources/api/v2/submission_template_resource'
 
-RSpec.describe Api::V2::PlateTemplateResource, type: :resource do
+RSpec.describe Api::V2::SubmissionTemplateResource, type: :resource do
   subject(:resource) { described_class.new(resource_model, {}) }
 
-  let(:resource_model) { build_stubbed :plate_template }
+  let(:resource_model) { build_stubbed :submission_template }
 
   # Test attributes
   it 'has the expected attributes', :aggregate_failures do
     expect(resource).not_to have_attribute :id
     expect(resource).to have_attribute :uuid
+    expect(resource).to have_attribute :name
   end
 
   # Updatable fields
+  it 'allows updating of read-write fields', :aggregate_failures do
+    expect(resource).to have_updatable_field :name
+  end
+
   it 'disallows updating of read only fields', :aggregate_failures do
     expect(resource).not_to have_updatable_field :uuid
   end

--- a/spec/resources/api/v2/transfer_template_resource_spec.rb
+++ b/spec/resources/api/v2/transfer_template_resource_spec.rb
@@ -1,20 +1,25 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-require './app/resources/api/v2/plate_template_resource'
+require './app/resources/api/v2/transfer_template_resource'
 
-RSpec.describe Api::V2::PlateTemplateResource, type: :resource do
+RSpec.describe Api::V2::TransferTemplateResource, type: :resource do
   subject(:resource) { described_class.new(resource_model, {}) }
 
-  let(:resource_model) { build_stubbed :plate_template }
+  let(:resource_model) { build_stubbed :transfer_template }
 
   # Test attributes
   it 'has the expected attributes', :aggregate_failures do
     expect(resource).not_to have_attribute :id
     expect(resource).to have_attribute :uuid
+    expect(resource).to have_attribute :name
   end
 
   # Updatable fields
+  it 'allows updating of read-write fields', :aggregate_failures do
+    expect(resource).to have_updatable_field :name
+  end
+
   it 'disallows updating of read only fields', :aggregate_failures do
     expect(resource).not_to have_updatable_field :uuid
   end

--- a/spec/resources/api/v2/tube_purpose_resource_spec.rb
+++ b/spec/resources/api/v2/tube_purpose_resource_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './app/resources/api/v2/tube_purpose_resource'
+
+RSpec.describe Api::V2::TubePurposeResource, type: :resource do
+  subject(:resource) { described_class.new(resource_model, {}) }
+
+  let(:resource_model) { build_stubbed :tube_purpose }
+
+  # Test attributes
+  it 'has the expected attributes', :aggregate_failures do
+    expect(resource).not_to have_attribute :id
+    expect(resource).to have_attribute :name
+    expect(resource).to have_attribute :purpose_type
+    expect(resource).to have_attribute :target_type
+  end
+
+  # Updatable fields
+  it 'allows updating of read-write fields', :aggregate_failures do
+    expect(resource).to have_updatable_field :name
+    expect(resource).to have_updatable_field :purpose_type
+    expect(resource).to have_updatable_field :target_type
+  end
+
+  # Filters
+  # eg. it { is_expected.to filter(:order_type) }
+
+  # Associations
+  # eg. it { is_expected.to have_many(:samples).with_class_name('Sample') }
+
+  # Custom method tests
+  # Add tests for any custom methods you've added.
+end


### PR DESCRIPTION
Closes #4214 

#### Changes proposed in this pull request

- Add new endpoints for migrated usage in Limber's `config:generate` Rake task.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  