### PR TITLE
Y24-429 [PR] update feature flag and warning message

### DIFF
--- a/app/models/submission/scrna_core_cdna_prep_feasibility_validator.rb
+++ b/app/models/submission/scrna_core_cdna_prep_feasibility_validator.rb
@@ -15,12 +15,6 @@
 #
 # The messages are generated using the strings in the locale file.
 #
-# This module is feature-flagged with the key
-# y24_429_enable_check_feasibility_of_cdna_prep_submission . If enabled, the
-# validate_scrna_core_cdna_prep_feasibility method is called by the
-# apply_additional_validations_by_template_name method of the
-# Submission::ValidationsByTemplateName module.
-#
 # rubocop:disable Metrics/ModuleLength
 module Submission::ScrnaCoreCdnaPrepFeasibilityValidator
   # Add the methods from the calculator module for volume calculations.

--- a/app/models/submission/validations_by_template_name.rb
+++ b/app/models/submission/validations_by_template_name.rb
@@ -30,7 +30,6 @@ module Submission::ValidationsByTemplateName
   # errors [ActiveModel::Errors] The errors object to which validation errors are added.
   #
   # @return [void]
-  # rubocop:disable Metrics/MethodLength
   def apply_additional_validations_by_template_name
     # depending on the submission template type, call additional validations
     # NB. assumption that all rows in the csv have the same submission template name
@@ -43,13 +42,9 @@ module Submission::ValidationsByTemplateName
       validate_consistent_column_value(HEADER_NUMBER_OF_POOLS)
       validate_consistent_column_value(HEADER_CELLS_PER_CHIP_WELL)
       validate_samples_per_pool_for_labware
-      if Flipper.enabled?(:y24_429_enable_check_feasibility_of_cdna_prep_submission)
-        validate_scrna_core_cdna_prep_feasibility
-      end
+      validate_scrna_core_cdna_prep_feasibility
     end
   end
-  # rubocop:enable Metrics/MethodLength
-
   def apply_number_of_samples_per_pool_validation
     # Creates groups of rows based on the study and project name (pool_number, study-project) combinations
     group_rows_by_study_and_project

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -4,4 +4,3 @@
 dpl_395_2_enable_advanced_search_tab: Shows the Search tab in the top navigation bar
 # Below is flagged off until some existing data that would violate the rule is fixed. Should be re-enabled in Y24-058.
 y24_052_enable_data_release_timing_validation: Enables server-side validation that enforces a relationship between the values of two study metadata fields
-y24_429_enable_check_feasibility_of_cdna_prep_submission: Enables the feasibility validations for cDNA Prep Bulk Submission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,16 +228,15 @@ en:
           However, %{count} samples with the same donor ID were found, while the number of pools requested was %{number_of_pools}.
           The samples with the same donor ID follow: %{barcodes_or_well_locations}.
       warnings:
-        # Validation: There is not enough material for the "full allowance" (2 full runs on the chip)
+        # Validation: There is not enough material for two repeat pooling attempts
         # study_name and project_name are the values of respective fields from the spreadsheet.
         # number_of_samples_in_smallest_pool is the number of samples in the smallest pool.
         # final_resuspension_volume is the final resuspension volume given the number of samples in the smallest pool for the smallest pool.
         # full_allowance is the full allowance given the number of cells per chip well for the study and project.
         full_allowance: >
-          There is not enough material for the "full allowance" (2 full runs on the chip) for the study %{study_name} and the project %{project_name}.
+          There is not enough material for two repeat pooling attempts for the study %{study_name} and the project %{project_name}.
           The final resuspension volume for the smallest pool should be greater than or equal to the full allowance.
           However, for the smallest pool of size %{number_of_samples_in_smallest_pool}, the final resuspension volume is %{final_resuspension_volume} and the full allowance is %{full_allowance}.
-          The number of cells per chip well will be adjusted according to the number of samples while pooling.
 
   cherrypick:
     picking_by_row: "This cherrypick may take longer as it is picking by rows, rather than columns."

--- a/spec/models/scrna_core_cdna_prep_feasibility_validator_spec.rb
+++ b/spec/models/scrna_core_cdna_prep_feasibility_validator_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe BulkSubmission, with: :uploader do
   subject(:bulk_submission) { described_class.new(spreadsheet: submission_file) }
 
   before do
-    Flipper.enable(:y24_429_enable_check_feasibility_of_cdna_prep_submission)
     SubmissionSerializer.construct!(submission_template_hash) # Create the template.
   end
 


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Remove the feature flag to always enable the cDNA Prep feasibility validations.
- Reword the warning message to say that the requested values would not give them enough material for 2 repeat pooling attempts rather than 'full allowance'. This will just be a bit clearer to the SSR what this means.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
