### PR TITLE
Y24-309 - Set vite build target to chrome65

### DIFF
--- a/app/frontend/.eslintrc.js
+++ b/app/frontend/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   parserOptions: {
     parser: "babel-eslint",
     sourceType: "module",
+    ecmaVersion: 2018,
   },
   rules: {
     "no-unused-vars": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,10 @@ import { createVuePlugin } from "vite-plugin-vue2";
 import legacy from "@vitejs/plugin-legacy";
 
 export default defineConfig({
-  build: { emptyOutDir: true },
+  build: {
+    emptyOutDir: true,
+    target: "chrome65",
+  },
   plugins: [RubyPlugin(), createVuePlugin(), legacy({ targets: ["defaults"] })],
   resolve: {
     alias: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import legacy from "@vitejs/plugin-legacy";
 export default defineConfig({
   build: {
     emptyOutDir: true,
-    target: "chrome65",
+    target: ["chrome65", "es2019"],
   },
   plugins: [RubyPlugin(), createVuePlugin(), legacy({ targets: ["defaults"] })],
   resolve: {


### PR DESCRIPTION
Closes #4335 

#### Changes proposed in this pull request

- The vite build target has been set to chrome65

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
