### PR TITLE
Y24-120 Part-1 Remove duplicate asset_links records

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       RUBOCOP_CACHE_ROOT: ".rubocop-cache"
       BUNDLE_WITHOUT: "cucumber deployment profile development default test"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -20,14 +20,14 @@ jobs:
       # Establish a cache of rubocop cache to improve performance
       # ${{ env.RUBOCOP_CACHE_ROOT }}
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"
       - name: Set up yarn
-        run: yarn
+        run: yarn install
       - name: Cache cops
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.RUBOCOP_CACHE_ROOT }}
@@ -46,13 +46,14 @@ jobs:
       # and parallel to try and improve speed
       - name: Run rubocop
         run: bundle exec rubocop --extra-details --display-style-guide --parallel --format github --format progress
+
   eslint:
     name: EsLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
           cache: "yarn"


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

This is the first of the two-part deployment to handle race conditions in asset links creation. The first part removes existing duplications from the database to be able to create a unique constraint. The second part enforces uniqueness and handles race conditions. They need to be done separately as they cannot co-exist because the part-1 rake task tests cannot work when the constraint is enabled by part-2.

The following changes are included in part-1:

- Rake task to remove duplicate asset_links records to be able to create a unique-together index on ancestor_id and descendant_id. It saves the records removed to a CSV file for recovery
- Rake task to restore the records saved to the CSV file earlier in case of recovery.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
