### PR TITLE
Y25-705 - Add event-user to accessioning exception notifications

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'exception_notification'
-
 # rubocop:todo Metrics/ClassLength
 class SamplesController < ApplicationController
   # WARNING! This filter bypasses security mechanisms in rails 4 and mimics rails 2 behviour.

--- a/app/jobs/sample_accessioning_job.rb
+++ b/app/jobs/sample_accessioning_job.rb
@@ -122,10 +122,15 @@ SampleAccessioningJob =
     end
 
     # Log and email developers of the accessioning error
-    def notify_developers(error, submission)
+    def notify_developers(error, submission) # rubocop:disable Metrics/CyclomaticComplexity
       sample_name = submission.sample.sample.name
       message = "SampleAccessioningJob failed for sample '#{sample_name}': #{error.message}"
-      data = { message: message, sample_name: sample_name, service_provider: submission.service&.provider.to_s }
+      data = {
+        message: message,
+        sample_name: sample_name,
+        service_provider: submission.service&.provider.to_s,
+        user: event_user&.login
+      }
 
       Rails.logger.error(message)
       Rails.logger.debug(error.backtrace.join("\n")) if error.backtrace # Log backtrace for debugging

--- a/spec/jobs/sample_accessioning_job_spec.rb
+++ b/spec/jobs/sample_accessioning_job_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe SampleAccessioningJob, type: :job do
                          "Sample '#{sample_name}' cannot be accessioned: " \
                          'Sample does not have the required metadata: sample-taxon-id.',
                 sample_name: sample_name,
-                service_provider: 'ENA'
+                service_provider: 'ENA',
+                user: nil
               }
             )
           end
@@ -169,7 +170,8 @@ RSpec.describe SampleAccessioningJob, type: :job do
               message: "SampleAccessioningJob failed for sample '#{sample.name}': " \
                        'Failed to process accessioning response',
               sample_name: sample.name, # 'Sample 1',
-              service_provider: 'ENA'
+              service_provider: 'ENA',
+              user: nil
             }
           )
         end

--- a/spec/lib/accession_spec.rb
+++ b/spec/lib/accession_spec.rb
@@ -155,7 +155,8 @@ RSpec.describe Accession do
                       data: { message: "SampleAccessioningJob failed for sample '#{sample_name}': " \
                                        'Failed to process accessioning response',
                               sample_name: sample_name,
-                              service_provider: 'ENA' })
+                              service_provider: 'ENA',
+                              user: event_user.login })
             end
           end
         end


### PR DESCRIPTION
Closes #5416

#### Changes proposed in this pull request

- Add the event-user's login to the exception emails for easier debugging.
  This will appear at the bottom of emails like so:
  > ```
  > -------------------------------
  > Data:
  > -------------------------------
  > 
  >   * data: {message:
  >     "SampleAccessioningJob failed for sample '6748STDY13016701': Sample '6748STDY13016701' cannot be accessioned: Sample does not have the required metadata: sample-common-name and sample-taxon-id.",
  >    sample_name: "6748STDY13016701",
  >    service_provider: "ENA",
  >    user: "ab12"}
  > ```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
