### PR TITLE
fix: don't cache classes by default in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,10 @@ Rails.application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = ENV.fetch('CACHE_CLASSES', 'false') == 'true'
 
-  # Do not eager load code on boot.
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
   # Show full error reports.


### PR DESCRIPTION
Whenever I make a change to ruby code I need to restart the rails server...

#### Changes proposed in this pull request

- In development only, disable `config.cache_classes` by default

#### Instructions for Reviewers

I assume this is the best way to achieve this?

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
