### PR TITLE
[dev] Revert to previous cache classes setting and remove rescues

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = ENV.fetch('CACHE_CLASSES', 'false') == 'true'
+  config.cache_classes = ENV.fetch('CACHE_CLASSES', 'true') == 'true'
 
   # Do not eager load code on boot.
   config.eager_load = true

--- a/config/initializers/bulk_submission_excel.rb
+++ b/config/initializers/bulk_submission_excel.rb
@@ -5,10 +5,6 @@ Rails.application.config.to_prepare do
     BulkSubmissionExcel.configure do |config|
       config.folder = File.join('config', 'bulk_submission_excel')
       config.load!
-    rescue StandardError => e
-      # catch undefined local variable or method `list_model' for an instance of
-      # SequencescapeExcel::ConditionalFormattingDefaultList
-      Rails.logger.warn("Error loading bulk submission excel configuration: #{e.message}")
     end
   end
 end

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -12,11 +12,7 @@ Rails.application.config.to_prepare do
     config.route_format = :underscored_route
   end
 
-  begin
-    # Monkey patch the ApiKeyAuthenticatable concern into all JSONAPI::ResourceControllers
-    JSONAPI::ResourceController.include(Api::V2::Concerns::ApiKeyAuthenticatable)
-    JSONAPI::ResourceController.include(Api::V2::Concerns::DisableCsrfTokenAuthentication)
-  rescue StandardError => e
-    Rails.logger.error("Error patching ApiKeyAuthenticatable in JSONAPI::ResourceController: #{e.message}")
-  end
+  # Monkey patch the ApiKeyAuthenticatable concern into all JSONAPI::ResourceControllers
+  JSONAPI::ResourceController.include(Api::V2::Concerns::ApiKeyAuthenticatable)
+  JSONAPI::ResourceController.include(Api::V2::Concerns::DisableCsrfTokenAuthentication)
 end


### PR DESCRIPTION
While testing picked up and corrected failures in the server process, the worker process still raised errors, even with the rescues.

This will require more time to solve completely, so in the meantime, let's revert the changes.

Set the environment variable to enable this on a temporary basis.

```sh
export export CACHE_CLASSES=false
```

See #4924, #4509 and #4528 for more adventures.

#### Changes proposed in this pull request

- Set cache classes default to True
- Remove rescues

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
