### PR TITLE
Revert typo fix in sample manifest title

### DIFF
--- a/config/sample_manifest_excel/columns.yml
+++ b/config/sample_manifest_excel/columns.yml
@@ -498,7 +498,7 @@ dna_source:
     empty_cell:
     is_error:
 date_of_sample_collection:
-  heading: DATE OF SAMPLE COLLECTION (YYYY-MM-DD)
+  heading: DATE OF SAMPLE COLLECTION (YYY-MM-DD) # Correcting this typo to YYYY-MM-DD prevents manifests to be re-uploaded
   unlocked: true
   validation:
     options:


### PR DESCRIPTION
This fix prevents manifests to be re-uploaded. 
Put in this fix to revert