### PR TITLE
V2 Bait Library Layout Preview fix

### DIFF
--- a/app/controllers/api/v2/bait_library_layouts_controller.rb
+++ b/app/controllers/api/v2/bait_library_layouts_controller.rb
@@ -33,7 +33,7 @@ module Api
           respond_with_errors('Validation failed', e.record.errors.full_messages, :unprocessable_entity) and return
         end
 
-        json = { data: { type: 'bait_library_layouts', attributes: { layout: preview.layout } } }
+        json = { data: { type: 'bait_library_layouts', attributes: { well_layout: preview.well_layout } } }
         render json: json, status: :ok
       end
 

--- a/features/api/pulldown/bait_library_assignment.feature
+++ b/features/api/pulldown/bait_library_assignment.feature
@@ -56,7 +56,7 @@ And I have a "full" authorised user with the key "cucumber"
               "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
             }
           },
-          "well_layout": {
+          "layout": {
             "A1":  "Human all exon 50MB",
             "A2":  "Human all exon 50MB",
             "A3":  "Human all exon 50MB",
@@ -186,7 +186,7 @@ And I have a "full" authorised user with the key "cucumber"
               "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
             }
           },
-          "well_layout": {
+          "layout": {
             "A1":  "Human all exon 50MB",
             "A2":  "Human all exon 50MB",
             "A3":  "Human all exon 50MB",

--- a/features/api/pulldown/bait_library_assignment.feature
+++ b/features/api/pulldown/bait_library_assignment.feature
@@ -56,7 +56,7 @@ And I have a "full" authorised user with the key "cucumber"
               "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
             }
           },
-          "layout": {
+          "well_layout": {
             "A1":  "Human all exon 50MB",
             "A2":  "Human all exon 50MB",
             "A3":  "Human all exon 50MB",
@@ -186,7 +186,7 @@ And I have a "full" authorised user with the key "cucumber"
               "read": "http://www.example.com/api/1/00000000-1111-2222-3333-000000000002"
             }
           },
-          "layout": {
+          "well_layout": {
             "A1":  "Human all exon 50MB",
             "A2":  "Human all exon 50MB",
             "A3":  "Human all exon 50MB",

--- a/spec/requests/api/v2/bait_library_layouts_spec.rb
+++ b/spec/requests/api/v2/bait_library_layouts_spec.rb
@@ -308,8 +308,8 @@ describe 'Bait Library Layouts API', with: :api_v2 do
           expect(json.dig('data', 'type')).to eq(resource_type)
         end
 
-        it 'returns a layout as an attribute' do
-          expect(json.dig('data', 'attributes', 'layout')).not_to be_nil
+        it 'returns a well_layout as an attribute' do
+          expect(json.dig('data', 'attributes', 'well_layout')).not_to be_nil
         end
       end
 


### PR DESCRIPTION
#### Changes proposed in this pull request

- Bait Library Layout preview in api v1 returned well_layout (as a layout attribute). This updates the v2 api to also return well_layout.

#### Instructions for Reviewers

Linked Limber PR: https://github.com/sanger/limber/pull/2040
There is also an integration suite PR.
