### PR TITLE
remove huMFre_code from sample_metadata column using migration

### DIFF
--- a/db/migrate/20241211143636_add_hu_m_fre_code_to_sample_metadata.rb
+++ b/db/migrate/20241211143636_add_hu_m_fre_code_to_sample_metadata.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddHuMFreCodeToSampleMetadata < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sample_metadata, :huMFre_code, :string, limit: 16
+  end
+end

--- a/db/migrate/20250220100453_remove_column_from_sample_metadata.rb
+++ b/db/migrate/20250220100453_remove_column_from_sample_metadata.rb
@@ -1,0 +1,5 @@
+class RemoveColumnFromSampleMetadata < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :sample_metadata, :huMFre_code, :string
+  end
+end

--- a/db/migrate/20250220100453_remove_column_from_sample_metadata.rb
+++ b/db/migrate/20250220100453_remove_column_from_sample_metadata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RemoveColumnFromSampleMetadata < ActiveRecord::Migration[7.0]
   def change
     remove_column :sample_metadata, :huMFre_code, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_02_07_151422) do
+ActiveRecord::Schema[7.0].define(version: 2025_02_20_100453) do
   create_table "aliquot_indices", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|
     t.integer "aliquot_id", null: false
     t.integer "lane_id", null: false


### PR DESCRIPTION
**_Background history_**:
Initially, the column was removed using a Rails rollback, followed by manually deleting the migration file. However, after deploying the project, it became apparent that the column was not removed from the table in the production environment. Additionally, this process caused confusion regarding the release rollback procedure.

This PR addresses the issue by restoring the migration file and properly removing the column through a new migration.