### PR TITLE
Use Docker variables to silence warnings and keep versions consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 ARG CHIPSET=default
+ARG RUBY_VERSION=3.3.6
+ARG APPLE_PLATFORM=linux/amd64
 
 # Use the correct base image depending on the architecture
 # For Apple M1 Chip, run: docker build --build-arg CHIPSET=m1 .
-FROM ruby:3.3.6-slim AS base_default
-FROM --platform=linux/amd64 ruby:3.2.5-slim AS base_m1
+FROM ruby:${RUBY_VERSION}-slim AS base_default
+FROM --platform=${APPLE_PLATFORM} ruby:${RUBY_VERSION}-slim AS base_m1
 FROM base_${CHIPSET} AS base
 
 COPY .nvmrc /.nvmrc


### PR DESCRIPTION
Silence Docker warnings and keep Ruby versions consistent

#### Changes proposed in this pull request

- Add `APPLE_PLATFORM` variable as required in https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/
- Add `RUBY_VERSION` variable as the normal one keeps being changed without the apple one being changed too

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
