### PR TITLE
Y24-398 - scRNA Pooling scenario restriction to study-project level

### DIFF
--- a/app/models/submission/validations_by_template_name.rb
+++ b/app/models/submission/validations_by_template_name.rb
@@ -6,6 +6,7 @@ module Submission::ValidationsByTemplateName
   # Column headers
   HEADER_TEMPLATE_NAME = 'template name'
   HEADER_STUDY_NAME = 'study name'
+  HEADER_PROJECT_NAME = 'project name'
   HEADER_NUM_SAMPLES = 'scrna core number of samples per pool'
 
   # Applies additional validations based on the submission template type.
@@ -41,14 +42,15 @@ module Submission::ValidationsByTemplateName
   # the errors collection.
   #
   # @return [void]
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
   def validate_scrna_core_samples_per_pool
     # Group rows by study name
     index_of_study_name = headers.index(HEADER_STUDY_NAME)
-    grouped_rows = csv_data_rows.group_by { |row| row[index_of_study_name] }
+    index_of_project_name = headers.index(HEADER_PROJECT_NAME)
+    grouped_rows = csv_data_rows.group_by { |row| [row[index_of_study_name], row[index_of_project_name]] }
 
     # Iterate through each study group
-    grouped_rows.each do |study_name, rows|
+    grouped_rows.each do |study_project, rows|
       # Get the unique values of scrna core number of samples per pool for the group
       index_of_num_samples = headers.index(HEADER_NUM_SAMPLES)
       list_of_uniq_number_of_samples_per_pool = rows.pluck(index_of_num_samples).uniq
@@ -57,11 +59,10 @@ module Submission::ValidationsByTemplateName
       next unless list_of_uniq_number_of_samples_per_pool.size > 1
       errors.add(
         :spreadsheet,
-        "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name '#{study_name}', " \
-          'all rows for a specific study must have the same value'
+        "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name '#{study_project[0]}' " \
+        "and Project name '#{study_project[1]}', all rows for a specific study and project must have the same value"
       )
     end
   end
-
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 end

--- a/app/models/submission/validations_by_template_name.rb
+++ b/app/models/submission/validations_by_template_name.rb
@@ -8,6 +8,7 @@ module Submission::ValidationsByTemplateName
   HEADER_STUDY_NAME = 'study name'
   HEADER_PROJECT_NAME = 'project name'
   HEADER_NUM_SAMPLES = 'scrna core number of samples per pool'
+  HEADER_CELLS_PER_CHIP_WELL = 'scrna core cells per chip well'
 
   # Applies additional validations based on the submission template type.
   #
@@ -31,36 +32,36 @@ module Submission::ValidationsByTemplateName
     case submission_template_name
     # this validation is for the scRNA pipeline cDNA submission
     when SCRNA_CORE_CDNA_PREP_GEM_X_5P
-      validate_scrna_core_samples_per_pool
+      validate_consistent_column_value(HEADER_NUM_SAMPLES)
+      validate_consistent_column_value(HEADER_CELLS_PER_CHIP_WELL)
     end
   end
 
-  # Validates that the scrna core number of samples per pool is consistent for all rows with the same study name.
+  # Validates that the specified column is consistent for all rows with the same study and project name.
   #
-  # This method groups the rows in the CSV data by the study name and checks if the scrna core number of samples
-  # per pool is the same for all rows within each study group. If inconsistencies are found, an error is added to
-  # the errors collection.
+  # This method groups the rows in the CSV data by the study name and project name, and checks if the specified column
+  # has the same value for all rows within each group. If inconsistencies are found, an error is
+  # added to the errors collection.
   #
+  # @param column_header [String] The header of the column to validate.
   # @return [void]
   # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
-  def validate_scrna_core_samples_per_pool
-    # Group rows by study name
+  def validate_consistent_column_value(column_header)
     index_of_study_name = headers.index(HEADER_STUDY_NAME)
     index_of_project_name = headers.index(HEADER_PROJECT_NAME)
+    index_of_column = headers.index(column_header)
+
     grouped_rows = csv_data_rows.group_by { |row| [row[index_of_study_name], row[index_of_project_name]] }
 
-    # Iterate through each study group
     grouped_rows.each do |study_project, rows|
-      # Get the unique values of scrna core number of samples per pool for the group
-      index_of_num_samples = headers.index(HEADER_NUM_SAMPLES)
-      list_of_uniq_number_of_samples_per_pool = rows.pluck(index_of_num_samples).uniq
+      unique_values = rows.pluck(index_of_column).uniq
 
-      # Check if there is more than one unique value
-      next unless list_of_uniq_number_of_samples_per_pool.size > 1
+      next unless unique_values.size > 1
       errors.add(
         :spreadsheet,
-        "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name '#{study_project[0]}' " \
-          "and Project name '#{study_project[1]}', all rows for a specific study and project must have the same value"
+        "Inconsistent values for column '#{column_header}' for Study name '#{study_project[0]}' and Project name " \
+          "'#{study_project[1]}', " \
+          'all rows for a specific study and project must have the same value'
       )
     end
   end

--- a/app/models/submission/validations_by_template_name.rb
+++ b/app/models/submission/validations_by_template_name.rb
@@ -60,7 +60,7 @@ module Submission::ValidationsByTemplateName
       errors.add(
         :spreadsheet,
         "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name '#{study_project[0]}' " \
-        "and Project name '#{study_project[1]}', all rows for a specific study and project must have the same value"
+          "and Project name '#{study_project[1]}', all rows for a specific study and project must have the same value"
       )
     end
   end

