### PR TITLE
Y24-372 - Correct country of origin values for submissions

### DIFF
--- a/app/models/accessionable/base.rb
+++ b/app/models/accessionable/base.rb
@@ -95,6 +95,8 @@ class Accessionable::Base
       MISSING_DATA_AGGREEMENT_PRE2023 = 'missing: data agreement established pre-2023'
       MISSING_ENDANGERED_SPECIES = 'missing: endangered species'
       MISSING_HUMAN_IDENTIFIABLE = 'missing: human-identifiable'
+      MISSING_CONTROL_SAMPLE = 'missing: control sample'
+      MISSING_SAMPLE_GROUP = 'missing: sample group'
 
       OTHER_DEFAULT_SETTINGS = [
         NOT_COLLECTED,
@@ -107,7 +109,9 @@ class Accessionable::Base
         MISING_THIRD_PARTY_DATA,
         MISSING_DATA_AGGREEMENT_PRE2023,
         MISSING_ENDANGERED_SPECIES,
-        MISSING_HUMAN_IDENTIFIABLE
+        MISSING_HUMAN_IDENTIFIABLE,
+        MISSING_CONTROL_SAMPLE,
+        MISSING_SAMPLE_GROUP
       ].freeze
 
       def value_for(value)

--- a/db/migrate/20241018131928_disable_invalid_insdc_countries.rb
+++ b/db/migrate/20241018131928_disable_invalid_insdc_countries.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This migration corrects the country list for missing samples/sample groups
+# following EBI's checklist https://www.ebi.ac.uk/ena/browser/view/ERC000011
+class DisableInvalidInsdcCountries < ActiveRecord::Migration[6.1]
+  def change
+    # Disable existing invalid countries
+    # We don't want to delete them yet in case they are used in existing records and existing manifests.
+    ['not applicable: control sample', 'not applicable: sample group'].each do |name|
+      Insdc::Country.find_by(name:)&.invalid!
+    end
+
+    # Add missing countries
+    ['missing: control sample', 'missing: sample group'].each do |name|
+      Insdc::Country.find_or_create_by(name: name, sort_priority: -2, validation_state: 0)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_17_133813) do
+ActiveRecord::Schema.define(version: 2024_10_18_131928) do
 
   create_table "aliquot_indices", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false

--- a/lib/accession/accession/tag.rb
+++ b/lib/accession/accession/tag.rb
@@ -72,6 +72,8 @@ module Accession
       MISSING_DATA_AGGREEMENT_PRE2023 = 'missing: data agreement established pre-2023'
       MISSING_ENDANGERED_SPECIES = 'missing: endangered species'
       MISSING_HUMAN_IDENTIFIABLE = 'missing: human-identifiable'
+      MISSING_CONTROL_SAMPLE = 'missing: control sample'
+      MISSING_SAMPLE_GROUP = 'missing: sample group'
 
       OTHER_DEFAULT_SETTINGS = [
         NOT_COLLECTED,
@@ -84,7 +86,9 @@ module Accession
         MISING_THIRD_PARTY_DATA,
         MISSING_DATA_AGGREEMENT_PRE2023,
         MISSING_ENDANGERED_SPECIES,
-        MISSING_HUMAN_IDENTIFIABLE
+        MISSING_HUMAN_IDENTIFIABLE,
+        MISSING_CONTROL_SAMPLE,
+        MISSING_SAMPLE_GROUP
       ].freeze
 
       def incorrect_format_value


### PR DESCRIPTION
Closes #4405 

#### Changes proposed in this pull request

- Sets Indsc::Country `not applicable: control sample` and `not applicable: sample group` to be invalid.
  - This means they will not appear in new manifests as options but does not prevent existing manifests with these types to be uploaded.  
- Creates Indsc::Country `missing: control sample` and `missing: sample group`

#### Instructions for Reviewers

There is [another story to migrate existing data](https://github.com/sanger/sequencescape/issues/4406). However this story ensures all new manifests will only have the valid countries visible whilst also allowing existing manifests to use the old/invalid countries so as not break any behaviour.
