### PR TITLE
Sink footer items to bottom of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,8 +493,6 @@ This isn't necessary at this stage, but it seems wise to note the intended patte
 
 The GH actions builds use the Knapsack-pro gem to reduce build time by parallelizing the RSpec and Cucumber tests. There is no need to regenerate the knapsack_rspec_report.json file, Knapsack Pro will dynamically allocate tests to ensure tests finish as close together as possible.
 
-Copyright (c) 2007, 2010-2021 Genome Research Ltd.
-
 ### ERD
 
 You can create a database entity relationship diagram, by specifying the title and attributes optionally, and view the output:
@@ -516,3 +514,5 @@ the table of contents, run:
 ```shell
 npx markdown-toc -i README.md --bullets "-"
 ```
+
+Copyright (c) 2007, 2010-2024 Genome Research Ltd.


### PR DESCRIPTION
Copyright notice and table-of-contents update commands are easiest to find at the bottom of the README.

#### Changes proposed in this pull request

- Move table of contents update command to bottom
- Move copyright notice to bottom
- Update table of contents

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
