### PR TITLE
Fix old message templates for Api::Messages::

### DIFF
--- a/app/models/messenger.rb
+++ b/app/models/messenger.rb
@@ -18,6 +18,13 @@ class Messenger < ApplicationRecord
     { root => render_class.to_hash(target), 'lims' => configatron.amqp.lims_id! }
   end
 
+  def template
+    # Replace IO with Io to match the class name
+    # This is a consequence of the zeitwerk renaming for the message modules from IO to Io
+    # This ensures that the correct class is loaded for historical messages
+    read_attribute(:template).gsub(/IO$/, 'Io')
+  end
+
   def resend
     Warren.handler << Warren::Message::Short.new(self)
   end

--- a/test/unit/messaging/messenger_test.rb
+++ b/test/unit/messaging/messenger_test.rb
@@ -18,6 +18,11 @@ class MessengerTest < ActiveSupport::TestCase
       should 'render the json' do
         assert_equal '{"example":{"example":"hash"},"lims":"SQSCP"}', @messenger.to_json
       end
+
+      should 'render the json when template is historical (ends in IO)' do
+        messenger = Messenger.new(target: @target, template: 'FlowcellIO', root: 'example')
+        assert_equal '{"example":{"example":"hash"},"lims":"SQSCP"}', messenger.to_json
+      end
     end
 
     should 'provide a routing key' do


### PR DESCRIPTION
#### Changes proposed in this pull request

- Add a custom template method to messenger that converts templates ending in `IO` to `Io`

#### Notes

- When [upgrading to Zeitwerk](https://github.com/sanger/sequencescape/pull/4371) the Api::Messages:: modules were updated to zeitwerk naming compatibility (IO to Io). This change inadvertently broke old Messenger objects because they store the template name as a string in the database so Api::Messages::FlowcellIO was no longer working because it was no longer a valid module name. When attempting to rebroadcast old messages @neilsycamore was getting the error `const_get': uninitialized constant Api::Messages::FlowcellIO (NameError)`.
- This PR adds a template override method to the messenger to replace templates ending in IO with Io to fix the module lookup. This change is slightly hacky but preferential over a massive data migration of existing data.


#### Alternative approaches
- Migrate existing data for all historical Messenger objects to rename their templates to the updated equivalent.
- Revert the name changes for the API::Messages:: modules and migrate their templates back to the old equivalent.