### PR TITLE
Y25-450 - API Allow list parameter

### DIFF
--- a/app/controllers/api/v2/concerns/api_key_authenticatable.rb
+++ b/app/controllers/api/v2/concerns/api_key_authenticatable.rb
@@ -74,7 +74,8 @@ module Api
         #
         # A route is considered permissive if the 'permissive' path parameter is present in the request
         # and the HTTP request method is 'GET'.
-        # Path parameters are defined next to the route in routes.rb e.g. jsonapi_resources :samples, permissive: true
+        # Path parameters can be defined via defaults next to the route in routes.rb
+        # e.g. jsonapi_resources :samples, defaults: { permissive: true }
         #
         # @return [Boolean] true if the route is permissive, false otherwise.
         def permissive_route

--- a/app/controllers/api/v2/concerns/api_key_authenticatable.rb
+++ b/app/controllers/api/v2/concerns/api_key_authenticatable.rb
@@ -74,11 +74,11 @@ module Api
         #
         # A route is considered permissive if the 'permissive' path parameter is present in the request
         # and the HTTP request method is 'GET'.
-        # Path paramters are defined next to the route in routes.rb e.g. jsonapi_resources :samples, permissive: true
+        # Path parameters are defined next to the route in routes.rb e.g. jsonapi_resources :samples, permissive: true
         #
         # @return [Boolean] true if the route is permissive, false otherwise.
         def permissive_route
-          # Use path_parameters as standard parameters are overridable by requestors
+          # Use path_parameters as standard parameters are overridable by requesters
           request.path_parameters.fetch(:permissive, false) && request.get?
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,9 +31,9 @@ Rails.application.routes.draw do
 
       jsonapi_resources :barcode_printers
       jsonapi_resources :bulk_transfers, except: %i[update]
-      jsonapi_resources :comments
+      jsonapi_resources :comments, permissive: true
       jsonapi_resources :custom_metadatum_collections
-      jsonapi_resources :labware
+      jsonapi_resources :labware, permissive: true
       jsonapi_resources :lanes
       jsonapi_resources :lot_types
       jsonapi_resources :lots
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
       jsonapi_resources :primer_panels
       jsonapi_resources :projects
       jsonapi_resources :purposes
-      jsonapi_resources :qc_assays
+      jsonapi_resources :qc_assays, permissive: true
       jsonapi_resources :qc_files, except: %i[update]
       jsonapi_resources :qc_results
       jsonapi_resources :qcables
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       jsonapi_resources :submission_templates
       jsonapi_resources :submissions, except: %i[update]
       jsonapi_resources :tag_group_adapter_types
-      jsonapi_resources :tag_groups
+      jsonapi_resources :tag_groups, permissive: true
       jsonapi_resources :tag_sets, only: %i[index show]
       jsonapi_resources :tag_layout_templates
       jsonapi_resources :tag_layouts, except: %i[update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,9 +31,9 @@ Rails.application.routes.draw do
 
       jsonapi_resources :barcode_printers
       jsonapi_resources :bulk_transfers, except: %i[update]
-      jsonapi_resources :comments, permissive: true
+      jsonapi_resources :comments, defaults: { permissive: true }
       jsonapi_resources :custom_metadatum_collections
-      jsonapi_resources :labware, permissive: true
+      jsonapi_resources :labware, defaults: { permissive: true }
       jsonapi_resources :lanes
       jsonapi_resources :lot_types
       jsonapi_resources :lots
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
       jsonapi_resources :primer_panels
       jsonapi_resources :projects
       jsonapi_resources :purposes
-      jsonapi_resources :qc_assays, permissive: true
+      jsonapi_resources :qc_assays, defaults: { permissive: true }
       jsonapi_resources :qc_files, except: %i[update]
       jsonapi_resources :qc_results
       jsonapi_resources :qcables
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
       jsonapi_resources :submission_templates
       jsonapi_resources :submissions, except: %i[update]
       jsonapi_resources :tag_group_adapter_types
-      jsonapi_resources :tag_groups, permissive: true
+      jsonapi_resources :tag_groups, defaults: { permissive: true }
       jsonapi_resources :tag_sets, only: %i[index show]
       jsonapi_resources :tag_layout_templates
       jsonapi_resources :tag_layouts, except: %i[update]

--- a/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
+++ b/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
@@ -8,22 +8,31 @@ RSpec.describe Api::V2::Concerns::ApiKeyAuthenticatable do
 
   describe '#permissive_route' do
     context 'when permissive param is present and request is GET' do
-      it 'returns true' do
+      before do
         allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: true)
+      end
+
+      it 'returns true' do
         expect(controller.send(:permissive_route)).to be true
       end
     end
 
     context 'when permissive param is present but request is not GET' do
-      it 'returns false' do
+      before do
         allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: false)
+      end
+
+      it 'returns false' do
         expect(controller.send(:permissive_route)).to be false
       end
     end
 
     context 'when permissive param is not present' do
-      it 'returns false' do
+      before do
         allow(controller.request).to receive_messages(path_parameters: {}, get?: true)
