### PR TITLE
Y24-194 [PR] Fix LCMT DNA Adp Lig purpose record

### DIFF
--- a/config/default_records/plate_purposes/013_lcm_triomics_plate_purposes.wip.yml
+++ b/config/default_records/plate_purposes/013_lcm_triomics_plate_purposes.wip.yml
@@ -1,10 +1,21 @@
 # Plate purposes for LCM Triomics WGS and EMSeq
 ---
+# The starting point for the 'LCM Triomics' pipeline is the LCMT Lysate plate.
+# It is defined here so it can be added to the acceptable purposes for the
+# 'LCM Triomics' manual submission. It is an input plate and so it is 'passed'
+# when all non-empty wells have requests out of them, i.e., when the submission
+# is built.
 LCMT Lysate:
   type: PlatePurpose::Input
   stock_plate: true
   cherrypickable_target: false
+# Five plates of the LCM Triomics pipeline all go from 'pending' to 'started'
+# at 'Bravo LCMT EMSeq Verify Initial Setup' and then to 'passed' one by one in
+# either single bed verification or manual transfer. None of them can be input
+# plates. The LCMT DNA Adp Lig purpose is defined here so it can be added to the
+# acceptable purposes for the 'LCM Triomics WGS' automated submission, which
+# is enabled when LCMT DNA Adp Lig is 'passed'.
 LCMT DNA Adp Lig:
-  type: PlatePurpose::Input
+  type: PlatePurpose
   stock_plate: false
   cherrypickable_target: false


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- LCMT DNA Adp Lig is not an input plate; its state is not determined by a submission build on it. This update fixes the state transition from pending to started at Bravo Verify Initial Setup and started to passed in Manual Transfer.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
