### PR TITLE
Fix uat actions

### DIFF
--- a/app/uat_actions/uat_actions/generate_plates.rb
+++ b/app/uat_actions/uat_actions/generate_plates.rb
@@ -52,7 +52,8 @@ class UatActions::GeneratePlates < UatActions
 
   validates :plate_purpose_name, presence: true
   validates :plate_count, numericality: { greater_than: 0, smaller_than: 20, only_integer: true, allow_blank: false }
-  validates :well_count, numericality: { greater_than: 0, only_integer: true, allow_blank: false }
+  # well_count is zero for the reracking test.
+  validates :well_count, numericality: { greater_than_or_equal_to: 0, only_integer: true, allow_blank: false }
   validates :number_of_samples_in_each_well,
             numericality: {
               greater_than: 0,

--- a/app/uat_actions/uat_actions/tube_submission.rb
+++ b/app/uat_actions/uat_actions/tube_submission.rb
@@ -125,10 +125,12 @@ class UatActions::TubeSubmission < UatActions
     barcodes =
       tube_barcodes
         .gsub(/(\\[trfvn])+/, ' ')
+        .strip
         .split
         .select do |barcode|
           Tube.find_by_barcode(barcode).blank? # not found
         end
+    return if barcodes.empty?
 
     message = format(ERROR_TUBES_DO_NOT_EXIST, barcodes.join(', '))
     errors.add(:tube_barcodes, message)


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Allow zero well_count in the generateplates UAT action for the reracking test.
- Sanitise barcodes before checking tubes in the tube_submission UAT action.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
