### PR TITLE
Y26-012 - [PR] Automating buffer addition - wireframes

### DIFF
--- a/app/frontend/entrypoints/cherrypick_strategies.js
+++ b/app/frontend/entrypoints/cherrypick_strategies.js
@@ -1,3 +1,15 @@
+// Toggle buffer_volume_for_empty_wells input based on automatic_buffer_addition checkbox
+document.addEventListener("DOMContentLoaded", function () {
+  const bufferInput = document.getElementById("buffer_volume_for_empty_wells");
+  const autoBufferCheckbox = document.getElementById("automatic_buffer_addition");
+  if (bufferInput && autoBufferCheckbox) {
+    function toggleBufferInput() {
+      bufferInput.disabled = !autoBufferCheckbox.checked;
+    }
+    autoBufferCheckbox.addEventListener("change", toggleBufferInput);
+    toggleBufferInput(); // Set initial state
+  }
+});
 // apply a border highlight to the card, based on the cherrypick strategy selected
 // this is admittedly a gratuitous addition to the user experience, but it's a nice touch
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -16,6 +16,8 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include ::Batch::PipelineBehaviour
   include ::Batch::StateMachineBehaviour
   include UnderRepWellCommentsToBroadcast
+  # Y26-012: Added for storing buffer_volume_for_empty_wells option on Cherrypick batches.
+  include HasPolyMetadata
   extend EventfulRecord
 
   # The three states of {Batch} Also @see {SequencingQcBatch}
@@ -50,8 +52,6 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   has_many :samples, -> { distinct }, through: :source_assets, source: :samples
   has_many :output_labware, -> { distinct }, through: :assets, source: :labware
   has_many :input_labware, -> { distinct }, through: :source_assets, source: :labware
-  # Y26-012: Added for storing buffer_volume_for_empty_wells option on Cherrypick batches.
-  has_many :poly_metadata, as: :metadatable, dependent: :destroy
 
   has_many_events
   has_many_lab_events

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -16,8 +16,9 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   include ::Batch::PipelineBehaviour
   include ::Batch::StateMachineBehaviour
   include UnderRepWellCommentsToBroadcast
-  # Y26-012: Added for storing buffer_volume_for_empty_wells option on Cherrypick batches.
+  # Added for storing buffer_volume_for_empty_wells option on Cherrypick batches.
   include HasPolyMetadata
+  include ::Batch::PolyMetadataBehaviour
   extend EventfulRecord
 
   # The three states of {Batch} Also @see {SequencingQcBatch}

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -50,6 +50,8 @@ class Batch < ApplicationRecord # rubocop:todo Metrics/ClassLength
   has_many :samples, -> { distinct }, through: :source_assets, source: :samples
   has_many :output_labware, -> { distinct }, through: :assets, source: :labware
   has_many :input_labware, -> { distinct }, through: :source_assets, source: :labware
+  # Y26-012: Added for storing buffer_volume_for_empty_wells option on Cherrypick batches.
+  has_many :poly_metadata, as: :metadatable, dependent: :destroy
 
   has_many_events
   has_many_lab_events

--- a/app/models/batch/poly_metadata_behaviour.rb
+++ b/app/models/batch/poly_metadata_behaviour.rb
@@ -3,7 +3,7 @@ module Batch::PolyMetadataBehaviour
   # Returns whether the Cherrypick automatic_buffer_addition option is enabled
   # @return [Boolean] whether the automatic_buffer_addition option is enabled
   def automatic_buffer_addition?
-    get_poly_metadata(:automatic_buffer_addition) == '1'
+    %w[1 on].include?(get_poly_metadata(:automatic_buffer_addition))
   end
 
   # Returns the Cherrypick buffer_volume_for_empty_wells option value if

--- a/app/models/batch/poly_metadata_behaviour.rb
+++ b/app/models/batch/poly_metadata_behaviour.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Batch::PolyMetadataBehaviour
+  # Returns whether the Cherrypick automatic_buffer_addition option is enabled
+  # @return [Boolean] whether the automatic_buffer_addition option is enabled
+  def automatic_buffer_addition?
+    get_poly_metadata(:automatic_buffer_addition) == '1'
+  end
+
+  # Returns the Cherrypick buffer_volume_for_empty_wells option value if
+  # automatic_buffer_addition is enabled, nil otherwise.
+  # @return [Float, nil] the buffer_volume_for_empty_wells value
+  def buffer_volume_for_empty_wells
+    get_poly_metadata(:buffer_volume_for_empty_wells).to_f if automatic_buffer_addition?
+  end
+end

