### PR TITLE
Y25-442 [PR] interim permissible post requests for y25_442_make_api_key_mandatory feature

### DIFF
--- a/app/controllers/api/v2/concerns/api_key_authenticatable.rb
+++ b/app/controllers/api/v2/concerns/api_key_authenticatable.rb
@@ -3,10 +3,10 @@ module Api
   module V2
     module Concerns
       # Provides the tools needed to confirm that a valid API key was provided for the header X-Sequencescape-Client-Id.
-      # - Skips the check if the endpoint specifies permissve GETs
+      # - Skips the check if the endpoint specifies permissive methods names.
       # - Where the API key is in the request and exists in among ApiApplication, allow the request to be served.
       # - Where the API key is in the request but does not exist, log the attempt and render an unauthorized response.
-      # - Where the API key is not in the request, respond normally (for now) and log the system that made the request.
+      # - Where the API key is not in the request, log the attempt and render an unauthorized response.
       module ApiKeyAuthenticatable
         extend ActiveSupport::Concern
 
@@ -74,14 +74,14 @@ module Api
         # Checks if the current request is a permissive route.
         #
         # A route is considered permissive if the 'permissive' path parameter is present in the request
-        # and the HTTP request method is 'GET'.
+        # and the HTTP request method is specified in the array of permissive methods.
         # Path parameters can be defined via defaults next to the route in routes.rb
-        # e.g. jsonapi_resources :samples, defaults: { permissive: true }
+        # e.g. jsonapi_resources :samples, defaults: { permissive: [:get, :post] }
         #
         # @return [Boolean] true if the route is permissive, false otherwise.
         def permissive_route
           # Use path_parameters as standard parameters are overridable by requesters
-          request.path_parameters.fetch(:permissive, false) && request.get?
+          request.path_parameters.fetch(:permissive, []).include?(request.method.downcase.to_sym)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,9 @@ Rails.application.routes.draw do
 
       jsonapi_resources :barcode_printers
       jsonapi_resources :bulk_transfers, except: %i[update]
-      jsonapi_resources :comments, defaults: { permissive: true }
+      jsonapi_resources :comments, defaults: { permissive: %i[post] }
       jsonapi_resources :custom_metadatum_collections
-      jsonapi_resources :labware, defaults: { permissive: true }
+      jsonapi_resources :labware, defaults: { permissive: %i[get] }
       jsonapi_resources :lanes
       jsonapi_resources :lot_types
       jsonapi_resources :lots
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
       jsonapi_resources :primer_panels
       jsonapi_resources :projects
       jsonapi_resources :purposes
-      jsonapi_resources :qc_assays, defaults: { permissive: true }
+      jsonapi_resources :qc_assays, defaults: { permissive: %i[post] }
       jsonapi_resources :qc_files, except: %i[update]
       jsonapi_resources :qc_results
       jsonapi_resources :qcables
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
       jsonapi_resources :submission_templates
       jsonapi_resources :submissions, except: %i[update]
       jsonapi_resources :tag_group_adapter_types
-      jsonapi_resources :tag_groups, defaults: { permissive: true }
+      jsonapi_resources :tag_groups, defaults: { permissive: %i[get] }
       jsonapi_resources :tag_sets, only: %i[index show]
       jsonapi_resources :tag_layout_templates
       jsonapi_resources :tag_layouts, except: %i[update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
       jsonapi_resources :barcode_printers
       jsonapi_resources :bulk_transfers, except: %i[update]
-      jsonapi_resources :comments, defaults: { permissive: %i[post] }
+      jsonapi_resources :comments, defaults: { permissive: %i[get post] }
       jsonapi_resources :custom_metadatum_collections
       jsonapi_resources :labware, defaults: { permissive: %i[get] }
       jsonapi_resources :lanes
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
       jsonapi_resources :primer_panels
       jsonapi_resources :projects
       jsonapi_resources :purposes
-      jsonapi_resources :qc_assays, defaults: { permissive: %i[post] }
+      jsonapi_resources :qc_assays, defaults: { permissive: %i[get post] }
       jsonapi_resources :qc_files, except: %i[update]
       jsonapi_resources :qc_results
       jsonapi_resources :qcables

--- a/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
+++ b/spec/controllers/api/v2/concerns/api_key_authenticatable_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Api::V2::Concerns::ApiKeyAuthenticatable do
   end
 
   describe '#permissive_route' do
-    context 'when permissive param is present and request is GET' do
+    context 'when permissive param includes :get and request method is GET' do
       before do
-        allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: true)
+        allow(controller.request).to receive_messages(path_parameters: { permissive: [:get] }, method: 'GET')
       end
 
       it 'returns true' do
@@ -17,9 +17,9 @@ RSpec.describe Api::V2::Concerns::ApiKeyAuthenticatable do
       end
     end
 
-    context 'when permissive param is present but request is not GET' do
+    context 'when permissive param includes :get but request method is not GET' do
       before do
-        allow(controller.request).to receive_messages(path_parameters: { permissive: true }, get?: false)
+        allow(controller.request).to receive_messages(path_parameters: { permissive: [:get] }, method: 'POST')
       end
 
       it 'returns false' do
@@ -29,7 +29,7 @@ RSpec.describe Api::V2::Concerns::ApiKeyAuthenticatable do
 
     context 'when permissive param is not present' do
       before do
-        allow(controller.request).to receive_messages(path_parameters: {}, get?: true)
+        allow(controller.request).to receive_messages(path_parameters: {}, method: 'GET')
       end
 
       it 'returns false' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Allow permissive params to include methods
- Add interim permissive params in routes

Integration suite test: https://gitlab.internal.sanger.ac.uk/psd/integration-suite/-/merge_requests/287

Added permissive params are based on the log analysis at https://github.com/sanger/limber/issues/2457

Bug discovered while sending QC information to Sequencescape from Limber. See https://psd-team.slack.com/archives/C01J32MB747/p1758635440918849

Bug reproduced locally shows that qc_assays did not allow post requests. See: https://psd-team.slack.com/archives/C01J32MB747/p1758638317886369?thread_ts=1758635440.918849&cid=C01J32MB747

Client side fixes will be done by the story https://github.com/sanger/limber/issues/2457 . Once it is implemented, interim permissions and the future flag can be removed. 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
