### PR TITLE
build: add explicit mysql service to automated release workflow

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -13,6 +13,18 @@ jobs:
   automated_release:
     name: Automated release
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        # Use the Mysql docker image https://hub.docker.com/_/mysql
+        image: mysql:8.0
+        ports:
+          - 3306 # Default port mappings
+          # Monitor the health of the container to mesaure when it is ready
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        env:
+          MYSQL_ROOT_PASSWORD: "" # Set root PW to nothing
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+
     steps:
       - name: Checkout Repository
         uses: sanger/.github/.github/actions/setup/checkout@master


### PR DESCRIPTION
Closes #4720 

#### Changes proposed in this pull request

- Add explicit mysql service to automated release workflow

Not quite sure why this is required for a build step - clearly due to a change in Rails 7.2.
Not ideal, but an easy workaround.

I encountered the same issue in #5285 and used this workaround in `.github/workflows/build_and_release.yml`.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
