### PR TITLE
Generate Supplier UAT action

### DIFF
--- a/app/uat_actions/uat_actions/generate_supplier.rb
+++ b/app/uat_actions/uat_actions/generate_supplier.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# This UAT action creates a supplier with the provided name if it does not
+# already exist. It can be used when custom suppliers are needed for testing.
+class UatActions::GenerateSupplier < UatActions
+  self.title = 'Generate supplier'
+  self.description = 'Generate a simple supplier with the provided name.'
+  self.category = :setup_and_test
+
+  # Only the supplier name is required for this UAT action.
+  form_field :supplier_name, :text_field, label: 'Supplier Name', help: 'The name of the supplier.'
+
+  # The default supplier name is used if no supplier name is provided.
+  def self.default
+    new(supplier_name: UatActions::StaticRecords.supplier.name)
+  end
+
+  # Creates the supplier and prints the supplier ID to the report.
+  # @return [Boolean] true if the UAT action was successful
+  def perform
+    supplier = create_supplier
+    print_report(supplier)
+    true
+  end
+
+  # Creates the supplier with the provided name if it does not already exist.
+  # @return [Supplier] the Supplier object
+  def create_supplier
+    Supplier.find_or_create_by!(name: supplier_name)
+  end
+
+  private
+
+  # Adds the supplier ID to the report.
+  # @param supplier [Supplier] the Supplier object
+  # @return [void]
+  def print_report(supplier)
+    report['supplier_id'] = supplier.id
+  end
+end

--- a/spec/uat_actions/generate_supplier_spec.rb
+++ b/spec/uat_actions/generate_supplier_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UatActions::GenerateSupplier do
+  context 'with valid options' do
+    let(:uat_action) { described_class.new(parameters) }
+    let(:supplier_name) { 'Test Supplier' }
+    let(:parameters) { { supplier_name: } }
+
+    describe '#perform' do
+      context 'when generating a supplier' do
+        it 'generates a supplier' do
+          expect { uat_action.perform }.to(change(Supplier, :count).by(1))
+        end
+
+        it 'creates the supplier with the correct data' do
+          uat_action.perform
+          expect(Supplier.last.name).to eq supplier_name
+        end
+      end
+
+      context 'when supplier already exists' do
+        before { create(:supplier, name: supplier_name) }
+
+        it 'does not create a new supplier' do
+          expect { uat_action.perform }.not_to(change(Supplier, :count))
+        end
+
+        it 'does not change the supplier name' do
+          uat_action.perform
+          expect(uat_action.report['supplier_id']).to eq Supplier.find_by(name: supplier_name).id
+        end
+      end
+    end
+  end
+
+  describe '#default' do
+    it 'returns a default' do
+      expect(described_class.default).to be_a described_class
+    end
+  end
+end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add Generate Supplier UAT action for creating custom supplier names in Integration Suite tests

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
