### PR TITLE
Y24-431 BUG - location report not showing retention instruction

### DIFF
--- a/app/models/labware.rb
+++ b/app/models/labware.rb
@@ -309,6 +309,10 @@ class Labware < Asset
   end
 
   def obtain_retention_instructions
+    # first check the retention_instruction field
+    return retention_instruction if retention_instruction.present?
+
+    # if not found, check the metadata (legacy)
     return if metadata.blank?
 
     metadata.symbolize_keys[:retention_instruction]

--- a/app/models/location_report.rb
+++ b/app/models/location_report.rb
@@ -160,7 +160,7 @@ class LocationReport < ApplicationRecord
       cur_plate.received_date&.strftime('%Y-%m-%d %H:%M:%S') || 'Unknown',
       cur_plate.storage_location,
       cur_plate.storage_location_service,
-      cur_plate.retention_instructions || 'Unknown'
+      cur_plate.retention_instruction || 'Unknown'
     ]
   end
 

--- a/app/models/location_report.rb
+++ b/app/models/location_report.rb
@@ -160,7 +160,7 @@ class LocationReport < ApplicationRecord
       cur_plate.received_date&.strftime('%Y-%m-%d %H:%M:%S') || 'Unknown',
       cur_plate.storage_location,
       cur_plate.storage_location_service,
-      cur_plate.retention_instruction || 'Unknown'
+      cur_plate.retention_instructions || 'Unknown'
     ]
   end
 

--- a/spec/models/labware_spec.rb
+++ b/spec/models/labware_spec.rb
@@ -147,11 +147,11 @@ RSpec.describe Labware do
       end
 
       it 'memoizes the retention instructions' do
-        expect(labware).to receive(:obtain_retention_instructions).once.and_return('Keep for 1 year')
-
         # Call the method twice
         labware.retention_instructions
         labware.retention_instructions
+
+        expect(labware).to have_received(:obtain_retention_instructions).once
       end
     end
 

--- a/spec/models/labware_spec.rb
+++ b/spec/models/labware_spec.rb
@@ -134,4 +134,60 @@ RSpec.describe Labware do
       expect(plate.storage_location).to eq('Not found - There is a problem with Labwhere')
     end
   end
+
+  context 'when retrieving retention instructions' do
+    let(:labware) { described_class.new }
+
+    # tests the higher level method
+    describe '#retention_instructions' do
+      before { allow(labware).to receive(:obtain_retention_instructions).and_return('Keep for 1 year') }
+
+      it 'returns the retention instructions' do
+        expect(labware.retention_instructions).to eq('Keep for 1 year')
+      end
+
+      it 'memoizes the retention instructions' do
+        expect(labware).to receive(:obtain_retention_instructions).once.and_return('Keep for 1 year')
+
+        # Call the method twice
+        labware.retention_instructions
+        labware.retention_instructions
+      end
+    end
+
+    # tests the low level private method that retrieves the retention instructions
+    # NB. expecting value to be in the field on labware, checking metadata if not
+    # present there for legacy reasons.
+    describe '#obtain_retention_instructions' do
+      let(:labware) { described_class.new }
+
+      context 'when the retention_instruction field is used on labware' do
+        before { allow(labware).to receive(:retention_instruction).and_return('Keep for 1 year') }
+
+        it 'returns the retention_instruction' do
+          expect(labware.send(:obtain_retention_instructions)).to eq('Keep for 1 year')
+        end
+      end
+
+      context 'when retention_instruction does not have a value on labware' do
+        before { allow(labware).to receive(:retention_instruction).and_return(nil) }
+
+        context 'when metadata is blank' do
+          before { allow(labware).to receive(:metadata).and_return(nil) }
+
+          it 'returns nil' do
+            expect(labware.send(:obtain_retention_instructions)).to be_nil
+          end
+        end
+
+        context 'when metadata is present' do
+          before { allow(labware).to receive(:metadata).and_return({ 'retention_instruction' => 'Keep for 2 years' }) }
+
+          it 'returns the retention_instruction from metadata' do
+            expect(labware.send(:obtain_retention_instructions)).to eq('Keep for 2 years')
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #4464 

#### Changes proposed in this pull request
Retention instruction in the code is stored in 2 places, a field on labware or in custom metadata. Lookup method used by report had only been looking in the metadata when the value was stored in the field.
Changed the method to first look in the field for the value (this is the primary place the data should be stored) with a backup of looking in metadata if not found in the field.