### PR TITLE
Revert "fix: don't cache classes by default in development"

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,12 +12,9 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = ENV.fetch('CACHE_CLASSES', 'false') == 'true'
+  config.cache_classes = ENV.fetch('CACHE_CLASSES', 'true') == 'true'
 
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
+  # Do not eager load code on boot.
   config.eager_load = true
 
   # Show full error reports.


### PR DESCRIPTION
Reverts sanger/sequencescape#4509

Clashing with rails 7 upgrade when locally developing with the following error when running the jobs worker:

```
NameError: undefined local variable or method `list_model' for <SequencescapeExcel::ConditionalFormattingDefaultList: @keys=[:type], @values=[<SequencescapeExcel::ConditionalFormattingDefault: @type=empty_cell, @style={"bg_color"=>"82CAFA", "type"=>:dxf}, @options={"type"=>:cellIs, "formula"=>"FALSE", "operator"=>:equal, "priority"=>1}>]>:SequencescapeExcel::ConditionalFormattingDefaultList (NameError)
      list_model.new(*(keys.collect { |_k| {} }))
      ^^^^^^^^^^
/Users/as28/Documents/workspace/sequencescape/app/sequencescape_excel/sequencescape_excel/list.rb:175:in `create_list'
```