--- a/app/models/cherrypick/task/buffer_volume_for_empty_wells_option.rb
+++ b/app/models/cherrypick/task/buffer_volume_for_empty_wells_option.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# frozen_sring_literal: true
+
+module Cherrypick::Task::BufferVolumeForEmptyWellsOption
+  def create_buffer_volume_for_empty_wells_option(params)
+    return unless @batch
+
+    key = :automatic_buffer_addition
+    # The checkbox value is either "1", or nil if not checked.
+    @batch.set_poly_metadata(key, params[key])
+
+    return if params[key] != '1'
+
+    # If automatic buffer addition for empty wells is required.
+    key = :buffer_volume_for_empty_wells
+    unless valid_float_param?(params[key])
+      raise Cherrypick::VolumeError,
+            "Invalid buffer volume for empty wells: #{params[key]}"
+    end
+
+    @batch.set_poly_metadata(key, params[key])
+  end
+end

--- a/app/models/cherrypick/task/buffer_volume_for_empty_wells_option.rb
+++ b/app/models/cherrypick/task/buffer_volume_for_empty_wells_option.rb
@@ -9,7 +9,7 @@ module Cherrypick::Task::BufferVolumeForEmptyWellsOption
     # The checkbox value is either "1", or nil if not checked.
     @batch.set_poly_metadata(key, params[key])
 
-    return if params[key] != '1'
+    return unless %w[1 on].include?(params[key])
 
     # If automatic buffer addition for empty wells is required.
     key = :buffer_volume_for_empty_wells

--- a/app/models/cherrypick/task/pick_helpers.rb
+++ b/app/models/cherrypick/task/pick_helpers.rb
@@ -5,6 +5,7 @@ module Cherrypick::Task::PickHelpers
       include Cherrypick::Task::PickByNanoGramsPerMicroLitre
       include Cherrypick::Task::PickByNanoGrams
       include Cherrypick::Task::PickByMicroLitre
+      include Cherrypick::Task::BufferVolumeForEmptyWellsOption
     end
   end
 

--- a/app/models/concerns/has_poly_metadata.rb
+++ b/app/models/concerns/has_poly_metadata.rb
@@ -26,4 +26,11 @@ module HasPolyMetadata
       record&.destroy!
     end
   end
+
+  # Returns the value of the PolyMetaDatum with the given key.
+  # @param key [String] The key of the PolyMetaDatum to retrieve.
+  # @return [String, nil] The value of the PolyMetaDatum, or nil if it does not exist.
+  def get_poly_metadata(key)
+    poly_metadata.find_by(key:)&.value
+  end
 end

--- a/app/models/concerns/has_poly_metadata.rb
+++ b/app/models/concerns/has_poly_metadata.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module HasPolyMetadata
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :poly_metadata, as: :metadatable, dependent: :destroy, inverse_of: :metadatable
+  end
+
+  # Sets a PolyMetaDatum for the given key and value.
+  # If value is present, it will create or update the PolyMetaDatum with the
+  # given key and value, otherwise it will destroy the PolyMetaDatum with the
+  # given key if that exists.
+  # @param key [String] The key of the PolyMetaDatum to set.
+  # @param value [String] The value of the PolyMetaDatum to set. If nil or empty, the PolyMetaDatum will be destroyed.
+  # @return [void]
+  def set_poly_metadata(key, value)
+    record = poly_metadata.find_by(key:)
+    if value.present?
+      if record
+        record.update!(value:)
+      else
+        poly_metadata.create!(key:, value:)
+      end
+    else
+      record&.destroy!
+    end
+  end
+end

--- a/app/models/robot/generator/behaviours/tecan_default.rb
+++ b/app/models/robot/generator/behaviours/tecan_default.rb
@@ -158,7 +158,7 @@ module Robot::Generator::Behaviours::TecanDefault # rubocop:disable Metrics/Modu
   #     }
   #   }
   def data_object_for_buffers(data_object) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
