### PR TITLE
Y24-087 - Error messages for labwhere reception

### DIFF
--- a/app/models/labwhere_reception.rb
+++ b/app/models/labwhere_reception.rb
@@ -55,7 +55,11 @@ class LabwhereReception
         )
 
       unless scan.valid?
-        errors.add(:scan, scan.error)
+        # Prepend the errors with 'Labwhere' to make it clear where the error came from
+        # This is important as you can get both Sequencescape and Labwhere errors of the same type
+        # e.g. User does not exist
+        labwhere_errors = scan.errors.map { |error| "Labwhere #{error}" }
+        errors.add(:base, labwhere_errors)
         return false
       end
     rescue LabWhereClient::LabwhereException => e

--- a/app/models/labwhere_reception.rb
+++ b/app/models/labwhere_reception.rb
@@ -58,7 +58,7 @@ class LabwhereReception
         # Prepend the errors with 'Labwhere' to make it clear where the error came from
         # This is important as you can get both Sequencescape and Labwhere errors of the same type
         # e.g. User does not exist
-        labwhere_errors = scan.errors.map { |error| "Labwhere #{error}" }
+        labwhere_errors = scan.errors.map { |error| "LabWhere #{error}" }
         errors.add(:base, labwhere_errors)
         return false
       end

--- a/app/views/labwhere_receptions/create.html.erb
+++ b/app/views/labwhere_receptions/create.html.erb
@@ -1,6 +1,6 @@
 <%= page_title 'Labwhere Reception' %>
 
-<% if @labwhere_reception.valid? %>
+<% if @labwhere_reception.valid? && @labwhere_reception.errors.nil? %>
   <h4>Receipt</h4>
   <p>The following labware has been scanned in.</p>
   <ul class="list-group">

--- a/app/views/labwhere_receptions/create.html.erb
+++ b/app/views/labwhere_receptions/create.html.erb
@@ -1,6 +1,6 @@
 <%= page_title 'Labwhere Reception' %>
 
-<% if @labwhere_reception.valid? && @labwhere_reception.errors.nil? %>
+<% if @labwhere_reception.errors.empty? && @labwhere_reception.valid? %>
   <h4>Receipt</h4>
   <p>The following labware has been scanned in.</p>
   <ul class="list-group">

--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -18,7 +18,6 @@ module LabWhereClient
 
     def parse_json(str)
       return nil if str == 'null'
-
       JSON.parse(str)
     rescue JSON::ParserError => e
       raise LabwhereException.new(e), 'LabWhere is returning unexpected content', e.backtrace

--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -150,10 +150,6 @@ module LabWhereClient
     def valid?
       @errors.nil?
     end
-
-    def error
-      @errors.join(';')
-    end
   end
 
   class Location < Endpoint

--- a/spec/controllers/labwhere_receptions_controller_spec.rb
+++ b/spec/controllers/labwhere_receptions_controller_spec.rb
@@ -15,7 +15,7 @@ describe LabwhereReceptionsController do
           location_barcode: location_barcode,
           user_code: SBCF::SangerBarcode.from_human(user.barcode).machine_barcode.to_s,
           labware_barcodes: [plate.human_barcode, plate_2.machine_barcode, sample_tube.human_barcode]
