### PR TITLE
Y24-213 - Removed `default_includes` from v2 API Resources

### DIFF
--- a/app/resources/api/v2/aliquot_resource.rb
+++ b/app/resources/api/v2/aliquot_resource.rb
@@ -14,8 +14,6 @@ module Api
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package for Sequencescape's implementation
     # of the JSON:API standard.
     class AliquotResource < BaseResource
-      default_includes :tag, :tag2
-
       # Associations
       has_one :study
       has_one :project

--- a/app/resources/api/v2/asset_resource.rb
+++ b/app/resources/api/v2/asset_resource.rb
@@ -16,8 +16,6 @@ module Api
     class AssetResource < BaseResource
       attributes :uuid
 
-      default_includes :uuid_object
-
       has_one :custom_metadatum_collection
       has_many :comments, readonly: true
 

--- a/app/resources/api/v2/barcode_printer_resource.rb
+++ b/app/resources/api/v2/barcode_printer_resource.rb
@@ -17,8 +17,6 @@ module Api
     class BarcodePrinterResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/base_resource.rb
+++ b/app/resources/api/v2/base_resource.rb
@@ -47,60 +47,6 @@ module Api
         super - self.class._attributes.select { |_attr, options| options[:writeonly] }.keys -
           self.class._relationships.select { |_rel_key, rel| rel.options[:writeonly] }.keys
       end
-
-      # Eager load specified models by default. Useful when attributes are
-      # dependent on an associated model.
-      def self.default_includes(*inclusions)
-        @default_includes = inclusions.freeze
-      end
-
-      def self.inclusions
-        @default_includes || [].freeze
-      end
-
-      # Extends the default behaviour to add our default inclusions if provided
-      def self.apply_includes(records, options = {})
-        if @default_includes.present?
-          super(records.preload(*inclusions), options)
-        else
-          super
-        end
-      end
-
-      # The majority of this is lifted from JSONAPI::Resource
-      # We've had to modify the when Symbol chunk to handle nested includes
-      # We disable the cops for the shared section to avoid accidental drift
-      # due to auto-correct.
-      # rubocop:disable all
-      def self.resolve_relationship_names_to_relations(resource_klass, model_includes, options = {})
-        case model_includes
-        when Array
-          return model_includes.map { |value| resolve_relationship_names_to_relations(resource_klass, value, options) }
-        when Hash
-          model_includes.keys.each do |key|
-            relationship = resource_klass._relationships[key]
-            value = model_includes[key]
-            model_includes.delete(key)
-
-            # MODIFICATION BEGINS
-            included_relationships =
-              resolve_relationship_names_to_relations(relationship.resource_klass, value, options)
-            model_includes[relationship.relation_name(options)] = relationship.resource_klass.inclusions +
-              included_relationships
-            # MODIFICATION ENDS
-          end
-          return model_includes
-        when Symbol
-          relationship = resource_klass._relationships[model_includes]
-
-          # MODIFICATION BEGINS
-          # return relationship.relation_name(options)
-          inclusions = relationship.resource_klass.inclusions
-          { relationship.relation_name(options) => inclusions }
-          # MODIFICATION ENDS
-        end
-      end
-      # rubocop:enable all
     end
   end
 end

--- a/app/resources/api/v2/custom_metadatum_collection_resource.rb
+++ b/app/resources/api/v2/custom_metadatum_collection_resource.rb
@@ -14,8 +14,6 @@ module Api
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package for Sequencescape's implementation
     # of the JSON:API standard.
     class CustomMetadatumCollectionResource < BaseResource
-      default_includes :uuid_object, :custom_metadata
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/labware_resource.rb
+++ b/app/resources/api/v2/labware_resource.rb
@@ -19,8 +19,6 @@ module Api
       # is automatically available on plate and tube.
       include Api::V2::SharedBehaviour::Labware
 
-      default_includes :uuid_object, :barcodes
-
       # Custom methods
       # These shouldn't be used for business logic, and are more about
       # I/O and isolating implementation details.

--- a/app/resources/api/v2/lot_resource.rb
+++ b/app/resources/api/v2/lot_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
       has_one :lot_type
       has_one :user

--- a/app/resources/api/v2/lot_type_resource.rb
+++ b/app/resources/api/v2/lot_type_resource.rb
@@ -21,8 +21,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
       has_one :target_purpose, write_once: true, class_name: 'Purpose'
 

--- a/app/resources/api/v2/plate_resource.rb
+++ b/app/resources/api/v2/plate_resource.rb
@@ -47,9 +47,6 @@ module Api
       # labware
       include Api::V2::SharedBehaviour::Labware
 
-      # TODO: {Y24-213} Possibly this line doesn't actually do anything and could be removed.
-      default_includes :uuid_object, :barcodes, :plate_purpose, :transfer_requests
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/plate_template_resource.rb
+++ b/app/resources/api/v2/plate_template_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/pre_capture_pool_resource.rb
+++ b/app/resources/api/v2/pre_capture_pool_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/project_resource.rb
+++ b/app/resources/api/v2/project_resource.rb
@@ -17,8 +17,6 @@ module Api
     class ProjectResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       attribute :name
       attribute :cost_code, delegate: :project_cost_code
       attribute :uuid, readonly: true

