### PR TITLE
docs: fixes logo image ref for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="app/frontend/images/logo-gradient-production.svg" alt="logo" style="height:1em;vertical-align:middle;"> Sequencescape
+# <img src="app/frontend/images/logo-gradient.svg" alt="logo" style="height:1em;vertical-align:middle;"> Sequencescape
 
 ![Ruby Test](https://github.com/sanger/sequencescape/workflows/Ruby%20Test/badge.svg)
 ![Javascript testing](https://github.com/sanger/sequencescape/workflows/Javascript%20testing/badge.svg)


### PR DESCRIPTION
#### Changes proposed in this pull request

- Corrects image source for README logo following changes to frontend image names.

Context:
<img width="995" height="242" alt="Screenshot 2025-08-11 at 15 13 09" src="https://github.com/user-attachments/assets/f391e66f-4fb4-4db0-a6e1-4b7f0ffc3bc6" />