-        ).and_return(instance_double(LabWhereClient::Scan, valid?: true, error: ''))
+        ).and_return(instance_double(LabWhereClient::Scan, valid?: true, errors: []))
 
         post :create,
              params: {

--- a/spec/features/labwhere_reception_spec.rb
+++ b/spec/features/labwhere_reception_spec.rb
@@ -7,6 +7,8 @@ describe 'Labwhere reception', :js do
   let(:plate) { create :plate }
 
   before { configatron.labwhere_api = 'https://labwhere.example.com/api' }
+  # Reset the configatron value after the test to avoid affecting other tests
+  after { configatron.labwhere_api = nil }
 
   it 'user can scan plates into the reception' do
     allow(RestClient).to receive(:post).with(
@@ -54,7 +56,7 @@ describe 'Labwhere reception', :js do
     fill_in('User barcode or swipecard', with: 12_345)
     fill_in('asset_scan', with: plate.human_barcode).send_keys(:return)
     click_on 'Update locations'
-    expect(page).to have_content 'Labwhere User does not exist'
+    expect(page).to have_content 'LabWhere User does not exist'
     expect(page).to have_no_content plate.human_barcode
     expect(page).to have_no_content plate.purpose.name
     expect(page).to have_no_link plate.name, href: labware_path(plate)

--- a/spec/features/labwhere_reception_spec.rb
+++ b/spec/features/labwhere_reception_spec.rb
@@ -6,7 +6,14 @@ describe 'Labwhere reception', :js do
   let(:user) { create :user, email: 'login@example.com', swipecard_code: 12_345 }
   let(:plate) { create :plate }
 
+  before { configatron.labwhere_api = 'https://labwhere.example.com/api' }
+
   it 'user can scan plates into the reception' do
+    allow(RestClient).to receive(:post).with(
+      "#{configatron.labwhere_api}/scans/",
+      { scan: { labware_barcodes: 'SQPD-1', location_barcode: '', user_code: '12345' } }
+    ).and_return('{"data":[]}')
+
     login_user user
     visit labwhere_receptions_path
     expect(page).to have_content 'Labwhere Reception'
@@ -29,8 +36,27 @@ describe 'Labwhere reception', :js do
       fill_in('asset_scan', with: plate.human_barcode).send_keys(:return)
       click_on 'Update locations'
     end
+    expect(page).to have_content 'Locations updated!'
     expect(page).to have_content plate.human_barcode
     expect(page).to have_content plate.purpose.name
     expect(page).to have_link plate.name, href: labware_path(plate)
+  end
+
+  it 'displays the correct labwhere error messages' do
+    allow(RestClient).to receive(:post).with(
+      "#{configatron.labwhere_api}/scans/",
+      { scan: { labware_barcodes: 'SQPD-1', location_barcode: '', user_code: '12345' } }
+    ).and_return('{"errors":["User does not exist"]}')
+
+    login_user user
+    visit labwhere_receptions_path
+    expect(page).to have_content 'Labwhere Reception'
+    fill_in('User barcode or swipecard', with: 12_345)
+    fill_in('asset_scan', with: plate.human_barcode).send_keys(:return)
+    click_on 'Update locations'
+    expect(page).to have_content 'Labwhere User does not exist'
+    expect(page).to have_no_content plate.human_barcode
+    expect(page).to have_no_content plate.purpose.name
+    expect(page).to have_no_link plate.name, href: labware_path(plate)
   end
 end

--- a/spec/lib/lab_where_client_spec.rb
+++ b/spec/lib/lab_where_client_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'lab_where_client'
+
+RSpec.describe LabWhereClient do
+  describe LabWhereClient::Scan do
+    let(:scan_params) { { 'message' => 'Scan successful', 'errors' => nil } }
+    let(:scan) { described_class.new(scan_params) }
+
+    it 'has the correct attributes' do
+      expect(scan.message).to eq('Scan successful')
+      expect(scan.errors).to be_nil
+    end
+
+    it 'has the correct endpoint_name' do
+      expect(described_class.endpoint).to eq('scans')
+    end
+
+    it 'has a response_message' do
+      expect(scan.response_message).to eq('Scan successful')
+    end
+
+    it 'has the correct creation_params' do
+      expect(described_class.creation_params(labware_barcodes: %w[123 456])).to eq(
+        scan: {
+          labware_barcodes: "123\n456"
+        }
+      )
+    end
+
+    describe '#create' do
+      it 'posts a scan to LabWhere' do
+        labwhere = instance_double(LabWhereClient::LabWhere)
+        allow(LabWhereClient::LabWhere).to receive(:new).and_return(labwhere)
+        allow(labwhere).to receive(:post)
+        described_class.create(location_barcode: '123', user_code: '456', labware_barcodes: ['789'])
+        expect(labwhere).to have_received(:post).with(
+          described_class,
+          nil,
+          { scan: { labware_barcodes: '789', user_code: '456', location_barcode: '123' } }
+        )
+      end
+
+      it 'raises an error when Labwhere is down' do
+        labwhere = instance_double(LabWhereClient::LabWhere)
+        allow(LabWhereClient::LabWhere).to receive(:new).and_return(labwhere)
+        allow(labwhere).to receive(:post).and_raise(LabWhereClient::LabwhereException.new, 'LabWhere service is down')
+
+        expect do
+          described_class.create(location_barcode: '123', user_code: '456', labware_barcodes: ['789'])
+        end.to raise_error(LabWhereClient::LabwhereException, 'LabWhere service is down')
+      end
+    end
+
+    describe '#valid?' do
+      it 'returns true when there are no errors' do
+        expect(scan.valid?).to be true
+      end
+
+      it 'returns false when there are errors' do
+        scan_params['errors'] = 'Error message'
+        expect(scan.valid?).to be false
+      end
+    end
+  end
+end

--- a/spec/models/labwhere_reception_spec.rb
+++ b/spec/models/labwhere_reception_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe LabwhereReception do
     expect(labwhere_reception.save).to be_falsey
     expect(labwhere_reception.errors).not_to be_empty
     expect(labwhere_reception.errors.full_messages.first).to eq(
-      ['Labwhere User not recognised', 'Labwhere Location does not exist']
+      ['LabWhere User not recognised', 'LabWhere Location does not exist']
     )
   end
 end

--- a/spec/models/labwhere_reception_spec.rb
+++ b/spec/models/labwhere_reception_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LabwhereReception do
 
   it 'records an event' do
     allow(LabWhereClient::Scan).to receive(:create).and_return(
-      instance_double(LabWhereClient::Scan, valid?: true, error: '')
+      instance_double(LabWhereClient::Scan, valid?: true, errors: [])
     )
     reception = described_class.new('12345', location, [plate_1.human_barcode])
     expect(reception.save).to be_truthy
@@ -22,7 +22,7 @@ RSpec.describe LabwhereReception do
       location_barcode: 'labwhere_location',
       user_code: '12345',
       labware_barcodes: [plate_1.human_barcode, plate_2.machine_barcode]
-    ).and_return(instance_double(LabWhereClient::Scan, valid?: true, error: ''))
+    ).and_return(instance_double(LabWhereClient::Scan, valid?: true, errors: []))
     labwhere_reception =
       described_class.new('12345', 'labwhere_location', [plate_1.human_barcode, plate_2.machine_barcode])
     expect(labwhere_reception.save).to be_truthy
