### PR TITLE
Y24-428 change entry point to gems plate ('LRC GEM-X 5p GEMs Input') instead of pmbc pools plate ('LRC PBMC Pools Input')

### DIFF
--- a/config/default_records/plate_purposes/011_scrna_core_cdna_prep_plate_purposes.yml
+++ b/config/default_records/plate_purposes/011_scrna_core_cdna_prep_plate_purposes.yml
@@ -2,10 +2,10 @@
 # Most are defined in the Limber config, but the below also need to be defined in Sequencescape.
 # They are in a separate file so it can be 'feature flagged off' until needed.
 ---
-# The 'LRC PBMC Pools Input' purpose is included here so that it's available for
+# The 'LRC GEM-X 5p GEMs Input' purpose is included here so that it's available for
 # sample manifests, and also because it is an acceptable purpose for the scRNA Core cDNA Prep Input
 # submission template.
-LRC PBMC Pools Input:
+LRC GEM-X 5p GEMs Input:
   input_plate: true
   stock_plate: true
   cherrypickable_target: false

--- a/config/default_records/request_types/014_limber_scrna_core_cdna_prep_request_types.yml
+++ b/config/default_records/request_types/014_limber_scrna_core_cdna_prep_request_types.yml
@@ -16,8 +16,8 @@ limber_scrna_core_cdna_prep_gem_x_5p:
     - LRC Bank Seq
     - LRC Bank Spare
     - LRC Bank Input
-limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input:
-  name: scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input
+limber_scrna_core_cdna_prep_gem_x_5p_gems_input:
+  name: scRNA Core cDNA Prep GEM-X 5p GEMs Input
   asset_type: Well
   order: 1
   request_class_name: CustomerRequest
@@ -25,7 +25,7 @@ limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input:
   billable: true
   product_line_name: Short Read
   acceptable_purposes:
-    - LRC PBMC Pools Input
+    - LRC GEM-X 5p GEMs Input
 limber_scrna_core_aggregation:
   name: scRNA Core Aggregation
   asset_type: Well

--- a/config/default_records/submission_templates/011_scrna_core_cdna_prep_submission_templates.yml
+++ b/config/default_records/submission_templates/011_scrna_core_cdna_prep_submission_templates.yml
@@ -16,9 +16,9 @@ Limber-Htp - scRNA Core cDNA Prep GEM-X 5p:
     request_type_keys: ["limber_scrna_core_cdna_prep_gem_x_5p"]
     product_line_name: Short Read
     product_catalogue_name: scRNA Core
-Limber-Htp - scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input:
+Limber-Htp - scRNA Core cDNA Prep GEM-X 5p GEMs Input:
   submission_class_name: "LinearSubmission"
   related_records:
-    request_type_keys: ["limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input"]
+    request_type_keys: ["limber_scrna_core_cdna_prep_gem_x_5p_gems_input"]
     product_line_name: Short Read
     product_catalogue_name: scRNA Core


### PR DESCRIPTION
Closes https://github.com/sanger/limber/issues/2027

#### Changes proposed in this pull request ####
This PR includes modifications to shift the entry point from the 'PBMC Pools' plate to the 'GEMS' plate. Specifically, it introduces the use of the 'LRC GEM-X 5p GEMs Input' plate instead of the previous 'LRC PBMC Pools Input' plate.

## Key Changes: ##

### 1.  Record Loaders Updates: ###

Added a new plate_purpose for 'LRC GEM-X 5p GEMs Input'.
Removed the plate_purpose for 'LRC PBMC Pools Input'.
Introduced a new request_type: limber_scrna_core_cdna_prep_gem_x_5p_gems_input.
Removed the request_type for limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input.
Created a new submission template for 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p GEMs Input'.
Removed the submission template for 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input'.

### 2. Existing Data Verification and Removal ###

The following section outlines the steps taken to verify the presence of any existing LRC PBMC Pools Input data in the Sequencescape production database. It also provides instructions for removing this data from the production database if necessary. Please review the steps carefully to determine if this approach is correct and comprehensive.
   
