### PR TITLE
CI Fix - Bumps upload artifact action

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -126,7 +126,7 @@ jobs:
           DBPORT: ${{ job.services.mysql.ports[3306] }}
         run: bin/knapsack_pro_rspec
       - name: Upload capybara artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         if: ${{ failure() }}
         with:
           name: capybara-${{ github.job }}-${{ matrix.ci_node_index }}
@@ -191,7 +191,7 @@ jobs:
           DBPORT: ${{ job.services.mysql.ports[3306] }}
         run: bin/knapsack_pro_cucumber
       - name: Upload capybara artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         if: ${{ failure() }}
         with:
           name: capybara-${{ github.job }}-${{ matrix.ci_node_index }}


### PR DESCRIPTION
[upload-artifact action is deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/) and now causing errors see https://github.com/sanger/sequencescape/actions/runs/10791930594/job/29930448291

#### Changes proposed in this pull request

- Bumps upload artifact action


