### PR TITLE
Y25-286 - Add missing argument to validates_associated message

### DIFF
--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -400,7 +400,7 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
   validates_each(:ena_study, on: %i[accession ENA EGA]) do |record, _attr, value|
     record.errors.add(:base, 'Sample has no study') if value.blank?
   end
-  validates_associated :ena_study, allow_blank: true, on: :accession, message: lambda { |record|
+  validates_associated :ena_study, allow_blank: true, on: :accession, message: lambda { |record, _attr|
     "is invalid: #{record.ena_study.errors.full_messages.join(', ')}"
   }
 


### PR DESCRIPTION
Fixes minor bug introduced in #5403 

#### Changes proposed in this pull request

- Add second (unused) attribute to validates_associated message

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
