### PR TITLE
fix: add sample collection date to summary view

### DIFF
--- a/app/views/samples/_summary.html.erb
+++ b/app/views/samples/_summary.html.erb
@@ -27,6 +27,10 @@
       <td><strong><%=h @sample.created_at.to_formatted_s(:day_full_with_time) %></strong></td>
     </tr>
     <tr>
+      <td class="item">Sample Collection Date</td>
+      <td><%=h @sample.sample_metadata.date_of_sample_collection %></td>
+    </tr>
+    <tr>
       <td class="item">Control:</td>
       <td><%=h @sample.control_formatted %></td>
     </tr>

--- a/features/samples/samples.feature
+++ b/features/samples/samples.feature
@@ -26,6 +26,7 @@ Feature: Show/update samples
     Then I should see "Sequencescape Sample ID"
      And I should see "Public Name"
      And I should see "TAXON ID"
+     And I should see "Sample Collection Date"
 
   Scenario: All sample metadata should show in genotyping workflow
     Given I have a sample called "sample_test" with metadata
@@ -37,6 +38,7 @@ Feature: Show/update samples
     Then I should see "Sequencescape Sample ID"
      And I should see "Public Name"
      And I should see "TAXON ID"
+     And I should see "Sample Collection Date"
 
   Scenario: User is an administrator
 


### PR DESCRIPTION
Closes https://github.com/sanger/sequencescape/issues/4514

#### Changes proposed in this pull request

- adds sample collection date to summary view

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
