### PR TITLE
Y24-178 - corrects request_class_name for scRNA core cDNA prep request type

### DIFF
--- a/config/default_records/request_types/014_limber_scrna_core_cdna_prep_request_types.wip.yml
+++ b/config/default_records/request_types/014_limber_scrna_core_cdna_prep_request_types.wip.yml
@@ -8,7 +8,7 @@ limber_scrna_core_cdna_prep_gem_x_5p:
   name: scRNA Core cDNA Prep
   asset_type: SampleTube
   order: 1
-  request_class_name: IlluminaHtp::Requests::StdLibraryRequest
+  request_class_name: CustomerRequest
   for_multiplexing: false
   billable: true
   product_line_name: Short Read


### PR DESCRIPTION
#### Changes proposed in this pull request

- update request_class_name for limber_scrna_core_cdna_prep_gem_x_5p since it is no longer considered library prep

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
