### PR TITLE
Y25-411 - [PR] Rename CSV files (ZIP entries)

### DIFF
--- a/app/controllers/ultima_sample_sheet/sample_sheet_generator.rb
+++ b/app/controllers/ultima_sample_sheet/sample_sheet_generator.rb
@@ -76,7 +76,7 @@ module UltimaSampleSheet::SampleSheetGenerator
     # @return [String] the ZIP entry name
     def entry_name(request)
       barcode = request.asset.human_barcode
-      "#{folder_name}/batch_#{@batch.id}_#{barcode}_sample_sheet.csv"
+      "#{folder_name}/#{@batch.id}_#{barcode}.csv"
     end
 
     # Returns the folder name for the batch sample sheets in the ZIP archive.

--- a/spec/controllers/ultima_sample_sheet/sample_sheet_generator_spec.rb
+++ b/spec/controllers/ultima_sample_sheet/sample_sheet_generator_spec.rb
@@ -137,12 +137,12 @@ RSpec.describe UltimaSampleSheet::SampleSheetGenerator do
     # Expected Zip entry names
     let(:zip_entry1_name) do
       folder = "batch_#{batch.id}_sample_sheets"
-      csv = "batch_#{batch.id}_#{tube1.human_barcode}_sample_sheet.csv"
+      csv = "#{batch.id}_#{tube1.human_barcode}.csv"
       "#{folder}/#{csv}"
     end
     let(:zip_entry2_name) do
       folder = "batch_#{batch.id}_sample_sheets"
-      csv = "batch_#{batch.id}_#{tube2.human_barcode}_sample_sheet.csv"
+      csv = "#{batch.id}_#{tube2.human_barcode}.csv"
       "#{folder}/#{csv}"
     end
     # Expected CSV section headers from Zip; to peek at the content.


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Rename CSV files (ZIP entries) to match the format `<batchid>_<ntnumber>.csv`

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