@@ -49,14 +49,14 @@ RSpec.describe LabwhereReception do
       location_barcode: 'labwhere_location',
       user_code: '12345',
       labware_barcodes: %w[1 11111111111111]
-    ).and_return(instance_double(LabWhereClient::Scan, valid?: true, error: ''))
+    ).and_return(instance_double(LabWhereClient::Scan, valid?: true, errors: []))
     labwhere_reception = described_class.new('12345', 'labwhere_location', %w[1 11111111111111])
     expect(labwhere_reception.save).to be_truthy
   end
 
   it 'does not scan the labware into the location if no user supplied' do
     allow(LabWhereClient::Scan).to receive(:create).and_return(
-      instance_double(LabWhereClient::Scan, valid?: true, error: '')
+      instance_double(LabWhereClient::Scan, valid?: true, errors: [])
     )
     labwhere_reception = described_class.new('', 'labwhere_location', [plate_1.human_barcode, plate_2.machine_barcode])
     expect(labwhere_reception.save).to be_falsey
@@ -65,7 +65,7 @@ RSpec.describe LabwhereReception do
 
   it 'does not scan the labware into the location if no barcodes scanned' do
     allow(LabWhereClient::Scan).to receive(:create).and_return(
-      instance_double(LabWhereClient::Scan, valid?: true, error: '')
+      instance_double(LabWhereClient::Scan, valid?: true, errors: [])
     )
     labwhere_reception = described_class.new('12345', 'labwhere_location', [])
     expect(labwhere_reception.save).to be_falsey
@@ -74,7 +74,7 @@ RSpec.describe LabwhereReception do
 
   it 'does not scan the labware into the location if scan was not created' do
     allow(LabWhereClient::Scan).to receive(:create).and_return(
-      instance_double(LabWhereClient::Scan, valid?: false, error: '')
+      instance_double(LabWhereClient::Scan, valid?: false, errors: [])
     )
     labwhere_reception =
       described_class.new('12345', 'labwhere_location', [plate_1.human_barcode, plate_2.machine_barcode])
@@ -87,5 +87,18 @@ RSpec.describe LabwhereReception do
       described_class.new('12345', 'labwhere_location', [plate_1.human_barcode, plate_2.machine_barcode])
     expect(labwhere_reception.save).to be_falsey
     expect(labwhere_reception.errors).not_to be_empty
+  end
+
+  it 'does not scan the labware into the location if Labwhere returns errors' do
+    allow(LabWhereClient::Scan).to receive(:create).and_return(
+      instance_double(LabWhereClient::Scan, valid?: false, errors: ['User not recognised', 'Location does not exist'])
+    )
+    labwhere_reception =
+      described_class.new('12345', 'labwhere_location', [plate_1.human_barcode, plate_2.machine_barcode])
+    expect(labwhere_reception.save).to be_falsey
+    expect(labwhere_reception.errors).not_to be_empty
+    expect(labwhere_reception.errors.full_messages.first).to eq(
+      ['Labwhere User not recognised', 'Labwhere Location does not exist']
+    )
   end
 end


### PR DESCRIPTION
#### Changes proposed in this pull request

- Adds 'Labwhere' prefix to labwhere reception scan error messages.
- Adds error check in labwhere_reception create.html to prevent showing successful receipt upon failure.

**New error messages with Labwhere prefix**
![Screenshot 2024-09-06 at 15 29 18](https://github.com/user-attachments/assets/5cc759c9-e07e-4b2f-a92b-2ef1539326fc)

