### PR TITLE
Revert "DPL-1104 - Adds NovaSeq 6000 PE sequencing request to the RVI Bait Capture Library Prep submission"

### DIFF
--- a/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
+++ b/config/default_records/submission_templates/010_rvi_bait_capture_library_submission_templates.yml
@@ -1,10 +1,10 @@
 # This submission template is associated with the Limber Bait Capture Library preparation pipeline.
+# To create this run WIP=010_bait_capture_library_submission_templates rake record_loader:all
 ---
-Limber-Htp - RVI Bait Capture Library - NovaSeq 6000 Paired end sequencing:
+Limber-Htp - RVI - Bait Capture Library:
   submission_class_name: "LinearSubmission"
   related_records:
-    request_type_keys:
-      ["limber_bait_capture_library_prep", "limber_multiplexing", "illumina_htp_novaseq_6000_paired_end_sequencing"]
+    request_type_keys: ["limber_bait_capture_library_prep", "limber_multiplexing"]
     project_name: Respiratory Virus and Microbiome Initiative
     product_line_name: Illumina-HTP
     product_catalogue_name: Bait Capture Library


### PR DESCRIPTION
Reverts sanger/sequencescape#4245

Cause: Bug spotted with RVI pipeline where the library requests arent getting 'started', causing the final sequencing request to be unavailable due to pending parents. We don't want to make this submission available in production until this bug is fixed so moving this out of develop.