### PR TITLE
Y25-280 - Limit accessioning error messages to prevent 500 page

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -153,13 +153,13 @@ class SamplesController < ApplicationController
 
     flash[:notice] = "Accession number generated: #{@sample.sample_metadata.sample_ebi_accession_number}"
   rescue ActiveRecord::RecordInvalid => e
-    flash[:error] = "Please fill in the required fields: #{@sample.errors.full_messages.join(', ')}"
+    flash[:error] = truncate_flash("Please fill in the required fields: #{@sample.errors.full_messages.join(', ')}")
   rescue AccessionService::NumberNotRequired => e
-    flash[:warning] = e.message || 'An accession number is not required for this study'
+    flash[:warning] = truncate_flash(e.message || 'An accession number is not required for this study')
   rescue AccessionService::NumberNotGenerated => e
-    flash[:warning] = "No accession number was generated: #{e.message}"
+    flash[:warning] = truncate_flash("No accession number was generated: #{e.message}")
   rescue AccessionService::AccessionServiceError => e
-    flash[:error] = "Accessioning Service Failed: #{e.message}"
+    flash[:error] = truncate_flash("Accessioning Service Failed: #{e.message}")
   ensure
     redirect_to(sample_path(@sample))
   end


### PR DESCRIPTION
Solves 500 error on https://psd-team.slack.com/archives/C01J32MB747/p1754385779757759

#### Changes proposed in this pull request

- Truncate long flash messages from accessioning

#### Additional context

[Debug logs](https://kibana.psd.sanger.ac.uk/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-30d,mode:quick,to:now))&_a=(columns:!(_source),index:'10b2b450-5719-11ee-8c04-7930a8f11eaa',interval:auto,query:(language:lucene,query:CookieOverflow),sort:!('@timestamp',desc)))

Test by visiting https://training.sequencescape.psd.sanger.ac.uk/samples/10189662 after 10 August and clicking `Generate Accession Number`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
