### PR TITLE
[dev] Install any missing packages at container initialisation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,12 @@ set -o nounset
 
 TIMEOUT=120
 
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /code/tmp/pids/server.pid
+
+# Install any missing packages - very useful for development without rebuilding the image
+bundle install
+
 ./wait_for_connection.sh "${DBHOST}" "${DBPORT}" "${TIMEOUT}"
 
 if [ "${RESET_DATABASE:-}" = "true" ]; then


### PR DESCRIPTION
Alternative to #4651

#### Changes proposed in this pull request

- Install any missing packages at container initialisation
  - Should help prevent containers from falling over at start-up after merging in from develop
- Remove server pid lock if it exists (like in Limber)

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
