### PR TITLE
Fix: Add uuid to tube purpose resource

### DIFF
--- a/app/resources/api/v2/tube_purpose_resource.rb
+++ b/app/resources/api/v2/tube_purpose_resource.rb
@@ -26,6 +26,22 @@ module Api
       # @!attribute [r]
       # @return [String] gets the UUID of the tube purpose.
       attribute :uuid
+
+      # Gets the list of fields which are creatable on a TubePurpose.
+      #
+      # @param _context [JSONAPI::Resource::Context] not used
+      # @return [Array<Symbol>] the list of creatable fields.
+      def self.creatable_fields(_context)
+        super - %i[uuid] # Do not allow creating with any readonly fields
+      end
+
+      # Gets the list of fields which are updatable on an existing TubePurpose.
+      #
+      # @param _context [JSONAPI::Resource::Context] not used
+      # @return [Array<Symbol>] the list of updatable fields.
+      def self.updatable_fields(_context)
+        super - %i[uuid] # Do not allow creating with any readonly fields
+      end
     end
   end
 end

--- a/app/resources/api/v2/tube_purpose_resource.rb
+++ b/app/resources/api/v2/tube_purpose_resource.rb
@@ -22,6 +22,10 @@ module Api
       # @!attribute [rw]
       # @return [String] The target type.
       attribute :target_type
+
+      # @!attribute [r]
+      # @return [String] gets the UUID of the tube purpose.
+      attribute :uuid
     end
   end
 end

--- a/spec/requests/api/v2/tube_purposes_spec.rb
+++ b/spec/requests/api/v2/tube_purposes_spec.rb
@@ -29,6 +29,7 @@ describe 'Tube Purposes API', with: :api_v2 do
       expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
       expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
       expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+      expect(json.dig('data', 'attributes', 'uuid')).to eq(resource_model.uuid)
     end
   end
 
@@ -56,6 +57,7 @@ describe 'Tube Purposes API', with: :api_v2 do
         expect(json.dig('data', 'attributes', 'name')).to eq(updated_name)
         expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
         expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+        expect(json.dig('data', 'attributes', 'uuid')).to eq(resource_model.uuid)
       end
     end
 
@@ -80,6 +82,7 @@ describe 'Tube Purposes API', with: :api_v2 do
         expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
         expect(json.dig('data', 'attributes', 'purpose_type')).to eq(updated_purpose_type)
         expect(json.dig('data', 'attributes', 'target_type')).to eq(resource_model.target_type)
+        expect(json.dig('data', 'attributes', 'uuid')).to eq(resource_model.uuid)
       end
     end
 
@@ -104,6 +107,27 @@ describe 'Tube Purposes API', with: :api_v2 do
         expect(json.dig('data', 'attributes', 'name')).to eq(resource_model.name)
         expect(json.dig('data', 'attributes', 'purpose_type')).to eq(resource_model.type)
         expect(json.dig('data', 'attributes', 'target_type')).to eq(updated_target_type)
+        expect(json.dig('data', 'attributes', 'uuid')).to eq(resource_model.uuid)
+      end
+    end
+
+    context 'when patching the uuid' do
+      let(:updated_uuid) { 'new-uuid' }
+      let(:payload) do
+        {
+          'data' => {
+            'id' => resource_model.id,
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'uuid' => updated_uuid
+            }
+          }
+        }
+      end
+
+      it 'returns 400, because uuid is read-only' do
+        api_patch "#{base_endpoint}/#{resource_model.id}", payload
+        expect(response).to have_http_status(400)
       end
     end
   end
@@ -149,6 +173,27 @@ describe 'Tube Purposes API', with: :api_v2 do
       it 'responds with 422 unprocessable entity' do
         api_post base_endpoint, payload
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'with an invalid payload (includes uuid)' do
+      let(:payload) do
+        {
+          'data' => {
+            'type' => 'tube_purposes',
+            'attributes' => {
+              'name' => 'New Name',
+              'purpose_type' => 'Test Purpose Type',
+              'target_type' => 'MultiplexedLibraryTube',
+              'uuid' => 'new-uuid'
+            }
+          }
+        }
+      end
+
+      it 'returns 400, because uuid is read-only' do
+        api_post base_endpoint, payload
+        expect(response).to have_http_status(400)
       end
     end
   end

--- a/spec/requests/api/v2/tube_purposes_spec.rb
+++ b/spec/requests/api/v2/tube_purposes_spec.rb
@@ -125,9 +125,9 @@ describe 'Tube Purposes API', with: :api_v2 do
         }
       end
 
-      it 'returns 400, because uuid is read-only' do
+      it 'responds with 400 bad request, because uuid is read-only' do
         api_patch "#{base_endpoint}/#{resource_model.id}", payload
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end
@@ -191,9 +191,9 @@ describe 'Tube Purposes API', with: :api_v2 do
         }
       end
 
-      it 'returns 400, because uuid is read-only' do
+      it 'responds with 400 bad request, because uuid is read-only' do
         api_post base_endpoint, payload
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(:bad_request)
       end
     end
   end

--- a/spec/resources/api/v2/tube_purpose_resource_spec.rb
+++ b/spec/resources/api/v2/tube_purpose_resource_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Api::V2::TubePurposeResource, type: :resource do
     expect(resource).to have_attribute :name
     expect(resource).to have_attribute :purpose_type
     expect(resource).to have_attribute :target_type
+    expect(resource).to have_attribute :uuid
   end
 
   # Updatable fields
@@ -21,6 +22,7 @@ RSpec.describe Api::V2::TubePurposeResource, type: :resource do
     expect(resource).to have_updatable_field :name
     expect(resource).to have_updatable_field :purpose_type
     expect(resource).to have_updatable_field :target_type
+    expect(resource).not_to have_updatable_field :uuid
   end
 
   # Filters


### PR DESCRIPTION


Closes #

#### Changes proposed in this pull request

- it was breaking Limber config generate task as that needed to retrieve the uuid
- copied over from the plate purpose resource

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