+      end
+
+      it 'returns false' do
         expect(controller.send(:permissive_route)).to be false
       end
     end

--- a/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
+++ b/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Api::V2::Concerns::ApiKeyAuthenticatable do
+  # Dummy controller to include the concern for testing
+  controller(ApplicationController) do
+    include Api::V2::Concerns::ApiKeyAuthenticatable # rubocop:disable RSpec/DescribedClass
+  end
+
+  describe '#permissive_route' do
+    context 'when permissive param is present and request is GET' do
+      it 'returns true' do
+        allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: true)
+        expect(controller.send(:permissive_route)).to be true
+      end
+    end
+
+    context 'when permissive param is present but request is not GET' do
+      it 'returns false' do
+        allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: false)
+        expect(controller.send(:permissive_route)).to be false
+      end
+    end
+
+    context 'when permissive param is not present' do
+      it 'returns false' do
+        allow(controller.request).to receive_messages(path_parameters: {}, get?: true)
+        expect(controller.send(:permissive_route)).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/shared_examples/api_key_authenticatable.rb
+++ b/spec/requests/api/v2/shared_examples/api_key_authenticatable.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 shared_examples_for 'ApiKeyAuthenticatable' do
   let(:client_headers) { { 'User-Agent' => 'Test Agent', 'Origin' => 'Test Origin' } }.freeze
+  let(:permissive_route) do
+    Rails.application.routes.recognize_path(base_endpoint, method: :get).fetch(:permissive, false)
+  end
 
   context 'without an API key' do
     it 'gets a success response' do
@@ -17,12 +20,15 @@ shared_examples_for 'ApiKeyAuthenticatable' do
 
       api_get base_endpoint, headers: client_headers
 
-      expect(Rails.logger).to have_received(:info).with(/Request made without an API key/)
-      expect(Rails.logger).to have_received(:info).with(/remote_ip: "127.0.0.1"/)
-      expect(Rails.logger).to have_received(:info).with(/user_agent: "Test Agent"/)
-      expect(Rails.logger).to have_received(:info).with(/origin: "Test Origin"/)
-      expect(Rails.logger).to have_received(:info).with(%r{original_url: "http://www.example.com#{base_endpoint}"})
-      expect(Rails.logger).to have_received(:info).with(/request_method: "GET"/)
+      # Permissive routes don't log details
+      unless permissive_route
+        expect(Rails.logger).to have_received(:info).with(/Request made without an API key/)
+        expect(Rails.logger).to have_received(:info).with(/remote_ip: "127.0.0.1"/)
+        expect(Rails.logger).to have_received(:info).with(/user_agent: "Test Agent"/)
+        expect(Rails.logger).to have_received(:info).with(/origin: "Test Origin"/)
+        expect(Rails.logger).to have_received(:info).with(%r{original_url: "http://www.example.com#{base_endpoint}"})
+        expect(Rails.logger).to have_received(:info).with(/request_method: "GET"/)
+      end
     end
   end
 
@@ -32,7 +38,12 @@ shared_examples_for 'ApiKeyAuthenticatable' do
     it 'gets an unauthorized response' do
       api_get(base_endpoint, headers:)
 
-      expect(response).to have_http_status(:unauthorized)
+      # Permissive routes are successful with invalid API keys
+      if permissive_route
+        expect(response).to have_http_status(:success)
+      else
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
     it 'logs the request with client details' do
@@ -40,13 +51,16 @@ shared_examples_for 'ApiKeyAuthenticatable' do
 
       api_get(base_endpoint, headers:)
 
-      expect(Rails.logger).to have_received(:info).with(/Request made with invalid API key/)
-      expect(Rails.logger).to have_received(:info).with(/remote_ip: "127.0.0.1"/)
-      expect(Rails.logger).to have_received(:info).with(/user_agent: "Test Agent"/)
-      expect(Rails.logger).to have_received(:info).with(/origin: "Test Origin"/)
-      expect(Rails.logger).to have_received(:info).with(%r{original_url: "http://www.example.com#{base_endpoint}"})
-      expect(Rails.logger).to have_received(:info).with(/request_method: "GET"/)
-      expect(Rails.logger).to have_received(:info).with(/api_key: "invalid-key"/)
+      # Permissive routes don't log details
+      unless permissive_route
+        expect(Rails.logger).to have_received(:info).with(/Request made with invalid API key/)
+        expect(Rails.logger).to have_received(:info).with(/remote_ip: "127.0.0.1"/)
+        expect(Rails.logger).to have_received(:info).with(/user_agent: "Test Agent"/)
+        expect(Rails.logger).to have_received(:info).with(/origin: "Test Origin"/)
+        expect(Rails.logger).to have_received(:info).with(%r{original_url: "http://www.example.com#{base_endpoint}"})
+        expect(Rails.logger).to have_received(:info).with(/request_method: "GET"/)
+        expect(Rails.logger).to have_received(:info).with(/api_key: "invalid-key"/)
+      end
     end
   end
 


### PR DESCRIPTION
Closes #5107 

#### Changes proposed in this pull request

- Adds ability to include 'permissive' as a path_parameter for a given route in order to skip API key checks.
