### PR TITLE
Y25-286 - Remove nonsensical failing test

### DIFF
--- a/spec/models/sample_spec.rb
+++ b/spec/models/sample_spec.rb
@@ -52,12 +52,6 @@ RSpec.describe Sample, :accession, :cardinal do
       Delayed::Worker.delay_jobs = true
     end
 
-    it 'will not proceed if the sample is not suitable' do
-      accessionable_sample.accession
-
-      expect(unaccessionable_sample.sample_metadata.sample_ebi_accession_number).to be_nil
-    end
-
     it 'will provide debug information if the sample is not suitable for accessioning' do
       sample_name = unaccessionable_sample.name
 


### PR DESCRIPTION
Introduced in #5356 - not sure how it passed there but is failing in develop...

#### Changes proposed in this pull request

- Remove spec 'will not proceed if the sample is not suitable' which tests a _suitable_ sample.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
