### PR TITLE
Y25-174: add retention_instruction as a readable attribute for labware

### DIFF
--- a/app/resources/api/v2/shared_behaviour/labware.rb
+++ b/app/resources/api/v2/shared_behaviour/labware.rb
@@ -44,6 +44,8 @@ module Api
           attribute :state, readonly: true
           attribute :created_at, readonly: true
           attribute :updated_at, readonly: true
+          # Add retention_instruction as a readable attribute
+          attribute :retention_instruction, delegate: :retention_instructions, readonly: true
 
           # Scopes
           filter :barcode, apply: ->(records, value, _options) { records.with_barcode(value) }

--- a/spec/resources/api/v2/shared_examples/labware.rb
+++ b/spec/resources/api/v2/shared_examples/labware.rb
@@ -8,6 +8,7 @@ shared_examples 'a labware resource' do
   it { is_expected.to have_readonly_attribute :state }
   it { is_expected.to have_readonly_attribute :created_at }
   it { is_expected.to have_readonly_attribute :updated_at }
+  it { is_expected.to have_readonly_attribute :retention_instruction }
 
   # Relationships
   it { is_expected.to have_a_write_once_has_one(:purpose).with_class_name('Purpose') }


### PR DESCRIPTION
Closes https://github.com/sanger/traction-ui/issues/2233

#### Changes proposed in this pull request

This pull request introduces a new readable attribute, `retention_instruction`, to the `Labware` module and updates the associated tests to ensure its behavior is validated.

### Changes to `Labware` module:

* Added `retention_instruction` as a readable attribute in the `Labware` module, delegating its value to `retention_instructions`. This attribute is marked as readonly. 
* Added a test to verify that `retention_instruction` is a readonly attribute in the `Labware` module. 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
