### PR TITLE
Y25-286 - Fix server error on study page when data release details are nil

### DIFF
--- a/app/views/studies/information/_study_accession_checklist.html.erb
+++ b/app/views/studies/information/_study_accession_checklist.html.erb
@@ -25,7 +25,7 @@
 
   <%= checklist_item(
         condition: !@study.study_metadata.strategy_not_applicable?,
-        good: "Study release strategy is #{Study::DATA_RELEASE_STRATEGY_OPEN.humanize} or #{Study::DATA_RELEASE_STRATEGY_MANAGED.humanize} #{tag.strong { "(#{@study.study_metadata.data_release_strategy.humanize})" }}".html_safe,
+        good: "Study release strategy is #{Study::DATA_RELEASE_STRATEGY_OPEN.humanize} or #{Study::DATA_RELEASE_STRATEGY_MANAGED.humanize} #{tag.strong { "(#{@study.study_metadata.data_release_strategy&.humanize})" }}".html_safe,
         bad: "Study release strategy is <strong>#{Study::DATA_RELEASE_STRATEGY_NOT_APPLICABLE.humanize}</strong>".html_safe,
         action: link_to('Change release strategy', edit_study_path(@study)),
         action_permission: can?(:edit, @study),
@@ -34,7 +34,7 @@
 
   <%= checklist_item(
         condition: !@study.study_metadata.never_release?,
-        good: "Study release timing is <strong>#{@study.study_metadata.data_release_timing.humanize}</strong>".html_safe,
+        good: "Study release timing is <strong>#{@study.study_metadata.data_release_timing&.humanize}</strong>".html_safe,
         bad: "Study release timing is <strong>#{Study::DATA_RELEASE_TIMING_NEVER.humanize}</strong>".html_safe,
         action: link_to('Change release settings', edit_study_path(@study)),
         action_permission: can?(:edit, @study),


### PR DESCRIPTION
Found a bug where old studies could produce a server error due to unexpected data.

Fortunately this only occurs in old studies (id =< 431).

#### Changes proposed in this pull request

- Add safe navigation operators before `humanize` in the Study Accessioning checklist

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