-    buffer_volume_for_empty_wells = @batch&.get_poly_metadata(:buffer_volume_for_empty_wells)
+    buffer_volume_for_empty_wells = @batch&.buffer_volume_for_empty_wells
     return data_object unless buffer_volume_for_empty_wells
 
     obj = { 'destination' => {} }

--- a/app/models/robot/generator/behaviours/tecan_default.rb
+++ b/app/models/robot/generator/behaviours/tecan_default.rb
@@ -119,8 +119,8 @@ module Robot::Generator::Behaviours::TecanDefault # rubocop:disable Metrics/Modu
     Map::Coordinate.vertical_plate_position_to_description(index, plate_size)
   end
 
-  def data_object_for_buffers(data_object) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-    buffer_volume_for_empty_wells = @batch.get_poly_metadata(:buffer_volume_for_empty_wells)
+  def data_object_for_buffers(data_object) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
+    buffer_volume_for_empty_wells = @batch&.get_poly_metadata(:buffer_volume_for_empty_wells)
     return data_object unless buffer_volume_for_empty_wells
 
     obj = { 'destination' => {} }

--- a/app/models/robot/generator/tecan_v3.rb
+++ b/app/models/robot/generator/tecan_v3.rb
@@ -17,6 +17,8 @@ class Robot::Generator::TecanV3 < Robot::Generator::TecanV2
     data_object = data_object_for_buffers(data_object)
     groups = Hash.new { |h, k| h[k] = [] } # channel => [steps]
     each_mapping(data_object) do |mapping, dest_plate_barcode, plate_details|
+      # src_well is checked to distinguish between buffer for sample wells
+      # and buffer for empty wells.
       next if mapping.key?('src_well') && total_volume <= mapping['volume']
 
       dest_name = data_object['destination'][dest_plate_barcode]['name']

--- a/app/models/robot/generator/tecan_v3.rb
+++ b/app/models/robot/generator/tecan_v3.rb
@@ -14,9 +14,10 @@ class Robot::Generator::TecanV3 < Robot::Generator::TecanV2
   # @see Robot::Generator::Behaviours::TecanDefault#buffers
   # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
   def buffers(data_object)
+    data_object = data_object_for_buffers(data_object)
     groups = Hash.new { |h, k| h[k] = [] } # channel => [steps]
     each_mapping(data_object) do |mapping, dest_plate_barcode, plate_details|
-      next unless total_volume > mapping['volume']
+      next if mapping.key?('src_well') && total_volume <= mapping['volume']
 
       dest_name = data_object['destination'][dest_plate_barcode]['name']
       volume = mapping['buffer_volume']

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -134,7 +134,7 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
       # Y26-012: Store the buffer volume for empty wells option in the batch's
       # poly_metadata for use in the worksheet rendering and robot driver file
       key = :buffer_volume_for_empty_wells
-      set_poly_metadata(key, params[key])
+      @batch.set_poly_metadata(key, params[key])
 
       # We can preload the well locations so that we can do efficient lookup later.
       well_locations =

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -131,6 +131,11 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
           raise StandardError, "Invalid cherrypicking type #{params[:cherrypick_strategy]}"
         end
 
+      # Y26-012: Store the buffer volume for empty wells option in the batch's
+      # poly_metadata for use in the worksheet rendering and robot driver file
+      key = :buffer_volume_for_empty_wells
+      set_poly_metadata(key, params[key])
+
       # We can preload the well locations so that we can do efficient lookup later.
       well_locations =
         Map

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -92,6 +92,8 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
     else
       raise StandardError, "Invalid cherrypicking strategy '#{params[:cherrypick][:strategy]}'"
     end
+    # Y26-012: Add buffer volume for empty wells option to params for pass through
+    @buffer_volume_for_empty_wells = params[:buffer_volume_for_empty_wells]
     @plate_purpose_id = params[:plate_purpose_id]
     @fluidigm_barcode = params[:fluidigm_plate]
   end
@@ -128,6 +130,8 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
         else
           raise StandardError, "Invalid cherrypicking type #{params[:cherrypick_strategy]}"
         end
+
+      binding.pry
 
       # We can preload the well locations so that we can do efficient lookup later.
       well_locations =

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -131,8 +131,6 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
           raise StandardError, "Invalid cherrypicking type #{params[:cherrypick_strategy]}"
         end
 
-      binding.pry
-
       # We can preload the well locations so that we can do efficient lookup later.
       well_locations =
         Map

