### PR TITLE
Y25-179 - Bulk submission upload error messages

### DIFF
--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -33,8 +33,7 @@ class BulkSubmissionsController < ApplicationController
       render action: 'new'
     end
   rescue ActiveRecord::RecordInvalid => e
-    flash.now[:error] = 'There was a problem when building your submissions'
-    @bulk_submission.errors.add(:base, e.message)
+    flash.now[:error] = "There was a problem when building your submissions: #{e.message}"
     render action: 'new'
   end
 

--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -33,7 +33,7 @@ class BulkSubmissionsController < ApplicationController
       render action: 'new'
     end
   rescue ActiveRecord::RecordInvalid
-    flash.now[:error] = "There was a problem when building your submissions"
+    flash.now[:error] = 'There was a problem when building your submissions'
     render action: 'new'
   end
 

--- a/app/controllers/bulk_submissions_controller.rb
+++ b/app/controllers/bulk_submissions_controller.rb
@@ -32,8 +32,8 @@ class BulkSubmissionsController < ApplicationController
       flash.now[:error] = 'There was a problem with your upload'
       render action: 'new'
     end
-  rescue ActiveRecord::RecordInvalid => e
-    flash.now[:error] = "There was a problem when building your submissions: #{e.message}"
+  rescue ActiveRecord::RecordInvalid
+    flash.now[:error] = "There was a problem when building your submissions"
     render action: 'new'
   end
 

--- a/app/models/bulk_submission.rb
+++ b/app/models/bulk_submission.rb
@@ -206,6 +206,8 @@ class BulkSubmission # rubocop:todo Metrics/ClassLength
               ] = "Submission #{submission.id} built (#{submission.orders.count} orders)"
             rescue Submission::ProjectValidation::Error => e
               errors.add :spreadsheet, "There was an issue with a project: #{e.message}"
+            rescue ActiveRecord::RecordInvalid => e
+              errors.add :base, e.message
             end
           end
         end

--- a/app/views/bulk_submissions/_upload.html.erb
+++ b/app/views/bulk_submissions/_upload.html.erb
@@ -3,7 +3,7 @@
   <strong>none</strong> of them will be processed. You will get feedback about any problems.</p>
 <% end %>
 <%= semantic_form_for @bulk_submission, html: { multipart: true } do |form|  %>
-
+  <%= form.semantic_errors :base %>
   <%= form.inputs do %>
     <%= form.input :spreadsheet, as: :file, required: true %>
     <%= form.input :encoding, as: :select, collection: Encoding.list.map(&:to_s) %>

--- a/spec/models/bulk_submission_spec.rb
+++ b/spec/models/bulk_submission_spec.rb
@@ -275,6 +275,101 @@ describe BulkSubmission, with: :uploader do
     end
   end
 
+  context 'with accessioning enabled' do
+    before do
+      # Ensure accessioning check is enabled
+      configatron.disable_accession_check = false
+    end
+
+    context 'is invalid if the samples dont have accession numbers and the study requies accessioning' do
+      # Setup the conditions for accessioning validation
+      # Create a request type where accessioning is required
+      let(:request_types) { [create(:well_request_type), create(:sequencing_request_type, read_lengths: [54, 100])] }
+      # Create a study that enforces accessioning
+      let(:study) { create(:study, name: 'abc123_study', enforce_accessioning: true) }
+      let(:submission_template_hash) do
+        {
+          name: 'Illumina-A - Cherrypick for pulldown - Pulldown WGS - HiSeq Paired end sequencing',
+          submission_class_name: 'LinearSubmission',
+          product_catalogue: 'Generic',
+          superceeded_by_id: -2,
+          submission_parameters: {
+            info_differential: 5,
+            request_options: {
+              'fragment_size_required_to' => '400',
+              'fragment_size_required_from' => '100'
+            },
+            request_types: request_types.map(&:key)
+          }
+        }
+      end
+      let(:spreadsheet_filename) { '1_valid_rows.csv' }
+
+      before { SubmissionSerializer.construct!(submission_template_hash) }
+
+      it 'is not valid' do
+        expect(subject).not_to be_valid
+      end
+
+      it 'sets an error message' do
+        subject.process
+        expect(subject.errors.messages[:base][0]).to eq(
+          'Validation failed: Orders study abc123_study and all samples must have accession numbers'
+        )
+      end
+    end
+
+    context 'is valid if the samples have accession numbers and the study requies accessioning' do
+      # Setup the conditions for accessioning validation
+      # Create a request type where accessioning is required
+      let(:request_types) { [create(:well_request_type), create(:sequencing_request_type, read_lengths: [54, 100])] }
+      # Create a study that enforces accessioning
+      let(:study) { create(:study, name: 'abc123_study', enforce_accessioning: true) }
+      let(:submission_template_hash) do
+        {
+          name: 'Illumina-A - Cherrypick for pulldown - Pulldown WGS - HiSeq Paired end sequencing',
+          submission_class_name: 'LinearSubmission',
+          product_catalogue: 'Generic',
+          superceeded_by_id: -2,
+          submission_parameters: {
+            info_differential: 5,
+            request_options: {
+              'fragment_size_required_to' => '400',
+              'fragment_size_required_from' => '100'
+            },
+            request_types: request_types.map(&:key)
+          }
+        }
+      end
+      let(:spreadsheet_filename) { '1_valid_rows.csv' }
+
+      before do
+        # Add accession numbers to study and samples
+        study.study_metadata.update!(study_ebi_accession_number: 'ABC123')
+        asset_group.assets.each do |asset|
+          asset.contained_samples.each do |sample|
+            sample.sample_metadata.update!(sample_ebi_accession_number: 'ABC123')
+          end
+        end
+        SubmissionSerializer.construct!(submission_template_hash)
+      end
+
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+
+      it 'generates submissions when processed' do
+        subject.process
+        expect(number_submissions_created).to eq(1)
+      end
+
+      it 'generates submissions with one order' do
+        subject.process
+        expect(generated_submission.orders.count).to eq(1)
+      end
+    end
+  end
+
   context 'a submission with additional template name validations' do
     context 'when valid for scRNA template' do
       let(:submission_template_hash) do


### PR DESCRIPTION
Closes #4717 

#### Changes proposed in this pull request

- Changes location for new bulk submission RecordInvalid error handling.
- Restores `form.semantic_errors` which was removed from here: https://github.com/sanger/sequencescape/pull/4660
  - This is required for errors on base (bulk submission) to appear on the form.
  - This was originally removed to fix a duplicate error message bug: https://github.com/sanger/sequencescape/issues/4579. I have confirmed this change does not break this behaviour and users only see 1 set of error messages.
- Adds test to bulk_submission model spec for accessioning checks.

#### Additional notes
- There are no test cases for bulk submission controller tests but I have added one to the model that covers the logic change.
- To test this locally you need to set `configatron.disable_accession_check = false`

