### PR TITLE
DPL-1104 - Adds NovaSeq 6000 PE sequencing request to the RVI Bait Capture Library Prep submission

### DIFF
--- a/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
+++ b/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
@@ -4,7 +4,7 @@
 Limber-Htp - RVI - Bait Capture Library:
   submission_class_name: "LinearSubmission"
   related_records:
-    request_type_keys: ["limber_bait_capture_library_prep", "limber_multiplexing"]
+    request_type_keys: ["limber_bait_capture_library_prep", "limber_multiplexing", "illumina_htp_novaseq_6000_paired_end_sequencing"]
     project_name: Respiratory Virus and Microbiome Initiative
     product_line_name: Illumina-HTP
     product_catalogue_name: Bait Capture Library

--- a/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
+++ b/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
@@ -4,7 +4,8 @@
 Limber-Htp - RVI - Bait Capture Library:
   submission_class_name: "LinearSubmission"
   related_records:
-    request_type_keys: ["limber_bait_capture_library_prep", "limber_multiplexing", "illumina_htp_novaseq_6000_paired_end_sequencing"]
+    request_type_keys:
+      ["limber_bait_capture_library_prep", "limber_multiplexing", "illumina_htp_novaseq_6000_paired_end_sequencing"]
     project_name: Respiratory Virus and Microbiome Initiative
     product_line_name: Illumina-HTP
     product_catalogue_name: Bait Capture Library

--- a/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
+++ b/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
@@ -1,7 +1,6 @@
 # This submission template is associated with the Limber Bait Capture Library preparation pipeline.
-# To create this run WIP=010_bait_capture_library_submission_templates rake record_loader:all
 ---
-Limber-Htp - RVI - Bait Capture Library:
+Limber-Htp - RVI Bait Capture Library - NovaSeq 6000 Paired end sequencing:
   submission_class_name: "LinearSubmission"
   related_records:
     request_type_keys:


### PR DESCRIPTION
Closes #4023 

#### Changes proposed in this pull request

- Adds NovaSeq 6000 PE sequencing request to the RVI Bait Capture Library Prep submission

#### Instructions for Reviewers

Requires manually updating
```
bundle exec rails c
rt = RequestType.find_by(key: 'illumina_htp_novaseq_6000_paired_end_sequencing')
st = SubmissionTemplate.find_by(name: 'Limber-Htp - RVI - Bait Capture Library')
st.name = 'Limber-Htp - RVI Bait Capture Library - NovaSeq 6000 Paired end sequencing'
st[:submission_parameters][:request_type_ids_list].push(rt.id)
st.save
```

