### PR TITLE
Y25-280 - Remove erroneous user from debug message

### DIFF
--- a/app/jobs/sample_accessioning_job.rb
+++ b/app/jobs/sample_accessioning_job.rb
@@ -36,24 +36,19 @@ SampleAccessioningJob =
 
     def raise_accession_error(submission, cause)
       sample_name = submission.sample.sample.name
-      user = submission.user
-      message = "SampleAccessioningJob failed for sample '#{sample_name}' " \
-                "accessioned by user '#{user.name}' (#{user.login}): #{cause}"
+      message = "SampleAccessioningJob failed for sample '#{sample_name}': #{cause}"
 
       raise(AccessionService::AccessionServiceError, message)
     end
 
     def handle_accession_error(error, submission, cause)
       sample_name = submission.sample.sample.name
-      user = submission.user
       service = submission.service
 
       Rails.logger.error(error.message)
       ExceptionNotifier.notify_exception(error, data: {
                                            cause_message: cause,
                                            sample_name: sample_name,
-                                           user_login: user.login,
-                                           user_username: user.name,
                                            service_provider: service.provider.to_s
                                          })
     end

--- a/spec/jobs/sample_accessioning_job_spec.rb
+++ b/spec/jobs/sample_accessioning_job_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe SampleAccessioningJob, type: :job do
 
       it 'logs the error' do
         expect(logger).to have_received(:error).with(
-          "SampleAccessioningJob failed for sample '#{sample.name}' " \
-          "accessioned by user '#{user.name}' (#{user.login}): " \
+          "SampleAccessioningJob failed for sample '#{sample.name}': " \
           'EBI failed to update accession number, data may be invalid'
         )
       end
@@ -51,9 +50,7 @@ RSpec.describe SampleAccessioningJob, type: :job do
           data: {
             cause_message: 'EBI failed to update accession number, data may be invalid',
             sample_name: sample.name, # 'Sample 1',
-            service_provider: 'ENA',
-            user_login: user.login, # 'user_abc1',
-            user_username: user.name # 'first_name last_name'
+            service_provider: 'ENA'
           }
         )
       end
@@ -62,8 +59,7 @@ RSpec.describe SampleAccessioningJob, type: :job do
     context 'when an exception is raised during submission' do
       let(:error) do
         AccessionService::AccessionServiceError.new(
-          "SampleAccessioningJob failed for sample '#{sample.name}' " \
-          "accessioned by user '#{user.name}' (#{user.login}): " \
+          "SampleAccessioningJob failed for sample '#{sample.name}': " \
           'EBI failed to update accession number, data may be invalid'
         )
       end

--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -101,8 +101,7 @@ RSpec.describe Sample, :accession, :cardinal do
         accessionable_sample.accession
 
         expect(Rails.logger).to have_received(:error).with(
-          "SampleAccessioningJob failed for sample '#{accessionable_sample.name}' " \
-          "accessioned by user '#{user.name}' (#{user.login}): " \
+          "SampleAccessioningJob failed for sample '#{accessionable_sample.name}': " \
           'EBI failed to update accession number, data may be invalid'
         )
       end
@@ -115,9 +114,7 @@ RSpec.describe Sample, :accession, :cardinal do
           instance_of(AccessionService::AccessionServiceError),
           data: { cause_message: 'EBI failed to update accession number, data may be invalid',
                   sample_name: accessionable_sample.name, # 'Sample1'
-                  service_provider: 'ENA',
-                  user_login: user.login, # 'user_abc1'
-                  user_username: user.name } # 'first_name last_name'
+                  service_provider: 'ENA' }
         )
       end
     end


### PR DESCRIPTION
Patch for #4875

#### Changes proposed in this pull request

- Remove erroenous contact user from accessioning debug message


  SampleAccessioningJob failed for sample '1929STDY15974877' ~accessioned by user 'Andrew P' (ap13)~: EBI failed to update accession number, data may be invalid


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