--- a/app/models/tasks/cherrypick_handler.rb
+++ b/app/models/tasks/cherrypick_handler.rb
@@ -92,7 +92,8 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
     else
       raise StandardError, "Invalid cherrypicking strategy '#{params[:cherrypick][:strategy]}'"
     end
-    # Y26-012: Add buffer volume for empty wells option to params for pass through
+    # Add buffer volume for empty wells option to params for pass through
+    @automatic_buffer_addition = params[:automatic_buffer_addition]
     @buffer_volume_for_empty_wells = params[:buffer_volume_for_empty_wells]
     @plate_purpose_id = params[:plate_purpose_id]
     @fluidigm_barcode = params[:fluidigm_plate]
@@ -131,10 +132,8 @@ module Tasks::CherrypickHandler # rubocop:todo Metrics/ModuleLength
           raise StandardError, "Invalid cherrypicking type #{params[:cherrypick_strategy]}"
         end
 
-      # Y26-012: Store the buffer volume for empty wells option in the batch's
-      # poly_metadata for use in the worksheet rendering and robot driver file
-      key = :buffer_volume_for_empty_wells
-      @batch.set_poly_metadata(key, params[key])
+      # Store the buffer volume for empty wells option in the batch's poly_metadata
+      create_buffer_volume_for_empty_wells_option(params)
 
       # We can preload the well locations so that we can do efficient lookup later.
       well_locations =

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -14,8 +14,8 @@
 <%# see Robot::Verification::Base#pick_number_to_expected_layout for structure of robot_plate_layout %>
 <% destination_layout, source_layout, control_layout = robot_plate_layout %>
 <% source_plate_colour = source_layout.transform_values { |sort_order| "colour#{sort_order%12}" } %>
-<!-- Y26-012 Get buffer_volume_for_empty_wells from batch poly_metadata -->
-<% buffer_volume_for_empty_wells = batch.get_poly_metadata(:buffer_volume_for_empty_wells) %>
+<%# Get buffer_volume_for_empty_wells from batch as float or nil -%>
+<% buffer_volume_for_empty_wells = batch.buffer_volume_for_empty_wells %>
 
 <div id="plate_details">
   <%= render partial: 'cherrypick_worksheet_plate_list', locals: { section_name: 'Source plates', plates: source_layout, bed_prefix: 'SCRC' } %>
@@ -50,7 +50,7 @@
             <td><strong><%= rowchar %></strong></td>
             <% (num_columns).times do |column| -%>
               <% well = plate_wells[row*num_columns+column] -%>
-                <!--Y26-012: flag to check if well is empty and needs to be represented on the chart with 'e' followed by the buffer volume for empty wells, for example e120.0 -->
+                <%# Flag to check if well is empty and needs to be represented on the chart with 'e' followed by the buffer volume for empty wells, for example e120.00 -%>
                 <% empty_well = true %>
                 <% if  well.present? -%>
                   <% request = indexed_requests[well.id]  %>
@@ -66,7 +66,7 @@
                       <% else %>
                         <td>
                       <% end -%>
-                      <!--Y26-012: flag to set if the well is not empty -->
+                      <%# Flag to set if the well is not empty -%>
                       <% empty_well = false %>
                       <%= source_well.map_description %>
                       <%= source_well.plate.barcode_number %>
@@ -101,12 +101,11 @@
 </div>
 
 <div id="footer">
-  <!-- Y26-012: Add buffer volume for empty wells to footer if the option was set; remove it otherwise-->
+  <%# Add buffer volume for empty wells to footer if the option was set -%>
   <% if buffer_volume_for_empty_wells.present? -%>
-    Buffer volume for empty wells: <%= buffer_volume_for_empty_wells %> µl<br>
+    Buffer volume for empty wells: <%= "%.#{configatron.tecan_precision}f" % buffer_volume_for_empty_wells %> %> µl<br>
   <% end -%>
   v = picking volume µl; b = buffer volume µl<% if buffer_volume_for_empty_wells.present? -%>; e = buffer volume for empty wells µl<br><% end -%>
-  <!-- v = picking volume µl; b = buffer volume µl<br> -->
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>
   Printed: <%= Time.now.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= current_user.login %>
 </div>

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -14,6 +14,8 @@
 <%# see Robot::Verification::Base#pick_number_to_expected_layout for structure of robot_plate_layout %>
 <% destination_layout, source_layout, control_layout = robot_plate_layout %>
 <% source_plate_colour = source_layout.transform_values { |sort_order| "colour#{sort_order%12}" } %>
