### PR TITLE
[ux] Set training navbar colour to match re-worked logo

### DIFF
--- a/app/frontend/stylesheets/all/colours.scss
+++ b/app/frontend/stylesheets/all/colours.scss
@@ -1,6 +1,6 @@
 /* Colours defined per environment */
 $production: $primary;
-$training: #1b5e20; // Sanger dark green to match logo
+$training: #217227; // a brightened Sanger dark green to better match production lightness
 $staging: $red;
 $development: $gray-600;
 


### PR DESCRIPTION
#5061 introduced a colour clash - this PR saves the eyes...

#### Changes proposed in this pull request

- Tone down th nav-bar green to match the logo
- Remove the `!default` css qualifiers that aren't neccesary since these values won't be overridden.

Before:
<img width="1023" height="142" alt="Screenshot 2025-07-21 at 11 48 48" src="https://github.com/user-attachments/assets/dbee5e59-0637-4b76-92b2-b480454d8222" />

After:
<img width="1049" height="139" alt="Screenshot 2025-07-21 at 11 53 33" src="https://github.com/user-attachments/assets/a35f2de7-97e6-4253-b84b-3fc385155b37" />


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