--- a/app/resources/api/v2/purpose_resource.rb
+++ b/app/resources/api/v2/purpose_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/qcable_resource.rb
+++ b/app/resources/api/v2/qcable_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object, :barcodes
-
       # Associations:
       has_one :lot
       has_one :asset, polymorphic: true

--- a/app/resources/api/v2/receptacle_resource.rb
+++ b/app/resources/api/v2/receptacle_resource.rb
@@ -18,8 +18,6 @@ module Api
       # attributes and filters. By adding behaviour here we ensure that it
       # is automatically available on well.
       include Api::V2::SharedBehaviour::Receptacle
-
-      default_includes :uuid_object
     end
   end
 end

--- a/app/resources/api/v2/request_resource.rb
+++ b/app/resources/api/v2/request_resource.rb
@@ -14,12 +14,6 @@ module Api
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package for Sequencescape's implementation
     # of the JSON:API standard.
     class RequestResource < BaseResource
-      default_includes :uuid_object,
-                       { request_metadata: %i[bait_library primer_panel] },
-                       :pooled_request,
-                       :order_role,
-                       :submission
-
       # Attributes
       attribute :uuid, readonly: true
       attribute :role, write_once: true

--- a/app/resources/api/v2/request_type_resource.rb
+++ b/app/resources/api/v2/request_type_resource.rb
@@ -21,8 +21,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/sample_manifest_resource.rb
+++ b/app/resources/api/v2/sample_manifest_resource.rb
@@ -17,8 +17,6 @@ module Api
     class SampleManifestResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       # Name of the supplier of the sample manifest
       attribute :supplier_name
     end

--- a/app/resources/api/v2/sample_resource.rb
+++ b/app/resources/api/v2/sample_resource.rb
@@ -14,8 +14,6 @@ module Api
     # or look at the [JSONAPI::Resources](http://jsonapi-resources.com/) package for Sequencescape's implementation
     # of the JSON:API standard.
     class SampleResource < BaseResource
-      default_includes :uuid_object
-
       has_one :sample_metadata, class_name: 'SampleMetadata', foreign_key_on: :related
       has_one :sample_manifest
 

--- a/app/resources/api/v2/submission_resource.rb
+++ b/app/resources/api/v2/submission_resource.rb
@@ -21,8 +21,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object, :sequencing_requests
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/submission_template_resource.rb
+++ b/app/resources/api/v2/submission_template_resource.rb
@@ -17,8 +17,6 @@ module Api
     class SubmissionTemplateResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/tag_group_resource.rb
+++ b/app/resources/api/v2/tag_group_resource.rb
@@ -18,8 +18,6 @@ module Api
 
       # model_name / model_hint if required
 
-      default_includes :uuid_object, :tags
-
       # Associations:
       has_one :tag_group_adapter_type,
               foreign_key: :adapter_type_id,

--- a/app/resources/api/v2/transfer_request_resource.rb
+++ b/app/resources/api/v2/transfer_request_resource.rb
@@ -17,8 +17,6 @@ module Api
     class TransferRequestResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       # Attributes
       attribute :uuid, readonly: true
       attribute :state, readonly: true

--- a/app/resources/api/v2/transfer_template_resource.rb
+++ b/app/resources/api/v2/transfer_template_resource.rb
@@ -17,8 +17,6 @@ module Api
     class TransferTemplateResource < BaseResource
       immutable
 
-      default_includes :uuid_object
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/tube_rack_resource.rb
+++ b/app/resources/api/v2/tube_rack_resource.rb
@@ -20,8 +20,6 @@ module Api
       #       Instead this should be done as part of adding authentication to
       #       the API in the security OKR.
 
-      default_includes :uuid_object, :barcodes
-
       # Attributes
       attribute :created_at, readonly: true
       attribute :labware_barcode, write_once: true

--- a/app/resources/api/v2/tube_rack_status_resource.rb
+++ b/app/resources/api/v2/tube_rack_status_resource.rb
@@ -16,8 +16,6 @@ module Api
     class TubeRackStatusResource < BaseResource
       # model_name / model_hint if required
 
-      default_includes :uuid_object
-
       # Associations:
 
       # Attributes

--- a/app/resources/api/v2/tube_resource.rb
+++ b/app/resources/api/v2/tube_resource.rb
@@ -19,8 +19,6 @@ module Api
 
       immutable
 
-      default_includes :uuid_object, :barcodes, :transfer_requests_as_target
-
       ###
       # Attributes
       ###

--- a/app/resources/api/v2/well_resource.rb
+++ b/app/resources/api/v2/well_resource.rb
@@ -16,8 +16,6 @@ module Api
     class WellResource < BaseResource
       include Api::V2::SharedBehaviour::Receptacle
 
-      default_includes :uuid_object, :map, :transfer_requests_as_target, plate: :barcodes
-
       # Attributes
       attribute :position, readonly: true
 

--- a/app/resources/api/v2/work_order_resource.rb
+++ b/app/resources/api/v2/work_order_resource.rb
@@ -19,8 +19,6 @@ module Api
     class WorkOrderResource < BaseResource
       IGNORED_METADATA_FIELDS = %w[id request_id created_at updated_at].freeze
 
-      default_includes [{ example_request: :request_metadata }, :work_order_type]
-
       # Attributes
       attribute :at_risk
       attribute :options, readonly: true


### PR DESCRIPTION
Closes #4233 

#### Changes proposed in this pull request

- Removed underlying support and all references to `default_includes` because it is no longer required.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
