### PR TITLE
Y24-014 - Ability to re-run RVI BCL pipeline

### DIFF
--- a/config/default_records/plate_purposes/005_limber_purposes.yml
+++ b/config/default_records/plate_purposes/005_limber_purposes.yml
@@ -72,3 +72,8 @@ LTN AL Lib:
 LTN Lib PCR XP:
   type: PlatePurpose
   stock_plate: false
+
+# RVI BCL plate for reISC
+RVI Lib PCR XP:
+  type: PlatePurpose
+  stock_plate: false

--- a/config/default_records/request_types/004_limber_high_throughput.yml
+++ b/config/default_records/request_types/004_limber_high_throughput.yml
@@ -37,6 +37,7 @@ limber_reisc:
   acceptable_purposes:
     - LB Lib PCR-XP
     - LTN Lib PCR XP # for Targeted NanoSeq ReISC
+    - RVI Lib PCR XP  # for RVI Bait Capture Library
   library_types:
     - Agilent Pulldown
     - Twist Pulldown
@@ -44,6 +45,7 @@ limber_reisc:
     - Targeted NanoSeq Pulldown Twist
     - Targeted NanoSeq Pulldown Agilent
     - BGE
+    - RVI-BCL
 limber_pcr_free:
   <<: *limber_htp_library
   name: Limber PCR Free

--- a/config/default_records/request_types/004_limber_high_throughput.yml
+++ b/config/default_records/request_types/004_limber_high_throughput.yml
@@ -37,7 +37,7 @@ limber_reisc:
   acceptable_purposes:
     - LB Lib PCR-XP
     - LTN Lib PCR XP # for Targeted NanoSeq ReISC
-    - RVI Lib PCR XP  # for RVI Bait Capture Library
+    - RVI Lib PCR XP # for RVI Bait Capture Library
   library_types:
     - Agilent Pulldown
     - Twist Pulldown


### PR DESCRIPTION
#### Changes proposed in this pull request

- Updates limber_reisc to include RVI acceptable purpose and library type

#### Notes

Relates to Limber PR: https://github.com/sanger/limber/pull/2030