### PR TITLE
Fix CI Failing from chromedriver updates.

### DIFF
--- a/app/models/cherrypick/volume_by_nano_grams.rb
+++ b/app/models/cherrypick/volume_by_nano_grams.rb
@@ -78,6 +78,12 @@ module Cherrypick::VolumeByNanoGrams
   private
 
   def calculate_buffer_volume(final_volume_desired, volume_so_far, robot_minimum_picking_volume)
+    puts("=====  TEST Volumes =====")
+    
+    puts("final_volume_desired: #{final_volume_desired}")
+    puts("volume_so_far: #{volume_so_far}")
+    puts("robot_minimum_picking_volume: #{robot_minimum_picking_volume}")
+
     buffer_to_add = final_volume_desired - volume_so_far
     return 0 if buffer_to_add <= 0
 

--- a/app/models/cherrypick/volume_by_nano_grams.rb
+++ b/app/models/cherrypick/volume_by_nano_grams.rb
@@ -78,12 +78,6 @@ module Cherrypick::VolumeByNanoGrams
   private
 
   def calculate_buffer_volume(final_volume_desired, volume_so_far, robot_minimum_picking_volume)
-    puts("=====  TEST Volumes =====")
-    
-    puts("final_volume_desired: #{final_volume_desired}")
-    puts("volume_so_far: #{volume_so_far}")
-    puts("robot_minimum_picking_volume: #{robot_minimum_picking_volume}")
-
     buffer_to_add = final_volume_desired - volume_so_far
     return 0 if buffer_to_add <= 0
 

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :headless_chrome do |app|
 
   options.add_argument('--window-size=1600,3200')
   options.add_preference('download.default_directory', DownloadHelpers::PATH.to_s)
-  options.add_argument('--headless=old')
+  options.add_argument('--headless')
   options.add_argument('--disable-gpu')
   options.add_argument('--disable-search-engine-choice-screen')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)

--- a/features/support/step_definitions/robot_verification_steps.rb
+++ b/features/support/step_definitions/robot_verification_steps.rb
@@ -13,7 +13,7 @@ Given(
   step('I follow "Select Plate Template"')
   step('I select "testtemplate" from "Plate Template"')
   step('I select "Infinium 670k" from "Output plate purpose"')
-  step('I fill in "nano_grams_per_micro_litre_volume_required" with "13"')
+  fill_in('nano_grams_per_micro_litre_volume_required', with: "13", fill_options: { clear: :backspace })
   step('I fill in "nano_grams_per_micro_litre_concentration_required" with "50"')
   fill_in('nano_grams_per_micro_litre_robot_minimum_picking_volume', with: minimum_robot_pick)
   step('I press "Next step"')

--- a/features/support/step_definitions/robot_verification_steps.rb
+++ b/features/support/step_definitions/robot_verification_steps.rb
@@ -109,6 +109,8 @@ Then /^the downloaded robot file for batch "([^"]*)" and plate "([^"]*)" is$/ do
   generated_lines.each_with_index do |line, index|
     assert_equal tecan_file_lines[index], line, "Mismatch on line #{index + 2} in #{generated_file}"
   end
+
+  DownloadHelpers.remove_downloads
 end
 
 Then /^the source plates should be sorted by bed:$/ do |expected_results_table|

--- a/features/support/step_definitions/robot_verification_steps.rb
+++ b/features/support/step_definitions/robot_verification_steps.rb
@@ -13,7 +13,7 @@ Given(
   step('I follow "Select Plate Template"')
   step('I select "testtemplate" from "Plate Template"')
   step('I select "Infinium 670k" from "Output plate purpose"')
-  fill_in('nano_grams_per_micro_litre_volume_required', with: "13", fill_options: { clear: :backspace })
+  fill_in('nano_grams_per_micro_litre_volume_required', with: '13', fill_options: { clear: :backspace })
   step('I fill in "nano_grams_per_micro_litre_concentration_required" with "50"')
   fill_in('nano_grams_per_micro_litre_robot_minimum_picking_volume', with: minimum_robot_pick)
   step('I press "Next step"')

--- a/features/support/step_definitions/robot_verification_steps.rb
+++ b/features/support/step_definitions/robot_verification_steps.rb
@@ -109,8 +109,6 @@ Then /^the downloaded robot file for batch "([^"]*)" and plate "([^"]*)" is$/ do
   generated_lines.each_with_index do |line, index|
     assert_equal tecan_file_lines[index], line, "Mismatch on line #{index + 2} in #{generated_file}"
   end
-
-  DownloadHelpers.remove_downloads
 end
 
 Then /^the source plates should be sorted by bed:$/ do |expected_results_table|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,7 +52,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
 
   options.add_preference('download.default_directory', DownloadHelpers::PATH.to_s)
-  options.add_argument('--headless=old')
+  options.add_argument('--headless')
   options.add_argument('--disable-gpu')
   options.add_argument('--disable-search-engine-choice-screen')
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)


### PR DESCRIPTION
Fixes CI failing.

GitHub runner image [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers) is now running Chrome 132 which deprecates --headless=old.

#### Changes proposed in this pull request

- Moves Selenium drivers from [the deprecated](https://developer.chrome.com/blog/removing-headless-old-from-chrome) `--headless=old` to `--headless`.
- Fixes failing robot_verification test where an input field was not being cleared before being written into.
