### PR TITLE
Y25-151 - Added new FluidX plate type (0.5ml)

### DIFF
--- a/config/default_records/plate_types/plate_types.yml
+++ b/config/default_records/plate_types/plate_types.yml
@@ -6,7 +6,7 @@ ABgene_0800:
 FluidX075:
   maximum_volume: 500
 FluidX05:
-  maximum_volume: 350
+  maximum_volume: 520
 FluidX03:
   maximum_volume: 280
 KingFisher 96 2ml:

--- a/config/default_records/plate_types/plate_types.yml
+++ b/config/default_records/plate_types/plate_types.yml
@@ -5,7 +5,7 @@ ABgene_0800:
   maximum_volume: 180
 FluidX075:
   maximum_volume: 500
-FluidX05:
+FluidX 0.5µl:
   maximum_volume: 520
 FluidX03:
   maximum_volume: 280

--- a/config/default_records/plate_types/plate_types.yml
+++ b/config/default_records/plate_types/plate_types.yml
@@ -5,6 +5,8 @@ ABgene_0800:
   maximum_volume: 180
 FluidX075:
   maximum_volume: 500
+FluidX05:
+  maximum_volume: 350
 FluidX03:
   maximum_volume: 280
 KingFisher 96 2ml:

--- a/spec/models/plate_type_spec.rb
+++ b/spec/models/plate_type_spec.rb
@@ -10,7 +10,7 @@ describe PlateType do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
-    create(:plate_type, name: 'FluidX05', maximum_volume: 520)
+    create(:plate_type, name: 'FluidX 0.5µl', maximum_volume: 520)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
   end
 
@@ -27,6 +27,6 @@ describe PlateType do
   it 'knows plate types names and maximum volumes' do
     expect(
       described_class.names_and_maximum_volumes
-    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX05: 520, FluidX03: 280'
+    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX 0.5µl: 520, FluidX03: 280'
   end
 end

--- a/spec/models/plate_type_spec.rb
+++ b/spec/models/plate_type_spec.rb
@@ -10,6 +10,7 @@ describe PlateType do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
+    create(:plate_type, name: 'FluidX05', maximum_volume: 350)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
   end
 
@@ -26,6 +27,6 @@ describe PlateType do
   it 'knows plate types names and maximum volumes' do
     expect(
       described_class.names_and_maximum_volumes
-    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX03: 280'
+    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX05: 350, FluidX03: 280'
   end
 end

--- a/spec/models/plate_type_spec.rb
+++ b/spec/models/plate_type_spec.rb
@@ -27,6 +27,6 @@ describe PlateType do
   it 'knows plate types names and maximum volumes' do
     expect(
       described_class.names_and_maximum_volumes
-    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX05: 350, FluidX03: 280'
+    ).to eq 'ABgene_0765: 800, ABgene_0800: 180, FluidX075: 500, FluidX05: 520, FluidX03: 280'
   end
 end

--- a/spec/models/plate_type_spec.rb
+++ b/spec/models/plate_type_spec.rb
@@ -10,7 +10,7 @@ describe PlateType do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
-    create(:plate_type, name: 'FluidX05', maximum_volume: 350)
+    create(:plate_type, name: 'FluidX05', maximum_volume: 520)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
   end
 

--- a/spec/models/stock_stamper_spec.rb
+++ b/spec/models/stock_stamper_spec.rb
@@ -14,6 +14,7 @@ describe StockStamper do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
+    create(:plate_type, name: 'FluidX05', maximum_volume: 350)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
 
     @attributes = {

--- a/spec/models/stock_stamper_spec.rb
+++ b/spec/models/stock_stamper_spec.rb
@@ -14,7 +14,7 @@ describe StockStamper do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
-    create(:plate_type, name: 'FluidX05', maximum_volume: 350)
+    create(:plate_type, name: 'FluidX05', maximum_volume: 520)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
 
     @attributes = {

--- a/spec/models/stock_stamper_spec.rb
+++ b/spec/models/stock_stamper_spec.rb
@@ -14,7 +14,7 @@ describe StockStamper do
     create(:plate_type, name: 'ABgene_0765', maximum_volume: 800)
     create(:plate_type, name: 'ABgene_0800', maximum_volume: 180)
     create(:plate_type, name: 'FluidX075', maximum_volume: 500)
-    create(:plate_type, name: 'FluidX05', maximum_volume: 520)
+    create(:plate_type, name: 'FluidX 0.5µl', maximum_volume: 520)
     create(:plate_type, name: 'FluidX03', maximum_volume: 280)
 
     @attributes = {


### PR DESCRIPTION
Closes #4702 

#### Changes proposed in this pull request

- Added a new FluidX plate type called "FluidX05" in the codebase
- It can be selected when creating a cherrypicking request, in the robot bed verification page, and in the final downloadable Tecan file.
- Added new plate type to the tests

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
