### PR TITLE
Y25-462 - Handle missing labwares on receptacles xml requests

### DIFF
--- a/app/views/receptacles/show.xml.builder
+++ b/app/views/receptacles/show.xml.builder
@@ -16,7 +16,7 @@ xml.asset(api_data) do
     @asset.aliquots.each { |aliquot| output_aliquot(xml, aliquot) }
   end
 
-  xml.children { @asset.children.each { |child_asset| xml.id child_asset.id } }
+  xml.children { @asset.children&.each { |child_asset| xml.id child_asset.id } }
   xml.parents { @asset.parents.each { |parent_asset| xml.id parent_asset.id } }
   if @exclude_nested_resource
     # just send the ids


### PR DESCRIPTION
Mitigates #5117, now also on the recommended receptacles endpoint

#### Changes proposed in this pull request

- Add the safe navigation operator to the receptacles xml endpoint to handle missing labware

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