+<!-- Y26-012 Get buffer_volume_for_empty_wells from batch poly_metadata -->
+<% buffer_volume_for_empty_wells = batch.get_poly_metadata(:buffer_volume_for_empty_wells) %>
 
 <div id="plate_details">
   <%= render partial: 'cherrypick_worksheet_plate_list', locals: { section_name: 'Source plates', plates: source_layout, bed_prefix: 'SCRC' } %>
@@ -78,8 +80,8 @@
                 <% else %>
                   <td>
                 <% end -%>
-                <% if empty_well -%>
-                  e120.00
+                <% if empty_well && buffer_volume_for_empty_wells.present? -%>
+                  e<%= "%.#{configatron.tecan_precision}f" % buffer_volume_for_empty_wells %>
                 <% end %>
                 </td>
             <% end -%>
@@ -100,8 +102,10 @@
 
 <div id="footer">
   <!-- Y26-012: Add buffer volume for empty wells to footer if the option was set; remove it otherwise-->
-  Buffer for empty wells: 120 µl<br>
-  v = picking volume µl; b = buffer volume µl; e = buffer for empty wells µl<br>
+  <% if buffer_volume_for_empty_wells.present? -%>
+    Buffer for empty wells: <%= buffer_volume_for_empty_wells %> µl<br>
+  <% end -%>
+  v = picking volume µl; b = buffer volume µl<% if buffer_volume_for_empty_wells.present? -%>; e = buffer for empty wells µl<br><% end -%>
   <!-- v = picking volume µl; b = buffer volume µl<br> -->
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>
   Printed: <%= Time.now.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= current_user.login %>

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -48,6 +48,8 @@
             <td><strong><%= rowchar %></strong></td>
             <% (num_columns).times do |column| -%>
               <% well = plate_wells[row*num_columns+column] -%>
+                <!--Y26-012: flag to check if well is empty and needs to be represented on the chart with 'e' followed by the buffer volume for empty wells, for example e120.0 -->
+                <% empty_well = true %>
                 <% if  well.present? -%>
                   <% request = indexed_requests[well.id]  %>
                   <% source_well = request&.asset %>
@@ -62,6 +64,8 @@
                       <% else %>
                         <td>
                       <% end -%>
+                      <!--Y26-012: flag to set if the well is not empty -->
+                      <% empty_well = false %>
                       <%= source_well.map_description %>
                       <%= source_well.plate.barcode_number %>
                       v<%= "%.#{configatron.tecan_precision}f" % well.get_picked_volume %> b<%= "%.#{configatron.tecan_precision}f" % well.get_buffer_volume %>
@@ -74,6 +78,9 @@
                 <% else %>
                   <td>
                 <% end -%>
+                <% if empty_well -%>
+                  e120.00
+                <% end %>
                 </td>
             <% end -%>
             <td><strong><%= rowchar %></strong></td>
@@ -92,7 +99,12 @@
 </div>
 
 <div id="footer">
-  v = picking volume µl; b = buffer volume µl<br>
+  <!-- Y26-012: Add buffer volume for empty wells to footer if the option was set; remove it otherwise-->
+  <!-- Buffer for empty wells: 120 µl<br> -->
+  
+  <!-- Alternatively, if empty wells are represented on the chart with 'e' followed by the buffer volume, add legend for that here -->
+  v = picking volume µl; b = buffer volume µl; e = buffer for empty wells µl<br>
+  <!-- v = picking volume µl; b = buffer volume µl<br> -->
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>
   Printed: <%= Time.now.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= current_user.login %>
 </div>

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -100,9 +100,7 @@
 
 <div id="footer">
   <!-- Y26-012: Add buffer volume for empty wells to footer if the option was set; remove it otherwise-->
-  <!-- Buffer for empty wells: 120 µl<br> -->
-  
-  <!-- Alternatively, if empty wells are represented on the chart with 'e' followed by the buffer volume, add legend for that here -->
+  Buffer for empty wells: 120 µl<br>
   v = picking volume µl; b = buffer volume µl; e = buffer for empty wells µl<br>
   <!-- v = picking volume µl; b = buffer volume µl<br> -->
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -103,9 +103,9 @@
 <div id="footer">
   <!-- Y26-012: Add buffer volume for empty wells to footer if the option was set; remove it otherwise-->
   <% if buffer_volume_for_empty_wells.present? -%>
