### PR TITLE
Y24-190: Add V2 endpoint for creating and reading WorkCompletions

### DIFF
--- a/app/controllers/api/v2/work_completions_controller.rb
+++ b/app/controllers/api/v2/work_completions_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # Provides a JSON API controller for work completion
+    # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
+    class WorkCompletionsController < JSONAPI::ResourceController
+      # By default JSONAPI::ResourceController provides most the standard
+      # behaviour, and in many cases this file may be left empty.
+    end
+  end
+end

--- a/app/resources/api/v2/work_completion_resource.rb
+++ b/app/resources/api/v2/work_completion_resource.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # @todo This documentation does not yet include a detailed description of what this resource represents.
+    # @todo This documentation does not yet include detailed descriptions for relationships, attributes and filters.
+    # @todo This documentation does not yet include any example usage of the API via cURL or similar.
+    #
+    # Provides a JSON:API representation of {WorkCompletion} which contains the QC data previously added to a piece of
+    # {Labware}. The file contents are stored in the database using the {DbFile} model.
+    #
+    # @note This resource cannot be modified after creation: its endpoint will not accept `PATCH` requests.
+    # @note Access this resource via the `/api/v2/work_completions/` endpoint.
+    #
+    # For more information about JSON:API see the [JSON:API Specifications](https://jsonapi.org/format/)
+    # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package for Sequencescape's implementation
+    # of the JSON:API standard.
+    class WorkCompletionResource < BaseResource
+      ###
+      # Attributes
+      ###
+
+      # @!attribute [w] submission_uuids
+      #   This is declared for convenience where the submissions are not available to set as a relationship.
+      #   Setting this attribute alongside the `submissions` relationships will prefer the relationship value.
+      #   @deprecated Use the `submissions` relationship instead.
+      #   @param value [Array<String>] The UUIDs of the [{Submission}s] related to this WorkCompletion.
+      #   @return [Void]
+      #   @see #submissions
+      attribute :submission_uuids, writeonly: true
+
+      def submission_uuids=(value)
+        @model.submissions = value.map { |v| Submission.with_uuid(v).first }
+      end
+
+      # @!attribute [w] target_uuid
+      #   This is declared for convenience where the target {Labware} is not available to set as a relationship.
+      #   Setting this attribute alongside the `target` relationship will prefer the relationship value.
+      #   @deprecated Use the `target` relationship instead.
+      #   @param value [String] The UUID of the {Labware} that this work completion targets.
+      #   @return [Void]
+      #   @see #target
+      attribute :target_uuid, writeonly: true
+
+      def target_uuid=(value)
+        @model.target = Labware.with_uuid(value).first
+      end
+
+      # @!attribute [w] user_uuid
+      #   This is declared for convenience where the {User} is not available to set as a relationship.
+      #   Setting this attribute alongside the `user` relationship will prefer the relationship value.
+      #   @deprecated Use the `user` relationship instead.
+      #   @param value [String] The UUID of the {User} who initiated this plate creation.
+      #   @return [Void]
+      #   @see #user
+      attribute :user_uuid, writeonly: true
+
+      def user_uuid=(value)
+        @model.user = User.with_uuid(value).first
+      end
+
+      ###
+      # Relationships
+      ###
+
+      # @!attribute [rw] submissions
+      #   Setting this relationship alongside the `submission_uuids` attribute will override the attribute value.
+      #   @return [Array<SubmissionResource>] The Submissions related to this WorkCompletion.
+      #   @note This relationship is required.
+      has_many :submissions, write_once: true
+
+      # @!attribute [rw] target
+      #   Setting this relationship alongside the `target_uuid` attribute will override the attribute value.
+      #   @return [LabwareResource] The Labware which this WorkCompletion targets. @todo: reword to active sense
+      #   @note This relationship is required.
+      has_one :target, write_once: true
+
+      # @!attribute [rw] user
+      #   Setting this relationship alongside the `user_uuid` attribute will override the attribute value.
+      #   @return [UserResource] The User who initiated this WorkCompletion.
+      #   @note This relationship is required.
+      has_one :user, write_once: true
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
       jsonapi_resources :users
       jsonapi_resources :volume_updates
       jsonapi_resources :wells