#### 2.1 Checking for Existing Data in the Sequencescape Production Database #### 

  ##### a. Confirming Plate Purpose Record #####
  
  Query the plate_purposes table to locate any existing records for LRC PBMC Pools Input.
  ```
   SELECT * FROM sequencescape_production.plate_purposes 
  WHERE name = 'LRC PBMC Pools Input';
  ```
  Result:
  _'479', 'LRC PBMC Pools Input', '2024-10-02 12:03:08', '2024-10-02 12:03:08', 'PlatePurpose::Input', 'Plate', '1', 'pending', '2', '0', 'column', '96', '1', NULL, NULL, '25'_

##### b. Confirming Request Type Record #####

Query the request_types table for any records related to scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input.
```

SELECT * FROM sequencescape_production.request_types 
WHERE name = 'scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input' 
AND `key` = 'limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input';
```
Result:

This query returned a record with the id 198, confirming the existence of the request type.
_'198', 'limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input', 'scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input', '2024-10-02 12:03:09', '2024-10-02 12:03:09', 'Well', '1', 'pending', NULL, '0', 'CustomerRequest', NULL, '0', '0', '1', '14', '0', '0', NULL, NULL, '1', NULL_


##### c. Confirm if any submissions have already been made using the LRC PBMC Pools Input request type. #####

Query submissions table

`SELECT * FROM sequencescape_production.submissions WHERE request_types LIKE '%198%';`

Result:
This query returned zero records, indicating no existing submissions for this request type.

##### d. Checking Labware for Existing Plate Purposes #####

Query labware table
```
SELECT * FROM sequencescape_production.labware
WHERE plate_purpose_id = (
    SELECT id FROM sequencescape_production.plate_purposes 
    WHERE name LIKE 'LRC PBMC Pools Input'
);
```
Result:
This query also returned zero records, confirming that no labware records are associated with this plate purpose.

#### 2.2 Removing Data from the Database Using Rails Console ####

If any LRC PBMC Pools Input data is found and requires deletion, follow these steps to remove the records using the Rails console.

##### a. Removing request_type for PMBC Pools Input #####

 Use the following Rails script to locate and delete the request_type:
request = RequestType.find_by(key: 'limber_scrna_core_cdna_prep_gem_x_5p_pbmc_pools_input', name: 'scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input')

```
# Check if the record exists
if request
  # Destroy the record
  request.destroy
  puts "Request type record destroyed successfully."
else
  puts "Request type record not found."
end
```

This code searches for a request_type that matches the specified key and name. If found, the record is destroyed, and a confirmation message is printed. If not found, a message indicates so.


##### b. Removing the Plate Purpose for PBMC Pools Input #####

To remove the plate_purpose record, use the following Rails script:
```

plate_purpose = PlatePurpose.find_by(name: 'LRC PBMC Pools Input')

# Check if the record exists
if plate_purpose
  # Destroy the record
  plate_purpose.destroy
  puts "Plate purpose record destroyed successfully."
else
  puts "Plate purpose record not found."
end
```
This script looks for a plate_purpose with the specified name. If found, the record is destroyed with a success message; if not, an appropriate message is displayed.


##### c. Removing the Submission template for PBMC Pools Input  - 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input' #####

To remove the submission_template record, use the following Rails script:
```

submission_template = SubmissionTemplate.find_by(name: 'Limber-Htp - scRNA Core cDNA Prep GEM-X 5p PBMC Pools Input')

# Check if the record exists
if submission_template
  # Destroy the record
  submission_template.destroy
  puts "Submission template destroyed successfully."
else
  puts "Submission template not found."
end

```
This script looks for a submission_template with the specified name. If found, the record is destroyed with a success message; if not, an appropriate message is displayed.

#### Instructions for Reviewer ####
Please review the steps for checking existing data and the deletion process to confirm their correctness and comprehensiveness. The goal is to ensure that all instances of LRC PBMC Pools Input data are identified and, if necessary, accurately removed from the production database. Additionally, please verify that the Rails scripts are written correctly to handle data removal safely.


_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
