### PR TITLE
[dev] Revert raise_on_missing_callback_actions to pre Rails 7.1

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   # Raise error when a before_action's only/except options reference missing actions
-  config.action_controller.raise_on_missing_callback_actions = true
+  config.action_controller.raise_on_missing_callback_actions = false
 end
 
 Rack::MiniProfiler.config.position = 'right'


### PR DESCRIPTION
Closes https://psd-team.slack.com/archives/C01J32MB747/p1748609978891769

#### Changes proposed in this pull request

- Revert `raise_on_missing_callback_actions` to pre Rails 7.1

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