-    Buffer for empty wells: <%= buffer_volume_for_empty_wells %> µl<br>
+    Buffer volume for empty wells: <%= buffer_volume_for_empty_wells %> µl<br>
   <% end -%>
-  v = picking volume µl; b = buffer volume µl<% if buffer_volume_for_empty_wells.present? -%>; e = buffer for empty wells µl<br><% end -%>
+  v = picking volume µl; b = buffer volume µl<% if buffer_volume_for_empty_wells.present? -%>; e = buffer volume for empty wells µl<br><% end -%>
   <!-- v = picking volume µl; b = buffer volume µl<br> -->
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>
   Printed: <%= Time.now.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= current_user.login %>

--- a/app/views/batches/_cherrypick_single_worksheet.html.erb
+++ b/app/views/batches/_cherrypick_single_worksheet.html.erb
@@ -103,7 +103,7 @@
 <div id="footer">
   <%# Add buffer volume for empty wells to footer if the option was set -%>
   <% if buffer_volume_for_empty_wells.present? -%>
-    Buffer volume for empty wells: <%= "%.#{configatron.tecan_precision}f" % buffer_volume_for_empty_wells %> %> µl<br>
+    Buffer volume for empty wells: <%= "%.#{configatron.tecan_precision}f" % buffer_volume_for_empty_wells %> µl<br>
   <% end -%>
   v = picking volume µl; b = buffer volume µl<% if buffer_volume_for_empty_wells.present? -%>; e = buffer volume for empty wells µl<br><% end -%>
   Created: <%= batch.updated_at.strftime("%I:%M %p on %A %d %B, %Y") %> for <%= batch.user.login %><br>

--- a/app/views/workflows/_cherrypick_batches.html.erb
+++ b/app/views/workflows/_cherrypick_batches.html.erb
@@ -40,7 +40,8 @@
   <%= hidden_field_tag 'robot_id', @robot_id    %>
   <%= hidden_field_tag 'cherrypick_strategy', @cherrypick_strategy %>
   <%= hidden_field_tag 'plate_type', @plate_type %>
-  <!-- Y26-012: Add hidden field to carry over the buffer volume for empty wells option from the form on the previous page -->
+  <%# Add hidden fields for the buffer volume for empty wells option to carry over -%>
+  <%= hidden_field_tag 'automatic_buffer_addition', @automatic_buffer_addition %>
   <%= hidden_field_tag 'buffer_volume_for_empty_wells', @buffer_volume_for_empty_wells %>
 
   <%= render(partial: 'next_stage_submit', locals: { check_selection: true }) %>

--- a/app/views/workflows/_cherrypick_batches.html.erb
+++ b/app/views/workflows/_cherrypick_batches.html.erb
@@ -40,6 +40,8 @@
   <%= hidden_field_tag 'robot_id', @robot_id    %>
   <%= hidden_field_tag 'cherrypick_strategy', @cherrypick_strategy %>
   <%= hidden_field_tag 'plate_type', @plate_type %>
+  <!-- Y26-012: Add hidden field to carry over the buffer volume for empty wells option from the form on the previous page -->
+  <%= hidden_field_tag 'buffer_volume_for_empty_wells', @buffer_volume_for_empty_wells %>
 
   <%= render(partial: 'next_stage_submit', locals: { check_selection: true }) %>
 <% end %>

--- a/app/views/workflows/_cherrypick_strategies.html.erb
+++ b/app/views/workflows/_cherrypick_strategies.html.erb
@@ -26,5 +26,18 @@
   </div>
 
 </div>
+<!-- Y26-012: Add form control to collect the buffer volume for empty wells -->
+<p>Additional options:</p>
+
+<div class="row">
+  <div class="col-md-4">
+    <div class ="form-group form-row">
+      <label class="col-12 col-lg-8 col-form-label" for="buffer_volume_for_empty_wells">Buffer volume for empty wells (µl)</label>
+      <div class="col-12 col-lg-4">
+        <input type="text" class="form-control" id="buffer_volume_for_empty_wells" name="buffer_volume_for_empty_wells">
+      </div>
+    </div>
+  </div>
+</div>
 
 <%= vite_javascript_tag 'cherrypick_strategies' %>

