### PR TITLE
Y24-435 - Shared check release version

### DIFF
--- a/.github/workflows/check_release_version.yml
+++ b/.github/workflows/check_release_version.yml
@@ -1,0 +1,18 @@
+# Checks that the .release-version file has been updated
+name: Check release version
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      # defaults
+      - opened
+      - synchronize
+      - reopened
+      # custom
+      - ready_for_review # required for Github-created PRs
+
+jobs:
+  check-release-version:
+    uses: sanger/.github/.github/workflows/check-release-version.yml@master


### PR DESCRIPTION
#### Changes proposed in this pull request

- Removes tj-actions/changed-files due to security issues.
- Replaces check release version with reusable worfklow.

Part of: https://github.com/sanger/General-Backlog-Items/issues/464