### PR TITLE
Y24-382: Clarify meaning of v and b in robot worksheet

### DIFF
--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -92,7 +92,7 @@
 </div>
 
 <div id="footer">
-  v = receptacle volume µl; b = buffer volume µl<br>
+  v = picking volume µl; b = buffer volume µl<br>
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>
   Printed: <%= Time.now.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= current_user.login %>
 </div>


### PR DESCRIPTION
Closes #4412 

#### Changes proposed in this pull request

Change footer of cherrypicking worksheets

- Add footnote describing `v` and `b`
- Put each footnote on a new line

Before:

<img width="525" alt="Screenshot 2024-12-05 at 11 34 10" src="https://github.com/user-attachments/assets/a2d9e0d9-7b74-42dd-8c4f-38b3817cec39">

After:

<img width="534" alt="Screenshot 2024-12-05 at 11 38 10" src="https://github.com/user-attachments/assets/a9bd9685-66bb-4bdd-80ab-410e6b42d472">


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