--- a/app/views/workflows/_cherrypick_strategies.html.erb
+++ b/app/views/workflows/_cherrypick_strategies.html.erb
@@ -1,4 +1,4 @@
-<%# locals: { form: } -%>
+<%# locals: { form: } %>
 
 <p>Choose a strategy below:</p>
 
@@ -26,15 +26,21 @@
   </div>
 
 </div>
-<!-- Y26-012: Add form control to collect the buffer volume for empty wells -->
+<%# Add form controls to collect the options for the buffer volume for empty wells -%>
 <p>Additional options:</p>
 
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-md-8">
+    <div class="form-group form-row">
+      <label class="col-12 col-lg-8 col-form-label" for="automatic_buffer_addition">Automatic buffer addition for empty wells required?</label>
+      <div class="col-12 col-lg-4">
+        <input type="checkbox" class="form-control text-right" name="automatic_buffer_addition" id="automatic_buffer_addition" />
+      </div>
+    </div>
     <div class ="form-group form-row">
       <label class="col-12 col-lg-8 col-form-label" for="buffer_volume_for_empty_wells">Buffer volume for empty wells (µl)</label>
       <div class="col-12 col-lg-4">
-        <input type="text" class="form-control" id="buffer_volume_for_empty_wells" name="buffer_volume_for_empty_wells">
+        <input type="text" class="form-control" id="buffer_volume_for_empty_wells" name="buffer_volume_for_empty_wells" value="120">
       </div>
     </div>
   </div>

--- a/app/views/workflows/_plate_template_batches.html.erb
+++ b/app/views/workflows/_plate_template_batches.html.erb
@@ -55,5 +55,6 @@
     <%= panel(:info, title: "Step 3: Set volumes and concentrations <a href='https://ssg-confluence.internal.sanger.ac.uk/x/NoHdDQ'><small>Information about cherrypicking options</small></a>".html_safe) do %>
       <%= render partial: 'cherrypick_strategies', locals: { form: form } %>
     <% end %>
+
   <%= render partial: "next_stage_submit" %>
 <% end %>

--- a/app/views/workflows/_plate_template_batches.html.erb
+++ b/app/views/workflows/_plate_template_batches.html.erb
@@ -55,6 +55,5 @@
     <%= panel(:info, title: "Step 3: Set volumes and concentrations <a href='https://ssg-confluence.internal.sanger.ac.uk/x/NoHdDQ'><small>Information about cherrypicking options</small></a>".html_safe) do %>
       <%= render partial: 'cherrypick_strategies', locals: { form: form } %>
     <% end %>
-
   <%= render partial: "next_stage_submit" %>
 <% end %>

--- a/spec/models/robot/generator/tecan_spec.rb
+++ b/spec/models/robot/generator/tecan_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe Robot::Generator::Tecan do
-  before { create(:full_plate) }
+  before do
+    create(:full_plate)
+    allow(batch).to receive(:buffer_volume_for_empty_wells).and_return(nil)
+  end
 
   shared_examples 'a generator' do
     describe '.as_text' do

--- a/spec/models/robot/generator/tecan_v3_spec.rb
+++ b/spec/models/robot/generator/tecan_v3_spec.rb
@@ -69,6 +69,11 @@ describe Robot::Generator::TecanV3 do
   # Expected output for the test cases.
   let(:expected_output) { File.read("spec/data/tecan_v3/case_#{case_num}.gwl") }
 
+  before do
+    allow(batch).to receive(:get_poly_metadata).with(:buffer_volume_for_empty_wells).and_return(nil)
+    allow(batch).to receive(:buffer_volume_for_empty_wells).and_return(nil)
+  end
+
   shared_examples 'a TecanV3 generator' do
     it 'generates the expected output' do
       expect(generator.as_text).to eq expected_output


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

An example implementation for Y25-680 - Automating Buffer Addition to Empty Wells During CP on the Tecan

- Add changes for generating screenshots
- Add changes for accepting the input 
- Add changes for worksheets
- Add changes for Tecan driver files

No tests are written for this. If the ideas are acceptable, one can continue with this PR or start a new.

For running it locally, see  Local setup in https://github.com/sanger/sequencescape/issues/5454#issuecomment-3928105718

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
