### PR TITLE
[dev] Hide SCSS deprecation warnings from Bootstrap 5

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,15 @@ export default defineConfig({
     emptyOutDir: true,
     target: ["chrome65", "es2019"],
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        quietDeps: true,
+        silenceDeprecations: ["import", "color-functions", "global-builtin"],
+        verbose: false,
+      },
+    },
+  },
   plugins: [RubyPlugin(), createVuePlugin(), legacy({ targets: ["defaults"] })],
   resolve: {
     alias: {


### PR DESCRIPTION
Removes deprecation warnings that are out of our control. They will likely be addressed in Bootstrap 6.

This will allow us to see valid warnings about code we introduce ourselves.

Config sourced and updated from https://www.reddit.com/r/bootstrap/comments/1e6i6qg/comment/mxmxx5t

#### Changes proposed in this pull request

- Hides SCSS deprecation warnings from bootstrap that we can't do anything about

```
DEPRECATION WARNING [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

   ┌──> node_modules/bootstrap/scss/_custom-forms.scss
415│       appearance: none;
   │       ^^^^^^^^^^^^^^^^ declaration
   ╵
   ┌──> node_modules/bootstrap/scss/mixins/_transition.scss
21 │ ┌       @media (prefers-reduced-motion: reduce) {
22 │ │         transition: none;
23 │ │       }
   │ └─── nested rule
   ╵
    node_modules/bootstrap/scss/_custom-forms.scss 415:5  @import
    node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
    app/frontend/stylesheets/application.scss 13:9        @import
    app/frontend/entrypoints/application.scss 1:9         root stylesheet

DEPRECATION WARNING [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

   ┌──> node_modules/bootstrap/scss/_custom-forms.scss
441│       appearance: none;
   │       ^^^^^^^^^^^^^^^^ declaration
   ╵
   ┌──> node_modules/bootstrap/scss/mixins/_transition.scss
21 │ ┌       @media (prefers-reduced-motion: reduce) {
22 │ │         transition: none;
23 │ │       }
   │ └─── nested rule
   ╵
    node_modules/bootstrap/scss/_custom-forms.scss 441:5  @import
    node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
    app/frontend/stylesheets/application.scss 13:9        @import
    app/frontend/entrypoints/application.scss 1:9         root stylesheet

DEPRECATION WARNING [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

   ┌──> node_modules/bootstrap/scss/_custom-forms.scss
470│       appearance: none;
   │       ^^^^^^^^^^^^^^^^ declaration
   ╵
   ┌──> node_modules/bootstrap/scss/mixins/_transition.scss
21 │ ┌       @media (prefers-reduced-motion: reduce) {
22 │ │         transition: none;
23 │ │       }
   │ └─── nested rule
   ╵
    node_modules/bootstrap/scss/_custom-forms.scss 470:5  @import
    node_modules/bootstrap/scss/bootstrap.scss 24:9       @import
    app/frontend/stylesheets/application.scss 13:9        @import
    app/frontend/entrypoints/application.scss 1:9         root stylesheet

DEPRECATION WARNING [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

   ┌──> node_modules/bootstrap/scss/_modal.scss
46 │       transform: $modal-fade-transform;
   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
   ┌──> node_modules/bootstrap/scss/mixins/_transition.scss
21 │ ┌       @media (prefers-reduced-motion: reduce) {
22 │ │         transition: none;
23 │ │       }
   │ └─── nested rule
   ╵
    node_modules/bootstrap/scss/_modal.scss 46:5     @import
    node_modules/bootstrap/scss/bootstrap.scss 38:9  @import
    app/frontend/stylesheets/application.scss 13:9   @import
    app/frontend/entrypoints/application.scss 1:9    root stylesheet
```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
