### PR TITLE
loading action descriptors for Element Aviti pipeline

### DIFF
--- a/app/views/workflows/_descriptor.html.erb
+++ b/app/views/workflows/_descriptor.html.erb
@@ -9,6 +9,8 @@
   <div class="field">
     <% if descriptor.kind == 'Selection' %>
       <%= select_tag "#{base_field_name}[#{descriptor.name}]", options_for_select(descriptor.selection.values, descriptor.value), id: field_id %>
+    <% elsif descriptor.kind == 'Date' %>
+      <%= date_field "#{base_field_name}", descriptor.name, value: descriptor.value, id: field_id %>
     <% else %>
       <%= text_field "#{base_field_name}", descriptor.name, value: descriptor.value, id: field_id %>
     <% end %>

--- a/config/default_records/descriptors/002_element_aviti_descriptors.wip.yml
+++ b/config/default_records/descriptors/002_element_aviti_descriptors.wip.yml
@@ -1,0 +1,84 @@
+Pipette Carousel:
+  name: Pipette Carousel
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 0
+200mM Tris PH7 lot#:
+  name: 200mM Tris PH7 lot#
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 1
+200 mM Tris Expiry:
+  name: 200 mM Tris Expiry
+  task: Loading
+  workflow: Element Aviti
+  kind: Date
+  required: false
+  sorter: 2
+PhiX lot_#:
+  name: "PhiX lot #"
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 3
+PhiX Expiry:
+  name: PhiX Expiry
+  task: Loading
+  workflow: Element Aviti
+  kind: Date
+  required: false
+  sorter: 4
+PhiX %:
+  name: PhiX %
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 5
+Library loading buffer lot#:
+  name: Library loading buffer lot#
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 6
+Library loading buffer expiry:
+  name: Library loading buffer expiry
+  task: Loading
+  workflow: Element Aviti
+  kind: Date
+  required: false
+  sorter: 7
+0.2N lot#:
+  name: 0.2N lot#
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 8
+0.2N lot expiry:
+  name: 0.2N lot expiry
+  task: Loading
+  workflow: Element Aviti
+  kind: Date
+  required: false
+  sorter: 9
+iPCR batch#:
+  name: iPCR batch#
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 10
+Comment:
+  name: Comment
+  task: Loading
+  workflow: Element Aviti
+  kind: Text
+  required: false
+  sorter: 11

--- a/lib/record_loader/descriptor_loader.rb
+++ b/lib/record_loader/descriptor_loader.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# This file was automatically generated via `rails g record_loader`
+
+# RecordLoader handles automatic population and updating of database records
+# across different environments
+# @see https://rubydoc.info/github/sanger/record_loader/
+module RecordLoader
+  # Creates the specified Descriptor if they are not present
+  class DescriptorLoader < ApplicationRecordLoader
+    config_folder 'descriptors'
+
+    def create_or_update!(name, options)
+      workflow_name = options.delete('workflow')
+      workflow = find_workflow!(workflow_name, name)
+      return nil if workflow.nil?
+      task_name = options.delete('task')
+      task = find_task!(task_name, workflow.id, name)
+      return nil if task.nil?
+      options[:task_id] = task.id
+      Descriptor.find_or_initialize_by(name: options['name'], task_id: task.id).tap { |desc| desc.update!(options) }
+    end
+
+    private
+
+    def find_workflow!(workflow_name, descriptor_name)
+      return unless workflow_name
+      Workflow.find_by!(name: workflow_name)
+    rescue ActiveRecord::RecordNotFound
+      message =
+        "Descriptor '#{descriptor_name}' creation or update failed " \
+          "because there was no workflow named '#{workflow_name}'"
+
+      handle_missing_reference(message)
+    end
+
+    def find_task!(task_name, workflow_id, descriptor_name)
+      Task.find_by!(name: task_name, pipeline_workflow_id: workflow_id)
+    rescue ActiveRecord::RecordNotFound
+      message =
+        "Descriptor '#{descriptor_name}' creation or update failed " \
+          "because there was no task with name '#{task_name}' " \
+          "associated with the workflow id '#{workflow_id}'"
+
+      handle_missing_reference(message)
+    end
+
+    def handle_missing_reference(message)
+      unless Rails.env.development? || Rails.env.staging? || Rails.env.cucumber?
+        raise ActiveRecord::RecordNotFound, message
+      end
+      Rails.logger.warn(message)
+      nil
+    end
+  end
+end

