### PR TITLE
build: remove Active Resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,6 @@ group :default do
   # Legacy support for parsing XML into params
   gem 'actionpack-xml_parser'
 
-  gem 'activeresource'
-
   # Provides bulk insert capabilities
   gem 'activerecord-import'
   gem 'record_loader', git: 'https://github.com/sanger/record_loader'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,19 +80,11 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.1.7.10)
       activesupport (= 6.1.7.10)
-    activemodel-serializers-xml (1.0.2)
-      activemodel (> 5.x)
-      activesupport (> 5.x)
-      builder (~> 3.1)
     activerecord (6.1.7.10)
       activemodel (= 6.1.7.10)
       activesupport (= 6.1.7.10)
     activerecord-import (1.7.0)
       activerecord (>= 4.2)
-    activeresource (6.1.0)
-      activemodel (>= 6.0)
-      activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 6.0)
     activestorage (6.1.7.10)
       actionpack (= 6.1.7.10)
       activejob (= 6.1.7.10)
@@ -574,7 +566,6 @@ DEPENDENCIES
   aasm
   actionpack-xml_parser
   activerecord-import
-  activeresource
   acts-as-dag!
   after_commit_everywhere (~> 1.0)
   avro (~> 1.11.0)


### PR DESCRIPTION
Related to #4401 #4481 

Can anyone confirm that [ActiveResource](https://github.com/rails/activeresource) is no longer used in Sequencescape?
There's dependency updates, but I don't think it's actually used?

#### Changes proposed in this pull request

- Remove the unused? ActiveResource gem

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
