### PR TITLE
[dev] Update shoulda gems to Rails 7 compatible versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -209,7 +209,8 @@ group :test, :cucumber do
   gem 'nokogiri', require: false
   gem 'rspec-rails', '~> 7.1.0', require: false # TODO: Update to '~> 8.0' when we move to Rails 8
   gem 'selenium-webdriver', '~> 4.1', require: false
-  gem 'shoulda'
+  gem 'shoulda-context', '~> 3.0.0.rc1'
+  gem 'shoulda-matchers', '~> 6.0'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
   gem 'timecop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,12 +536,9 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     set (1.1.1)
-    shoulda (4.0.0)
-      shoulda-context (~> 2.0)
-      shoulda-matchers (~> 4.0)
-    shoulda-context (2.0.0)
-    shoulda-matchers (4.5.1)
-      activesupport (>= 4.2.0)
+    shoulda-context (3.0.0.rc1)
+    shoulda-matchers (6.5.0)
+      activesupport (>= 5.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -712,7 +709,8 @@ DEPENDENCIES
   sanger_barcode_format!
   sanger_warren
   selenium-webdriver (~> 4.1)
-  shoulda
+  shoulda-context (~> 3.0.0.rc1)
+  shoulda-matchers (~> 6.0)
   simplecov
   simplecov-lcov
   sinatra


### PR DESCRIPTION
Update shoulda gems to Rails 7 compatibile versions for #4720 

#### Changes proposed in this pull request

- `'shoulda'` -> `'shoulda-context', '~> 3.0.0.rc1'` + `'shoulda-matchers', '~> 6.0'`

#### Instructions for Reviewers

- See output here: https://github.com/sanger/sequencescape/actions/runs/19039462688/job/54372422218?pr=5332 compared to https://github.com/sanger/sequencescape/actions/runs/19036269186/job/54361334902

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
