### PR TITLE
Remove checks for not raising specific errors

### DIFF
--- a/spec/models/study_spec.rb
+++ b/spec/models/study_spec.rb
@@ -663,10 +663,11 @@ RSpec.describe Study do
 
         it 'does not error if the data_release_timing is invalid' do
           study.study_metadata.data_release_timing = 'never'
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+
+          # There will be errors, but they shouldn't include anything about data release timing.
+          expect(study.save).to be_falsey
+          expect(study.errors).not_to be_nil
+          expect(study.errors.full_messages).not_to include(/data release timing/)
         end
       end
     end
@@ -697,10 +698,11 @@ RSpec.describe Study do
 
         it 'does not error if the data_release_timing is invalid' do
           study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+
+          # There will be errors, but they shouldn't include anything about data release timing.
+          expect(study.save).to be_falsey
+          expect(study.errors).not_to be_nil
+          expect(study.errors.full_messages).not_to include(/data release timing/)
         end
       end
     end
@@ -809,10 +811,7 @@ RSpec.describe Study do
 
         it 'is valid if the data_release_timing is never' do
           study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+          expect { study.save! }.not_to raise_error
         end
       end
 
@@ -821,18 +820,12 @@ RSpec.describe Study do
 
         it 'does not error if the data_release_timing is standard' do
           study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_STANDARD
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+          expect { study.save! }.not_to raise_error
         end
 
         it 'does not error if the data_release_timing is immediate' do
           study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_IMMEDIATE
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+          expect { study.save! }.not_to raise_error
         end
 
         it 'does not error if the data_release_timing is delayed' do
@@ -840,18 +833,12 @@ RSpec.describe Study do
           study.study_metadata.data_release_delay_reason = Study::DATA_RELEASE_DELAY_REASONS_STANDARD[0]
           study.study_metadata.data_release_delay_period = Study::DATA_RELEASE_DELAY_PERIODS[0]
           study.study_metadata.data_release_delay_approval = Study::YES
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+          expect { study.save! }.not_to raise_error
         end
 
         it 'is still valid if the data_release_timing is never' do
           study.study_metadata.data_release_timing = Study::DATA_RELEASE_TIMING_NEVER
-          expect { study.save! }.not_to raise_error(
-            ActiveRecord::RecordInvalid,
-            /Study metadata data release timing is not included in the list/
-          )
+          expect { study.save! }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
RSpec warns about these while the tests are running and for good reason. We don't expect to raise ANY error, but the test only confirms that a single specific error won't be raised.