### PR TITLE
[ruby] Restrict rspec-rails to Rails 7.1 versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -206,7 +206,7 @@ group :test, :cucumber do
   gem 'launchy', require: false
   gem 'mocha', require: false # avoids load order problems
   gem 'nokogiri', require: false
-  gem 'rspec-rails', require: false
+  gem 'rspec-rails', '~> 7.1.0', require: false # TODO: Update to '~> 8.0' when we move to Rails 8
   gem 'selenium-webdriver', '~> 4.1', require: false
   gem 'shoulda'
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -693,7 +693,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-json_expectations
   rspec-longrun
-  rspec-rails
+  rspec-rails (~> 7.1.0)
   rubocop
   rubocop-capybara
   rubocop-factory_bot


### PR DESCRIPTION
Removes dependency conflict in Depfu: https://depfu.com/repos/github/sanger/sequencescape

#### Changes proposed in this pull request

- Limits versions of `rspec-rails` to 7.1.x
- Should be updated when Rails is upgraded

Current version is `7.1.1` and is not changed by this PR, only the range of valid versions is altered.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
