### PR TITLE
Y24-286-1 - Fix RVI BCL Library prep requests

### DIFF
--- a/app/models/transfer_request.rb
+++ b/app/models/transfer_request.rb
@@ -80,7 +80,7 @@ class TransferRequest < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
 
     event :process_1 do
-      transitions to: :processed_1, from: [:pending]
+      transitions to: :processed_1, from: [:pending], after: :on_started
     end
 
     event :process_2 do

--- a/spec/models/state_changer/standard_plate_spec.rb
+++ b/spec/models/state_changer/standard_plate_spec.rb
@@ -21,12 +21,25 @@ RSpec.describe StateChanger::StandardPlate do
     context 'when the plate is the initial plate in the pipeline' do
       include_context 'a limber target plate with submissions', 'pending'
 
-      let(:target_state) { 'started' }
+      context 'when the target state is started' do
+        let(:target_state) { 'started' }
 
-      it 'starts the requests', :aggregate_failures do
-        # Requests are started and we create one event per order.
-        expect { state_changer.update_labware_state }.to change(BroadcastEvent::LibraryStart, :count).by(1)
-        expect(library_requests).to all(be_started)
+        it 'starts the requests', :aggregate_failures do
+          # Requests are started and we create one event per order.
+          expect { state_changer.update_labware_state }.to change(BroadcastEvent::LibraryStart, :count).by(1)
+          expect(library_requests).to all(be_started)
+        end
+      end
+
+      # RVI BCL uses the processed_1 state as the first state for the the intial plate
+      context 'when the target state is processed_1' do
+        let(:target_state) { 'processed_1' }
+
+        it 'starts the requests', :aggregate_failures do
+          # Requests are started and we create one event per order.
+          expect { state_changer.update_labware_state }.to change(BroadcastEvent::LibraryStart, :count).by(1)
+          expect(library_requests).to all(be_started)
+        end
       end
     end
 

--- a/spec/models/state_changer/standard_plate_spec.rb
+++ b/spec/models/state_changer/standard_plate_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe StateChanger::StandardPlate do
         end
       end
 
-      # RVI BCL uses the processed_1 state as the first state for the the intial plate
+      # RVI BCL uses the processed_1 state as the first state for the the initial plate
       context 'when the target state is processed_1' do
         let(:target_state) { 'processed_1' }
 


### PR DESCRIPTION
Part 1 of https://github.com/sanger/sequencescape/issues/4306

#### Changes proposed in this pull request

- Updates transfer request to start sibiling requests when going from pending to processed_1

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
