### PR TITLE
Y25-319 - [PR][Sequencescape] Use sanger-jsonapi-resources version 0.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :default do
   # Version 0.1.1 was created from the [develop](https://github.com/sanger/jsonapi-resources/tree/develop) branch
   # published, and pinned for Sequencescape compatibility.
   # This version is tested and compatible with Rails 7.1/7.2 and Ruby 3.2/3.3.
-  gem 'sanger-jsonapi-resources', '~> 0.1.1'
+  gem 'sanger-jsonapi-resources', '~> 0.1.2'
 
   # gem 'sanger-jsonapi-resources', github: 'sanger/jsonapi-resources', branch: 'develop'
   gem 'csv', '~> 3.3' # Required by jsonapi-resources, previously part of ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,11 +324,11 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.9-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (1.27.0)
@@ -511,7 +511,7 @@ GEM
       logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
-    sanger-jsonapi-resources (0.1.1)
+    sanger-jsonapi-resources (0.1.2)
       activerecord (>= 4.1)
       concurrent-ruby
       csv
@@ -704,7 +704,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   ruby-prof
   ruby-units
-  sanger-jsonapi-resources (~> 0.1.1)
+  sanger-jsonapi-resources (~> 0.1.2)
   sanger_barcode_format!
   sanger_warren
   selenium-webdriver (~> 4.1)

--- a/app/controllers/api/v2/bait_library_layouts_controller.rb
+++ b/app/controllers/api/v2/bait_library_layouts_controller.rb
@@ -40,7 +40,7 @@ module Api
       private
 
       def respond_with_errors(title, details, status)
-        status_code = Rack::Utils::SYMBOL_TO_STATUS_CODE[status]
+        status_code = Rack::Utils.status_code(status)
 
         errors = details.map { |detail| { title: title, detail: detail, code: status_code, status: status_code } }
 


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Use sanger-jsonapi-resources version 0.1.2

Uses the changes in Y25-319 - [PR] [Develop] Add compatibility for obsolete Rack status symbols https://github.com/sanger/jsonapi-resources/pull/5

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
