### PR TITLE
[dev] Post merge linting

### DIFF
--- a/spec/controllers/npg_actions/assets_controller_spec.rb
+++ b/spec/controllers/npg_actions/assets_controller_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe NpgActions::AssetsController, type: :request do
         regexp =
           Regexp.new(
             "<error><message>The request on this lane has already been completed with qc state: 'pass'. " \
-              "Unable to set it to new qc state: 'fail'.</message></error>",
+            "Unable to set it to new qc state: 'fail'.</message></error>",
             Regexp::MULTILINE
           )
         expect(response).to have_http_status(:bad_request)


### PR DESCRIPTION
It seems like there was a linting failure post-merge of #4993 - strange...

Ah it makes sense now: there was a race condition between the last commits of the prettier/rubocop PR and #4987. The `pull_request` event only triggers on commit pushes rather than reading the mind of the developer immediately prior to merge - seem reasonable I guess...

#### Changes proposed in this pull request

- Lint rubocop to fix

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
