### PR TITLE
Y24-373 - Sample Metadata migration to update invalid country_or_origin data

### DIFF
--- a/db/migrate/20250123105050_migrate_sample_metadata_for_invalid_insdc_country_of_origin.rb
+++ b/db/migrate/20250123105050_migrate_sample_metadata_for_invalid_insdc_country_of_origin.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# Migrates the data related to invalid INSDC countries of origin to their current equivalent
+# See DisableInvalidInsdcCountries migration for more details
+class MigrateSampleMetadataForInvalidInsdcCountryOfOrigin < ActiveRecord::Migration[7.0]
+  def change
+    sample_metadata =
+      Sample::Metadata.where(country_of_origin: ['not applicable: control sample', 'not applicable: sample group'])
+
+    sample_metadata.each do |sm|
+      if sm.country_of_origin == 'not applicable: control sample'
+        sm.update!(country_of_origin: 'missing: control sample')
+      elsif sm.country_of_origin == 'not applicable: sample group'
+        sm.update!(country_of_origin: 'missing: sample group')
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_14_135342) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_23_105050) do
   create_table "aliquot_indices", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false
     t.integer "lane_id", null: false


### PR DESCRIPTION
Closes #4406 

#### Changes proposed in this pull request

- Adds migration to update invalid country_of_origin sample metadata values to their valid equivalent.

#### Notes

- Relates to previous work https://github.com/sanger/sequencescape/pull/4433
- Will resolve schema conflict when its ready to merge as there are several other PRs with schema changes so don't want to waste effort.