### PR TITLE
build: add syslog as separate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :default do
   # Previously part of ruby or rails, now separate gems
   gem 'drb', '~> 2.2'
   gem 'mutex_m', '~> 0.3.0'
+  gem 'syslog', '~> 0.2.0'
 
   # Fix incompatibility with between Ruby 3.1 and Psych 4 (used for yaml)
   # see https://stackoverflow.com/a/71192990

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,7 @@ GEM
       syntax_tree (>= 2.0.1)
     sys-uname (1.2.3)
       ffi (~> 1.1)
+    syslog (0.2.0)
     temple (0.10.3)
     test-prof (1.4.2)
     thor (1.3.2)
@@ -649,6 +650,7 @@ DEPENDENCIES
   syntax_tree
   syntax_tree-haml
   syntax_tree-rbs
+  syslog (~> 0.2.0)
   test-prof
   timecop
   traceroute


### PR DESCRIPTION
Follows on from #4647 with `syslog`.

Removes warning:

```sh
/Users/[user]/.rbenv/versions/3.3.6/lib/ruby/3.3.0/syslog/logger.rb:2: warning: /Users/[user]/.rbenv/versions/3.3.6/lib/ruby/3.3.0/arm64-darwin24/syslog.bundle was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add syslog to your Gemfile or gemspec to silence this warning.
```

#### Changes proposed in this pull request

- Add `syslog` as separate dependency in Gemfile

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
