### PR TITLE
Revert "[ruby] Update bullet 7.1.6 → 7.2.0 (minor)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
-    bullet (7.2.0)
+    bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     bunny (2.22.0)
@@ -560,7 +560,7 @@ GEM
       backports (>= 3.18)
       rainbow
       yard
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   arm64-darwin


### PR DESCRIPTION
Reverts sanger/sequencescape#4202