--- a/lib/tasks/record_loader/descriptor.rake
+++ b/lib/tasks/record_loader/descriptor.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This file was automatically generated via `rails g record_loader`
+namespace :record_loader do
+  desc 'Automatically generate Descriptor through DescriptorLoader'
+  task descriptor: :environment do
+    RecordLoader::DescriptorLoader.new.create!
+  end
+end
+
+# Automatically run this record loader as part of record_loader:all
+# Remove this line if the task should only run when invoked explicitly
+task 'record_loader:all' => 'record_loader:descriptor'

--- a/spec/data/record_loader/descriptors/descriptors_basic.yml
+++ b/spec/data/record_loader/descriptors/descriptors_basic.yml
@@ -1,0 +1,23 @@
+# This file was automatically generated via `rails g record_loader`
+# You should modify it to match your particular model.
+---
+name 1:
+  name: name 1
+  task: task 1
+  workflow: workflow 1
+  value: value 1
+  selection: selection 1
+  kind: kind 1
+  required: false
+  sorter: 1
+  key: key 1
+name 2:
+  name: name 2
+  task: task 1
+  workflow: workflow 1
+  value: value 2
+  selection: selection 2
+  kind: kind 2
+  required: false
+  sorter: 2
+  key: key 2

--- a/spec/lib/record_loader/descriptor_loader_spec.rb
+++ b/spec/lib/record_loader/descriptor_loader_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'record_loader/descriptor_loader'
+
+# This file was initially generated via `rails g record_loader`
+RSpec.describe RecordLoader::DescriptorLoader, :loader, type: :model do
+  def a_new_record_loader
+    described_class.new(directory: test_directory, files: selected_files)
+  end
+
+  subject(:record_loader) { a_new_record_loader }
+
+  # Tests use a separate directory to avoid coupling your specs to the data
+  let(:test_directory) { Rails.root.join('spec/data/record_loader/descriptors') }
+
+  context 'with descriptors_basic selected' do
+    let(:selected_files) { 'descriptors_basic' }
+    let!(:workflow) { create(:workflow, name: 'workflow 1') }
+    let!(:task) { create(:task, name: 'task 1', pipeline_workflow_id: workflow.id) }
+
+    it 'creates two records' do
+      expect { record_loader.create! }.to change(Descriptor, :count).by(2)
+    end
+
+    # It is important that multiple runs of a RecordLoader do not create additional
+    # copies of existing records.
+    it 'is idempotent' do
+      record_loader.create!
+      expect { a_new_record_loader }.not_to change(Descriptor, :count)
+    end
+
+    it 'sets attributes on the created records' do
+      record_loader.create!
+      expect(Descriptor.all).to include(
+        have_attributes(
+          name: 'name 1',
+          value: 'value 1',
+          selection: 'selection 1',
+          kind: 'kind 1',
+          required: false,
+          sorter: 1,
+          key: 'key 1',
+          task_id: task.id
+        ),
+        have_attributes(
+          name: 'name 2',
+          value: 'value 2',
+          selection: 'selection 2',
+          kind: 'kind 2',
+          required: false,
+          sorter: 2,
+          key: 'key 2',
+          task_id: task.id
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
**Dev testing notes:**
This is should be deployed after [Y25-037](https://github.com/sanger/sequencescape/issues/4630)
1. Run `bundle exec rake application:post_deploy` to create the descriptors 
2. Create an element aviti batch
3. On the batch view page, actions section, click on Loading
4. The loading descriptors should be displayed successfully, as below:
<img width="1250" alt="Screenshot 2025-04-25 at 15 32 58" src="https://github.com/user-attachments/assets/1f131805-f8e9-4f94-b74e-dec6794a064a" />
5. User should be able to save and edit the task details values (Saving is performed by clicking on "Next Step" button) 