### PR TITLE
add search by project cost code

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'aasm'
 
+# rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
   # It has to be here, as there are has_many through: :orders associations in modules
   has_many :orders
@@ -57,7 +58,15 @@ class Project < ApplicationRecord
   validates :name, :state, presence: true
   validates :name, uniqueness: { on: :create, message: "already in use (#{name})", case_sensitive: false }
 
-  scope :for_search_query, ->(query) { where(['name LIKE ? OR id=?', "%#{query}%", query]) }
+  scope :for_search_query,
+        ->(query) do
+          joins(project_metadata: :project).where(
+            'projects.name LIKE ? OR projects.id = ? OR project_cost_code LIKE ?',
+            "%#{query}%",
+            query,
+            "%#{query}%"
+          )
+        end
 
   # Allow us to pass in nil or '' if we don't want to filter state.
   # State is required so we don't need to look up an actual null state
@@ -147,3 +156,4 @@ class Project < ApplicationRecord
           )
         end
 end
+# rubocop:enable Metrics/ClassLength

--- a/features/3550676_search_functionality.feature
+++ b/features/3550676_search_functionality.feature
@@ -5,6 +5,7 @@ Feature: Searching sequencescape
     And I am on the search page
 
     Given a project named "This Rabbit" exists
+    And a project named "Project 2" with project cost code "This Cost Code"
     And a study named "This Hedgehog" exists
     And a sample named "SampleForThis" exists
     And sample "SampleForThis" is in a sample tube named "This Asset"
@@ -17,11 +18,12 @@ Feature: Searching sequencescape
     And I should see "<result>"
 
     Examples:
-      |  search   |   type  |   result       |
-      | Rabbit    | project | This Rabbit    |
-      | Hedgehog  | study   | This Hedgehog  |
-      | Sample    | sample  | SampleForThis  |
-      | Asset     | labware | This Asset     |
+      | search          | type    | result         |
+      | Rabbit          | project | This Rabbit    |
+      | Hedgehog        | study   | This Hedgehog  |
+      | Sample          | sample  | SampleForThis  |
+      | Asset           | labware | This Asset     |
+      | This Cost Code  | project | This Cost Code |
 
   Scenario: No matching results
     When I fill in "Search for" with "No way this will ever match anything!"
@@ -34,8 +36,9 @@ Feature: Searching sequencescape
     And I press "Go"
     Then I should be on the search page
     And the search results I should see are:
-      | section |   result      |
-      | project | This Rabbit   |
-      | study   | This Hedgehog |
-      | sample  | SampleForThis |
-      | labware | This Asset    |
+      | section | section count |result       |
+      | project | 2             |This Rabbit  |
+      | study   | 1             |This Hedgehog|
+      | sample  | 1             |SampleForThis|
+      | labware | 1             |This Asset   |
+      | project | 2             |Project 2    |

--- a/features/support/step_definitions/3550676_search_functionality_steps.rb
+++ b/features/support/step_definitions/3550676_search_functionality_steps.rb
@@ -9,7 +9,7 @@ end
 
 Then /^the search results I should see are:$/ do |table|
   table.hashes.each do |row|
-    step "I should see \"1 #{row['section']}\""
+    step "I should see \"#{row['section count']} #{row['section']}\""
     step "I should see \"#{row['result']}\""
   end
 end

--- a/features/support/step_definitions/project_steps.rb
+++ b/features/support/step_definitions/project_steps.rb
@@ -6,8 +6,8 @@ Given /^I have a project called "([^"]*)"$/ do |project|
 end
 
 Given /^a project named "([^"]*)" with project cost code "([^"]*)"$/ do |project_name, cost_code|
-  project =  FactoryBot.create(:project, name: project_name)
-  project.project_metadata.update!(project_cost_code: cost_code )
+  project = FactoryBot.create(:project, name: project_name)
+  project.project_metadata.update!(project_cost_code: cost_code)
 end
 
 Given /^project "([^"]*)" approval is "([^"]*)"$/ do |project, approval|

--- a/features/support/step_definitions/project_steps.rb
+++ b/features/support/step_definitions/project_steps.rb
@@ -5,6 +5,11 @@ Given /^I have a project called "([^"]*)"$/ do |project|
   FactoryBot.create(:project, name: project)
 end
 
+Given /^a project named "([^"]*)" with project cost code "([^"]*)"$/ do |project_name, cost_code|
+  project =  FactoryBot.create(:project, name: project_name)
+  project.project_metadata.update!(project_cost_code: cost_code )
+end
+
 Given /^project "([^"]*)" approval is "([^"]*)"$/ do |project, approval|
   proj = Project.find_by(name: project)
   proj.approved = (approval == 'approved')

--- a/lib/informatics/lib/informatics/globals.rb
+++ b/lib/informatics/lib/informatics/globals.rb
@@ -25,7 +25,7 @@ module Informatics
     end
 
     def search_options
-      global_searchable_classes.map { |klass| [klass.name] * 2 } << ['All', nil]
+      global_searchable_classes.map { |klass| [klass.name, klass.name] } + [['Cost Code', 'Project'], ['All', nil]]
     end
   end
 end


### PR DESCRIPTION
For more visibility, I am copy pasting @KatyTaylor's comment here:

`Discussed with Liz whether they'd select a value from the dropdown in top right or leave it saying 'All' - she's happy to do either as long as they've got a way to search, but I think the ideal solution was thought to be that the cost code search should work on 'All', and also to have a new option 'Cost code' in the list, which would make it very clear you could use that to search. We could also enhance the 'Project' drop down to allow searching by Cost code.`

=> The code change adds a 'cost code' option to the search box, the cost code search works on 'All' too.