### PR TITLE
refactor: remove unused full allowance table from scrna_config

### DIFF
--- a/config/initializers/scrna_config.rb
+++ b/config/initializers/scrna_config.rb
@@ -30,15 +30,6 @@ Rails.application.config.scrna_config = {
   desired_number_of_runs: 2,
   # Volume taken for cell counting in microlitres
   volume_taken_for_cell_counting: 10.0,
-  # Full allowance table, keyed on numbers of samples with values for number of cells per chip well
-  full_allowance_table: {
-    5 => 26_250,
-    6 => 37_500,
-    7 => 48_750,
-    8 => 60_000,
-    9 => 71_250,
-    10 => 82_500
-  },
   # Key for the required number of cells metadata stored on Study (in poly_metadata)
   study_required_number_of_cells_per_sample_in_pool_key: 'scrna_core_pbmc_donor_pooling_required_number_of_cells',
   # Default viability threshold when passing/failing samples (in percent)


### PR DESCRIPTION
Closes #5129 (kinda)

#### Changes proposed in this pull request

- The story is being closed because the bug is no longer in the latest version of SS, see: https://github.com/sanger/sequencescape/issues/5129#issuecomment-3163487974.
- The full allowance table has been removed from config because it wasn't used at all, the values are calculated on the fly during the pooling feasibility check.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