+      jsonapi_resources :work_completions, except: %i[update]
       jsonapi_resources :work_orders
 
       namespace :heron do

--- a/spec/factories/work_completions_factories.rb
+++ b/spec/factories/work_completions_factories.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :work_completion do
+    target { create(:labware) }
+    user { create(:user) }
+    submissions { create_list(:submission, 3) }
+  end
+end

--- a/spec/requests/api/v2/work_completions_spec.rb
+++ b/spec/requests/api/v2/work_completions_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './spec/requests/api/v2/shared_examples/api_key_authenticatable'
+require './spec/requests/api/v2/shared_examples/requests'
+
+describe 'Work Completions API', with: :api_v2 do
+  let(:model_class) { WorkCompletion }
+  let(:base_endpoint) { "/api/v2/#{resource_type}" }
+  let(:resource_type) { model_class.name.demodulize.pluralize.underscore }
+
+  it_behaves_like 'ApiKeyAuthenticatable'
+
+  context 'with a list of resources' do
+    let(:resource_count) { 5 }
+
+    before { create_list(:work_completion, resource_count) }
+
+    describe '#GET all resources' do
+      before { api_get base_endpoint }
+
+      it 'responds with a success http code' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns all the resources' do
+        expect(json['data'].count).to eq(resource_count)
+      end
+    end
+  end
+
+  context 'with a single resource' do
+    describe '#GET resource by ID' do
+      let(:resource) { create(:work_completion) }
+
+      context 'without included relationships' do
+        before { api_get "#{base_endpoint}/#{resource.id}" }
+
+        it 'responds with a success http code' do
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'returns the correct resource' do
+          expect(json['data']['id']).to eq(resource.id.to_s)
+        end
+
+        it 'returns the resource with the correct type' do
+          expect(json.dig('data', 'type')).to eq(resource_type)
+        end
+
+        it 'response returns no attributes' do
+          expect(json.dig('data', 'attributes')).to be_nil
+        end
+
+        it 'returns a reference to the target relationship' do
+          expect(json.dig('data', 'relationships', 'target')).to be_present
+        end
+
+        it 'returns a reference to the user relationship' do
+          expect(json.dig('data', 'relationships', 'user')).to be_present
+        end
+
+        it 'returns a reference to the submissions relationship' do
+          expect(json.dig('data', 'relationships', 'submissions')).to be_present
+        end
+
+        it 'does not include attributes for related resources' do
+          expect(json['included']).not_to be_present
+        end
+      end
+
+      context 'with included relationships' do
+        it_behaves_like 'a GET request including a has_many relationship', 'submissions'
+        it_behaves_like 'a GET request including a has_one relationship', 'target'
+        it_behaves_like 'a GET request including a has_one relationship', 'user'
+      end
+    end
+  end
+
+  describe '#PATCH a resource' do
+    let(:resource_model) { create(:work_completion) }
+    let(:payload) { { data: { id: resource_model.id, type: resource_type, attributes: {} } } }
+
+    it 'finds no route for the method' do
+      expect { api_patch "#{base_endpoint}/#{resource_model.id}", payload }.to raise_error(
+        ActionController::RoutingError
+      )
+    end
+  end
+
+  describe '#POST a resource' do
+    let(:submissions) { create_list(:submission, 3) }
+    let(:target) { create(:labware) }
+    let(:user) { create(:user) }
+
+    let(:submissions_relationship) { { data: submissions.map { |s| { type: 'submissions', id: s.id } } } }
+    let(:target_relationship) { { data: { type: 'labware', id: target.id } } }
+    let(:user_relationship) { { data: { type: 'users', id: user.id } } }
+
+    context 'with a valid payload' do
+      shared_examples 'a valid request' do
+        before { api_post base_endpoint, payload }
+
+        it 'creates a new resource' do
+          expect { api_post base_endpoint, payload }.to change(model_class, :count).by(1)
+        end
+
+        it 'responds with success' do
+          expect(response).to have_http_status(:success)
+        end
+
+        it 'responds with a resource of the correct type' do
+          expect(json.dig('data', 'type')).to eq(resource_type)
+        end
+
+        it 'response returns no attributes' do
+          expect(json.dig('data', 'attributes')).to be_nil
+        end
+
+        it 'returns a reference to the submissions relationship' do
+          expect(json.dig('data', 'relationships', 'submissions')).to be_present
+        end
+
+        it 'returns a reference to the target relationship' do
+          expect(json.dig('data', 'relationships', 'target')).to be_present
+        end
+
+        it 'returns a reference to the user relationship' do
+          expect(json.dig('data', 'relationships', 'user')).to be_present
+        end
+
+        it 'associates the submissions with the new record' do
+          new_record = model_class.last
+          expect(new_record.submissions).to eq(submissions)
+        end
+
+        it 'associates the user with the new record' do
+          new_record = model_class.last
+          expect(new_record.user).to eq(user)
+        end
+
+        it 'associates the target with the new record' do
+          new_record = model_class.last
+          expect(new_record.target).to eq(target)
+        end
+      end
+
+      context 'with all attributes' do
+        let(:payload) do
+          {
+            data: {
+              type: resource_type,
+              attributes: {
+                submission_uuids: submissions.map(&:uuid),
+                target_uuid: target.uuid,
+                user_uuid: user.uuid
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'a valid request'
+      end
+
+      context 'with all relationships' do
+        let(:payload) do
+          {
+            data: {
+              type: resource_type,
+              relationships: {
+                submissions: submissions_relationship,
+                target: target_relationship,
+                user: user_relationship
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'a valid request'
+      end
+
+      context 'with required relationships' do
+        let(:payload) do
+          { data: { type: resource_type, relationships: { target: target_relationship, user: user_relationship } } }
+        end
+        let(:submissions) { [] }
+
+        it_behaves_like 'a valid request'
+      end
+
+      context 'with both attributes and relationships' do
+        let(:other_submissions) { create_list(:submission, 2) }
+        let(:other_target) { create(:labware) }
+        let(:other_user) { create(:user) }
+
+        let(:payload) do
+          {
+            data: {
+              type: resource_type,
+              attributes: {
+                submission_uuids: other_submissions.map(&:uuid),
+                target_uuid: other_target.uuid,
+                user_uuid: other_user.uuid
+              },
+              relationships: {
+                submissions: submissions_relationship,
+                target: target_relationship,
+                user: user_relationship
+              }
+            }
+          }
+        end
+
+        it_behaves_like 'a valid request'
+      end
+    end
+
+    context 'with a missing required relationship' do
+      context 'without target' do
+        let(:payload) { { data: { type: resource_type, relationships: { user: user_relationship } } } }
+        let(:error_detail_message) { 'target - must exist' }
+
+        it_behaves_like 'an unprocessable POST request with a specific error'
+      end
+
+      context 'without user' do
+        let(:payload) { { data: { type: resource_type, relationships: { target: target_relationship } } } }
+        let(:error_detail_message) { 'user - must exist' }
+
+        it_behaves_like 'an unprocessable POST request with a specific error'
+      end
+    end
+  end
+end

--- a/spec/resources/api/v2/work_completion_resource_spec.rb
+++ b/spec/resources/api/v2/work_completion_resource_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './app/resources/api/v2/work_completion_resource'
+
+RSpec.describe Api::V2::WorkCompletionResource, type: :resource do
+  subject(:resource) { described_class.new(resource_model, {}) }
+
+  let(:resource_model) { build_stubbed(:work_completion) }
+
+  # Model Name
+  it { is_expected.to have_model_name 'WorkCompletion' }
+
+  # Attributes
+  it { is_expected.to have_writeonly_attribute :submission_uuids }
+  it { is_expected.to have_writeonly_attribute :target_uuid }
+  it { is_expected.to have_writeonly_attribute :user_uuid }
+
+  # Relationships
+  it { is_expected.to have_a_write_once_has_many(:submissions).with_class_name('Submission') }
+  it { is_expected.to have_a_write_once_has_one(:target).with_class_name('Labware') }
+  it { is_expected.to have_a_write_once_has_one(:user).with_class_name('User') }
+end


### PR DESCRIPTION
Closes https://github.com/sanger/sequencescape/issues/4244

#### Changes proposed in this pull request

- Support Limber's transition to V2 by creating an endpoint for WorkCompletion fetching and creation.
- Add new unit tests for the resource and the requests on the endpoint.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  