### PR TITLE
Y24-190-3: Handle a missing User on transfers

### DIFF
--- a/app/resources/api/v2/transfers/transfer_resource.rb
+++ b/app/resources/api/v2/transfers/transfer_resource.rb
@@ -49,7 +49,7 @@ module Api
         attribute :user_uuid
 
         def user_uuid
-          @model.user.uuid
+          @model.user&.uuid # Some old data may not have a User relationship even though it's required for new records.
         end
 
         def user_uuid=(uuid)

--- a/spec/requests/api/v2/transfers/transfers_spec.rb
+++ b/spec/requests/api/v2/transfers/transfers_spec.rb
@@ -11,7 +11,7 @@ describe 'Transfer API', with: :api_v2 do
   it_behaves_like 'ApiKeyAuthenticatable'
 
   context 'with a list of Transfers' do
-    let!(:transfers) { create_list(:transfer_between_plates, 5) }
+    let(:transfers) { create_list(:transfer_between_plates, 5) }
 
     describe '#get all Transfers' do
       before { api_get base_endpoint }

--- a/spec/requests/api/v2/transfers/transfers_spec.rb
+++ b/spec/requests/api/v2/transfers/transfers_spec.rb
@@ -11,7 +11,7 @@ describe 'Transfer API', with: :api_v2 do
   it_behaves_like 'ApiKeyAuthenticatable'
 
   context 'with a list of Transfers' do
-    let(:transfers) { create_list(:transfer_between_plates, 5) }
+    before { create_list(:transfer_between_plates, 5) }
 
     describe '#get all Transfers' do
       before { api_get base_endpoint }

--- a/spec/requests/api/v2/transfers/transfers_spec.rb
+++ b/spec/requests/api/v2/transfers/transfers_spec.rb
@@ -26,25 +26,58 @@ describe 'Transfer API', with: :api_v2 do
     end
 
     describe '#get Transfer by ID' do
-      let(:transfer) { transfers.first }
+      context 'with all relationships' do
+        let(:transfer) { create :transfer_between_plates }
 
-      before { api_get "#{base_endpoint}/#{transfer.id}" }
+        before { api_get "#{base_endpoint}/#{transfer.id}" }
 
-      it 'responds with a success http code' do
-        expect(response).to have_http_status(:success)
+        it 'responds with a success http code' do
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns the Transfer' do
+          expect(json.dig('data', 'id')).to eq(transfer.id.to_s)
+          expect(json.dig('data', 'type')).to eq('between_plates')
+          expect(json.dig('data', 'attributes', 'uuid')).to eq(transfer.uuid)
+          expect(json.dig('data', 'attributes', 'user_uuid')).to eq(transfer.user.uuid)
+          expect(json.dig('data', 'attributes', 'source_uuid')).to eq(transfer.source.uuid)
+          expect(json.dig('data', 'attributes', 'destination_uuid')).to eq(transfer.destination.uuid)
+          expect(json.dig('data', 'attributes', 'transfers')).to eq(transfer.transfers)
+
+          # We don't want to see the TransferTemplate UUID as it's not fetchable.
+          expect(json.dig('data', 'attributes', 'transfer_template_uuid')).not_to be_present
+        end
       end
 
-      it 'returns the Transfer' do
-        expect(json.dig('data', 'id')).to eq(transfer.id.to_s)
-        expect(json.dig('data', 'type')).to eq('between_plates')
-        expect(json.dig('data', 'attributes', 'uuid')).to eq(transfer.uuid)
-        expect(json.dig('data', 'attributes', 'user_uuid')).to eq(transfer.user.uuid)
-        expect(json.dig('data', 'attributes', 'source_uuid')).to eq(transfer.source.uuid)
-        expect(json.dig('data', 'attributes', 'destination_uuid')).to eq(transfer.destination.uuid)
-        expect(json.dig('data', 'attributes', 'transfers')).to eq(transfer.transfers)
+      # Some old data may not have a User relationship even though it's required for new records.
+      context 'without a User relationship' do
+        let(:transfer) { create :transfer_between_plates }
 
-        # We don't want to see the TransferTemplate UUID as it's not fetchable.
-        expect(json.dig('data', 'attributes', 'transfer_template_uuid')).not_to be_present
+        before do
+          # We need to remove the user relationship without invoking validations.
+          # The validations prevent new records from being created without a User.
+          transfer.user = nil
+          transfer.save(validate: false)
+
+          api_get "#{base_endpoint}/#{transfer.id}"
+        end
+
+        it 'responds with a success http code' do
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns the Transfer' do
+          expect(json.dig('data', 'id')).to eq(transfer.id.to_s)
+          expect(json.dig('data', 'type')).to eq('between_plates')
+          expect(json.dig('data', 'attributes', 'uuid')).to eq(transfer.uuid)
+          expect(json.dig('data', 'attributes', 'user_uuid')).not_to be_present
+          expect(json.dig('data', 'attributes', 'source_uuid')).to eq(transfer.source.uuid)
+          expect(json.dig('data', 'attributes', 'destination_uuid')).to eq(transfer.destination.uuid)
+          expect(json.dig('data', 'attributes', 'transfers')).to eq(transfer.transfers)
+
+          # We don't want to see the TransferTemplate UUID as it's not fetchable.
+          expect(json.dig('data', 'attributes', 'transfer_template_uuid')).not_to be_present
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #4274 

#### Changes proposed in this pull request

- Upon testing in UAT, it turns out that not all legacy transfers have a User.
- Therefore I've added a test for that situation and added a fix for retrieving those records.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  