### PR TITLE
Y24-236 - Fix for concurrent sample manifest uploads causing duplicates

### DIFF
--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -56,7 +56,7 @@ class SampleManifest::Uploader
   def process_upload_and_callbacks
     return false unless upload.process(tag_group)
 
-    upload.finished!
+    upload.sample_manifest.finished!
     upload.broadcast_sample_manifest_updated_event(user)
     upload.register_stock_resources
     upload.trigger_accessioning

--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -74,6 +74,8 @@ class SampleManifest::Uploader
   end
 
   def check_sample_manifest_upload
+    # Refetch the sample manifest to ensure it is in it's newest state
+    upload.sample_manifest.reload
     return true unless upload.sample_manifest&.state == 'processing'
 
     errors.add(

--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -75,7 +75,7 @@ class SampleManifest::Uploader
 
   def check_sample_manifest_upload
     # Refetch the sample manifest to ensure it is in it's newest state
-    upload.sample_manifest.reload
+    upload.sample_manifest&.reload
     return true unless upload.sample_manifest&.state == 'processing'
 
     errors.add(

--- a/app/models/sample_manifest/uploader.rb
+++ b/app/models/sample_manifest/uploader.rb
@@ -14,6 +14,7 @@ class SampleManifest::Uploader
   validates :tag_group, presence: { message: 'is not correctly configured for manifest generation' }
   validates :file, :configuration, :user, presence: true
   validate :check_upload
+  validate :check_sample_manifest_upload
 
   delegate :processed?, :study, to: :upload
 
@@ -27,9 +28,12 @@ class SampleManifest::Uploader
       SampleManifestExcel::Upload::Base.new(file: file, column_list: self.configuration.columns.all, override: override)
   end
 
-  def run!
+  def run! # rubocop:disable Metrics/MethodLength
     # Validation outside the transaction because we want to return the errors
     return false unless valid?
+
+    # Start the upload so that we can prevent concurrent uploads
+    upload.sample_manifest.start!
 
     # Rails 6.1 doesn't allow return value from transaction block
     success =
@@ -67,6 +71,15 @@ class SampleManifest::Uploader
     return true if upload.valid?
 
     extract_errors
+  end
+
+  def check_sample_manifest_upload
+    return true unless upload.sample_manifest&.state == 'processing'
+
+    errors.add(
+      :base,
+      'A version of this sample manifest is already being processed, please wait until it has completed.'
+    )
   end
 
   def extract_errors

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -33,7 +33,6 @@ module SampleManifestExcel
       validate :check_processor, if: :processor?
 
       delegate :processed?, to: :processor
-      delegate :finished!, to: :sample_manifest
       delegate :data_at, to: :rows
       delegate :study, to: :sample_manifest, allow_nil: true
 

--- a/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
+++ b/app/sample_manifest_excel/sample_manifest_excel/upload/base.rb
@@ -77,7 +77,6 @@ module SampleManifestExcel
         # saves will result in duplicate accessions
         Sample::Current.processing_manifest = true
         sample_manifest.last_errors = nil
-        sample_manifest.start!
         @cache.populate!
         processor.run(tag_group)
 

--- a/spec/sample_manifest_excel/upload/processor_spec.rb
+++ b/spec/sample_manifest_excel/upload/processor_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
         before do
           upload.process(tag_group) || raise("Process error: #{upload.errors.full_messages}")
-          upload.finished!
+          upload.sample_manifest.state = 'completed'
         end
 
         after { File.delete(new_test_file) if File.exist?(new_test_file_name) }
@@ -374,7 +374,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
         before do
           upload.process(tag_group) || raise("Process error: #{upload.errors.full_messages}")
-          upload.finished!
+          upload.sample_manifest.state = 'completed'
         end
 
         after { File.delete(new_test_file) if File.exist?(new_test_file_name) }
@@ -445,7 +445,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
           before do
             upload.process(tag_group)
-            upload.finished!
+            upload.sample_manifest.state = 'completed'
           end
 
           after { File.delete(new_test_file_name) if File.exist?(new_test_file_name) }
@@ -517,7 +517,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
           before do
             upload.process(nil)
-            upload.finished!
+            upload.sample_manifest.state = 'completed'
           end
 
           after { File.delete(new_test_file_name) if File.exist?(new_test_file_name) }
@@ -693,7 +693,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
           before do
             upload.process(nil)
-            upload.finished!
+            upload.sample_manifest.state = 'completed'
           end
 
           after { File.delete(new_test_file_name) if File.exist?(new_test_file_name) }
@@ -739,7 +739,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
           before do
             upload.process(nil)
-            upload.finished!
+            upload.sample_manifest.state = 'completed'
           end
 
           after { File.delete(new_test_file_name) if File.exist?(new_test_file_name) }
@@ -775,7 +775,7 @@ RSpec.describe SampleManifestExcel::Upload::Processor, type: :model do
 
           before do
             upload.process(nil)
-            upload.finished!
+            upload.sample_manifest.state = 'completed'
           end
 
           after { File.delete(new_test_file_name) if File.exist?(new_test_file_name) }

--- a/spec/sample_manifest_excel/upload/upload_spec.rb
+++ b/spec/sample_manifest_excel/upload/upload_spec.rb
@@ -89,8 +89,9 @@ RSpec.describe SampleManifestExcel::Upload, :sample_manifest, :sample_manifest_e
     download.save(test_file_name)
     upload = SampleManifestExcel::Upload::Base.new(file: test_file, column_list: columns, start_row: 9)
     expect(upload.sample_manifest.state).to eq 'pending'
+    upload.sample_manifest.start!
     upload.process(tag_group)
-    upload.finished!
+    upload.sample_manifest.finished!
     expect(upload.sample_manifest.state).to eq 'completed'
   end
 


### PR DESCRIPTION
Closes #4266 

#### Changes proposed in this pull request
- Add uploader validation to prevent upload if it is already uploading.

#### Instructions for Reviewers

- To test locally create a fairly large manifest > 3 plates. (this just makes it easier to replicate concurrent uploads as small ones upload quickly).
- Update config/puma and `workers 1` so you can handle concurrent requests locally.
- You many need to increase db pools in config/database.yml to handle all the connections.
- Upload 2 manifests within 5-10 seconds of one another.

#### Notes

@yoldas managed to create duplicate samples, even with these changes, by actively trying to bypass validation by uploading two manifests at the exact same time. There is a theoretical window of a few milliseconds where the validation passes in the first manifest and second manifest at the same time before both setting the manifest state to processing.
We discussed possible solutions but agreed this solution is good enough as it is very unlikely this level of concurrency happens in reality. If this problem continues we will need to use record locking.