### PR TITLE
[bug] Limit widths of role select fields

### DIFF
--- a/app/frontend/stylesheets/all/sequencescape.scss
+++ b/app/frontend/stylesheets/all/sequencescape.scss
@@ -491,6 +491,12 @@ table.sample_list td:first-child {
 .loading {
   text-align: center;
 }
+.mw-12em {
+  max-width: 12em;
+}
+.mw-15em {
+  max-width: 15em;
+}
 .notice {
   border: 1px solid #f66;
   padding: 5px;

--- a/app/views/admin/users/_add_role.html.erb
+++ b/app/views/admin/users/_add_role.html.erb
@@ -3,11 +3,11 @@
 <h3><%= role_class_name %></h3>
 <div class='text-center'>
   <%= form_tag [:grant_user_role_admin,@user], remote: true, data: {success: "#role_list"}, class: 'form-inline remote-form' do -%>
-  <label for="role_authorizable_name"><%= role_class_name %> role</label>
-    <%= select "role", "authorizable_name", @all_roles, { prompt: true }, {class: 'form-control-sm mx-2'} %>
+    <label for="role_authorizable_name"><%= role_class_name %> role</label>
+    <%= select "role", "authorizable_name", @all_roles, { prompt: true }, {class: 'form-control-sm mx-2 mw-12em'} %>
 
     <label for="role_authorizable_id">for <%= role_class_name %></label>
-    <%= select "role", "authorizable_id", authorizable_type.pluck(:name,:id).sort, { prompt: true }, {class: 'form-control-sm mx-2'} %>
+    <%= select "role", "authorizable_id", authorizable_type.pluck(:name,:id).sort, { prompt: true }, {class: 'form-control-sm mx-2 mw-15em'} %>
 
     <div class="flex-grow-1"></div>
 


### PR DESCRIPTION
Closes #4921 

#### Changes proposed in this pull request

- Limits the widths of Study and Project dropdowns to account for long field names.

Before:
<img width="683" alt="Screenshot 2025-05-22 at 14 35 10" src="https://github.com/user-attachments/assets/374ea34c-f440-4a9b-8fcd-6a5e23cbcd42" />


After:
<img width="1471" alt="Screenshot 2025-05-22 at 15 33 44" src="https://github.com/user-attachments/assets/9da5fdc2-b177-455c-818d-6c2be81e52aa" />



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
