### PR TITLE
Y25-286 - Hide the accession all samples button if not able to accession

### DIFF
--- a/app/helpers/studies_helper.rb
+++ b/app/helpers/studies_helper.rb
@@ -76,4 +76,16 @@ module StudiesHelper
       end
     end
   end
+
+  def accession_all_samples_button(study)
+    if !accessioning_enabled?
+      tag.span('Accessioning is currently disabled.', class: 'text-muted')
+    elsif !(permitted_to_accession?(study) && study.samples_accessionable?)
+      tag.span('Unable to accession study.', class: 'text-muted')
+    else
+      link_to('<i class="fa fa-upload"></i> Accession all samples'.html_safe,
+              accession_all_samples_study_path(study),
+              class: 'btn btn-sm btn-outline-primary')
+    end
+  end
 end

--- a/app/views/studies/information/_accession_statuses.html.erb
+++ b/app/views/studies/information/_accession_statuses.html.erb
@@ -1,14 +1,7 @@
 <%# Top content %>
 <% content_for :top_content do %>
   <%= tag.div(class: 'd-flex justify-content-end') do %>
-    <% unless accessioning_enabled? %>
-      <%= tag.span('Accessioning is currently disabled.', class: 'text-muted') %>
-    <% else %>
-      <%= link_to('<i class="fa fa-upload"></i> Accession all samples'.html_safe,
-          accession_all_samples_study_path(@study),
-          class: "btn btn-sm btn-outline-primary")
-      %>
-    <% end %>
+    <%= accession_all_samples_button(@study) %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Bug fix for #5499 

#### Changes proposed in this pull request

- Add study and permissions check to the display of the accession all samples button
- Move the logic into the study helper

Before:

<img width="1243" height="725" alt="Screenshot 2026-02-04 at 14 35 41" src="https://github.com/user-attachments/assets/708459bb-9cfe-4aa7-8ae8-a83b36e3409d" />

After:
<img width="1237" height="545" alt="Screenshot 2026-02-04 at 14 36 18" src="https://github.com/user-attachments/assets/1c04d05c-5542-4269-b6ce-f4332bf3a859" />



#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
