### PR TITLE
[fix] Set all volume defaults to 13

### DIFF
--- a/app/views/workflows/_cherrypick_by_volume.html.erb
+++ b/app/views/workflows/_cherrypick_by_volume.html.erb
@@ -1,7 +1,6 @@
 <%# locals: { form:, default_volume_value: '', hide_strategy_option: false } -%>
 <%
   hide_strategy_option ||= false
-  default_volume_value ||= ''
 %>
 
 <div id='pick_by_micro_litre'>
@@ -12,7 +11,7 @@
     <%= cherrypick_strategy_radio_button :cherrypick, :strategy, :micro_litre, 'Pick by volume (µl)' %>
   <% end %>
   <%= fields_for :micro_litre do | micro_litre_fields |%>
-    <%= cherrypick_form_group_text micro_litre_fields, :volume_required, 'Volume (µl)', default_volume_value %>
+    <%= cherrypick_form_group_text micro_litre_fields, :volume_required, 'Volume (µl)', '13' %>
   <% end %>
 
 </div>

--- a/app/views/workflows/_cherrypick_strategies.html.erb
+++ b/app/views/workflows/_cherrypick_strategies.html.erb
@@ -21,7 +21,7 @@
   <div class="card" data-group='cherrypick_strategy'>
     <div class="card-body">
       <h5 class="card-title">Volume</h5>
-      <%= render partial: 'cherrypick_by_volume', locals: { form: form, default_volume_value: 65 } %>
+      <%= render partial: 'cherrypick_by_volume', locals: { form: form } %>
     </div>
   </div>
 

--- a/app/views/workflows/_fluidigm_template_batches.html.erb
+++ b/app/views/workflows/_fluidigm_template_batches.html.erb
@@ -65,7 +65,7 @@
   </div>
   <div class="col-md-6">
     <%= panel(:info,title:"Step 3: Layout wells on plates") do %>
-      <%= render partial: 'cherrypick_by_volume', locals: { form: form, hide_strategy_option: true, default_volume_value: 13 } %>
+      <%= render partial: 'cherrypick_by_volume', locals: { form: form, hide_strategy_option: true } %>
     <% end %>
   </div>
 


### PR DESCRIPTION
> Hi psd, in the recent story "User interface improvements to cherrypicking options" that was released on 17th March, the default volume for a cherrypick "pick by volume" was changed from 13ul to 65ul. Please can this be changed back to 13ul as default? Thanks EC

#### Changes proposed in this pull request

- Set default volume to 13 ul in all cases
- Remove `default_volume_value` variable

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
