### PR TITLE
SR-52903 - Link to sanger/warren github instead of rubygem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ group :default do
   gem 'csv', '~> 3.3' # Required by jsonapi-resources, previously part of ruby
 
   # Wraps bunny with connection pooling and consumer process handling
-  gem 'sanger_warren'
+  gem 'sanger_warren', github: 'sanger/warren', branch: 'master'
 
   # Use bunny for simple RabbitMQ publishing operations
   gem 'bunny', '>= 2.22.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,17 @@ GIT
   specs:
     sanger_barcode_format (0.2.0)
 
+GIT
+  remote: https://github.com/sanger/warren.git
+  revision: fcee96dbf39e8187fe1759a0b0c80cdf98740d1d
+  branch: master
+  specs:
+    sanger_warren (0.5.1)
+      bunny (~> 2.17)
+      connection_pool (~> 2.2)
+      multi_json (>= 1.0, < 1.18.0)
+      thor (~> 1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -319,7 +330,7 @@ GEM
     mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
-    multi_json (1.19.1)
+    multi_json (1.17.0)
     multi_test (1.1.0)
     multipart-post (2.4.1)
     mustermann (3.0.0)
@@ -541,11 +552,6 @@ GEM
       concurrent-ruby
       csv
       railties (>= 4.1)
-    sanger_warren (0.5.0)
-      bunny (~> 2.17)
-      connection_pool (~> 2.2)
-      multi_json (~> 1.0)
-      thor (~> 1.1)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -734,7 +740,7 @@ DEPENDENCIES
   ruby-units
   sanger-jsonapi-resources (~> 0.1.2)
   sanger_barcode_format!
-  sanger_warren
+  sanger_warren!
   selenium-webdriver (~> 4.1)
   shoulda-context (~> 3.0.0.rc1)
   shoulda-matchers (~> 6.0)


### PR DESCRIPTION
Updates sanger_warren to the latest version (0.5.1).

#### Changes proposed in this pull request

- Changes sanger_warren source from RubyGems to GitHub
- Downgrades multi_json to 1.17.0

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