--- a/spec/data/submission/scrna_additional_validations_invalid_cells_per_chip_well.csv
+++ b/spec/data/submission/scrna_additional_validations_invalid_cells_per_chip_well.csv
@@ -1,4 +1,3 @@
 User Login,template name,study name,project name,submission name,asset names,asset group name,read length,fragment size from,fragment size to,library type,comments,pre-capture plex level,pre-capture group,gigabases expected,scrna core number of samples per pool,scrna core cells per chip well
 user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub1,,assetgroup123,100,,,Standard,hello there,,,1.35,15,10000
-user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub2,,assetgroup123,100,,,Standard,hello there,,,1.35,15,10000
-user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Project 1,sub2,,assetgroup2,100,,,Standard,hello there,,,1.35,10,20000
+user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub2,,assetgroup123,100,,,Standard,hello there,,,1.35,15,20000

--- a/spec/data/submission/scrna_additional_validations_invalid_samples_per_pool.csv
+++ b/spec/data/submission/scrna_additional_validations_invalid_samples_per_pool.csv
@@ -1,3 +1,3 @@
 User Login,template name,study name,project name,submission name,asset names,asset group name,read length,fragment size from,fragment size to,library type,comments,pre-capture plex level,pre-capture group,gigabases expected,scrna core number of samples per pool,scrna core cells per chip well
-user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub1,,assetgroup123,100,,,Standard,hello there,,,1.35,15,
-user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub2,,assetgroup123,100,,,Standard,hello there,,,1.35,10,
+user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub1,,assetgroup123,100,,,Standard,hello there,,,1.35,15,10000
+user,Limber-Htp - scRNA Core cDNA Prep GEM-X 5p,abc123_study,Test project,sub2,,assetgroup123,100,,,Standard,hello there,,,1.35,10,10000

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -297,8 +297,8 @@ describe BulkSubmission, with: :uploader do
       it 'raises an error and sets an error message' do
         expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
         expect(subject.errors.messages[:spreadsheet][0]).to eq(
-          "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for " \
-            "Study name 'abc123_study', all rows for a specific study must have the same value"
+          "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name 'abc123_study' " \
+          "and Project name 'Test project', all rows for a specific study and project must have the same value"
         )
       end
     end

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -20,6 +20,7 @@ describe BulkSubmission, with: :uploader do
 
   let!(:study) { create(:study, name: 'abc123_study') }
   let!(:asset_group) { create(:asset_group, name: 'assetgroup123', study: study, asset_count: 2) }
+  let!(:asset_group_2) { create(:asset_group, name: 'assetgroup2', study: study, asset_count: 1) }
   let!(:library_type) { create(:library_type, name: 'Standard') }
 
   before do
@@ -277,7 +278,7 @@ describe BulkSubmission, with: :uploader do
       end
     end
 
-    context 'when invalid for scRNA template' do
+    context 'when invalid for scRNA template on samples per pool' do
       let(:submission_template_hash) do
         {
           name: 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p',
@@ -290,14 +291,40 @@ describe BulkSubmission, with: :uploader do
           }
         }
       end
-      let(:spreadsheet_filename) { 'scrna_additional_validations_invalid.csv' }
+      let(:spreadsheet_filename) { 'scrna_additional_validations_invalid_samples_per_pool.csv' }
 
       before { SubmissionSerializer.construct!(submission_template_hash) }
 
       it 'raises an error and sets an error message' do
         expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
         expect(subject.errors.messages[:spreadsheet][0]).to eq(
-          "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name 'abc123_study' " \
+          "Inconsistent values for column 'scrna core number of samples per pool' for Study name 'abc123_study' " \
+            "and Project name 'Test project', all rows for a specific study and project must have the same value"
+        )
+      end
+    end
+
+    context 'when invalid for scRNA template on cells per chip well' do
+      let(:submission_template_hash) do
+        {
+          name: 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p',
+          submission_class_name: 'LinearSubmission',
+          product_catalogue: 'Generic',
+          submission_parameters: {
+            request_options: {
+            },
+            request_types: request_types.map(&:key)
+          }
+        }
+      end
+      let(:spreadsheet_filename) { 'scrna_additional_validations_invalid_cells_per_chip_well.csv' }
+
+      before { SubmissionSerializer.construct!(submission_template_hash) }
+
+      it 'raises an error and sets an error message' do
+        expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(subject.errors.messages[:spreadsheet][0]).to eq(
+          "Inconsistent values for column 'scrna core cells per chip well' for Study name 'abc123_study' " \
             "and Project name 'Test project', all rows for a specific study and project must have the same value"
         )
       end

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -298,7 +298,7 @@ describe BulkSubmission, with: :uploader do
         expect { subject.process }.to raise_error(ActiveRecord::RecordInvalid)
         expect(subject.errors.messages[:spreadsheet][0]).to eq(
           "Inconsistent values for column 'scRNA Core Number of Samples per Pool' for Study name 'abc123_study' " \
-          "and Project name 'Test project', all rows for a specific study and project must have the same value"
+            "and Project name 'Test project', all rows for a specific study and project must have the same value"
         )
       end
     end


### PR DESCRIPTION
Closes #4422 

#### Changes proposed in this pull request

- Updates scRNA submission templates validation for pooling restrictions to only reject on same study and project combination
- Adds 'scrna core cells per chip well' validation to ensure they are consistent in study/project combinations.
