### PR TITLE
[ux] Show the number of samples in a study

### DIFF
--- a/app/views/studies/_study_list.html.erb
+++ b/app/views/studies/_study_list.html.erb
@@ -19,7 +19,7 @@
         <small><%= link_to 'Details', properties_study_path(study) %></small>
       </td>
       <td><span style="display:none"><%= study.created_at %></span><%= study.created_at.to_formatted_s(:sortable) %></td>
-      <td><%= study.study_samples.size %></td>
+      <td><%= StudySample.where(study_id: study.id).size %></td>
       <td><%= display_owners(study) %></td>
     </tr>
   <% end -%>


### PR DESCRIPTION
Very helpful for finding a study for debugging - as so many have 0 or 2 samples...

#### Changes proposed in this pull request

- Add a Samples column to the studies page.

Screenshot:
<img width="1508" height="649" alt="Screenshot 2026-01-07 at 12 54 12" src="https://github.com/user-attachments/assets/f1c2dc58-f7f2-4962-a5a9-de3c6fc30cfb" />

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
