### PR TITLE
[ux] Add genders to internal accessioning validations

### DIFF
--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -142,17 +142,10 @@ class SamplesController < ApplicationController
     # @sample needs to be set before initially for use in the ensure block
     @sample = Sample.find(params[:id])
 
-    unless accessioning_enabled?
-      flash[:error] = 'Accessioning is not enabled in this environment'
-      redirect_to sample_path(@sample)
-      return
-    end
+    return accession_not_enabled unless accessioning_enabled?
+
     # TODO: Y26-026 - Enforce accessioning permissions
-    # unless permitted_to_accession?(@sample)
-    #   flash[:error] = 'Permission required to accession this sample'
-    #   redirect_to sample_path(@sample)
-    #   return
-    # end
+    # return not_permitted_to_accession unless permitted_to_accession?(@sample)
 
     # Must check if an accession number is assigned _before_ performing the accession
     accession_action = @sample.accession_number? ? :update : :create
@@ -160,18 +153,18 @@ class SamplesController < ApplicationController
     # Synchronously perform accessioning job
     Accession.accession_sample(@sample, current_user, perform_now: true)
 
-    if accession_action == :create
-      flash[:notice] = "Accession number generated: #{@sample.sample_metadata.sample_ebi_accession_number}"
-    elsif accession_action == :update
-      flash[:notice] = 'Accessioned metadata updated'
-    end
+    messages = {
+      create: "Accession number generated: #{@sample.ebi_accession_number}",
+      update: 'Accessioned metadata updated'
+    }
+    flash[:notice] = messages[accession_action]
 
     # Handle errors for both synchronous and asynchronous accessioning
   rescue Accession::InternalValidationError
     flash[:error] = @sample.errors.map(&:full_message).join(', ')
     redirect_to(edit_sample_path(@sample)) # send the user to edit the sample
   rescue Accession::ExternalValidationError => e
-    flash[:warning] = "No accession number was generated: #{e.message}"
+    flash[:error] = "No accession number was generated: #{e.message}"
   rescue Accession::Error => e
     flash[:error] = "Accessioning Service Failed: #{e.message}"
   rescue Faraday::Error => e
@@ -182,6 +175,17 @@ class SamplesController < ApplicationController
   end
 
   private
+
+  def accession_not_enabled
+    flash[:error] = 'Accessioning is not enabled in this environment'
+    redirect_to sample_path(@sample)
+  end
+
+  # TODO: Y26-026 - Enforce accessioning permissions
+  # def not_permitted_to_accession
+  #   flash[:error] = 'Permission required to accession this sample'
+  #   redirect_to sample_path(@sample)
+  # end
 
   # Redirect back to the referer with an anchor, or to a fallback location
   # Based closely on redirect_back_or_to

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -168,7 +168,7 @@ class SamplesController < ApplicationController
 
     # Handle errors for both synchronous and asynchronous accessioning
   rescue Accession::InternalValidationError
-    flash[:error] = "Please fill in the required fields: #{@sample.errors.full_messages.join(', ')}"
+    flash[:error] = @sample.errors.map(&:full_message).join(', ')
     redirect_to(edit_sample_path(@sample)) # send the user to edit the sample
   rescue Accession::ExternalValidationError => e
     flash[:warning] = "No accession number was generated: #{e.message}"

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -25,6 +25,7 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
 
   GC_CONTENTS = ['Neutral', 'High AT', 'High GC'].freeze
   GENDERS = ['Male', 'Female', 'Mixed', 'Hermaphrodite', 'Unknown', 'Not Applicable'].freeze
+  EGA_GENDERS = %w[Female Male Unknown].freeze
   DNA_SOURCES = [
     'Genomic',
     'Whole Genome Amplified',
@@ -193,7 +194,9 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
 
     with_options(on: :EGA) do
+      one_of_ega_genders = EGA_GENDERS.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ')
       validates :gender, presence: { message: 'is required' }
+      validates :gender, inclusion: { in: EGA_GENDERS, message: "must be #{one_of_ega_genders}" }
       validates :phenotype, presence: { message: 'is required' }
       validates :donor_id, presence: { message: 'is required' }
     end

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -194,7 +194,7 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
 
     with_options(on: :EGA) do
-      one_of_ega_genders = EGA_GENDERS.to_sentence(last_word_connector: ', or ', two_words_connector: ' or ').downcase
+      one_of_ega_genders = EGA_GENDERS.to_sentence(last_word_connector: ', or ', two_words_connector: ' or ')
       validates :gender, inclusion: { in: EGA_GENDERS, message: "must be #{one_of_ega_genders}" }
       validates :phenotype, presence: { message: 'is required' }
       validates :donor_id, presence: { message: 'is required' }

--- a/app/models/sample.rb
+++ b/app/models/sample.rb
@@ -194,8 +194,7 @@ class Sample < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
 
     with_options(on: :EGA) do
-      one_of_ega_genders = EGA_GENDERS.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ')
-      validates :gender, presence: { message: 'is required' }
+      one_of_ega_genders = EGA_GENDERS.to_sentence(last_word_connector: ', or ', two_words_connector: ' or ').downcase
       validates :gender, inclusion: { in: EGA_GENDERS, message: "must be #{one_of_ega_genders}" }
       validates :phenotype, presence: { message: 'is required' }
       validates :donor_id, presence: { message: 'is required' }

--- a/lib/accession/sample.rb
+++ b/lib/accession/sample.rb
@@ -125,12 +125,7 @@ module Accession
                    "does not have the required metadata: #{missing_accession_tags.sort.to_sentence.dasherize}.")
       end
 
-      service_context = service.ena? ? :ENA : :EGA
-      unless sample.valid?(service_context)
-        sample.sample_metadata.errors.each do |error|
-          errors.add(:sample, "Sample #{error.attribute} #{error.message}")
-        end
-      end
+      check_sample_for_service
     end
 
     def missing_accession_tags
@@ -142,6 +137,15 @@ module Accession
 
       if accessionable_study.nil?
         errors.add(:sample, 'can only be accessioned if linked to a releasable, accessioned study.')
+      end
+    end
+
+    def check_sample_for_service
+      service_context = service.ena? ? :ENA : :EGA
+      unless sample.valid?(service_context)
+        sample.sample_metadata.errors.each do |error|
+          errors.add(:sample, "Sample #{error.attribute} #{error.message}")
+        end
       end
     end
   end

--- a/lib/accession/sample.rb
+++ b/lib/accession/sample.rb
@@ -124,6 +124,13 @@ module Accession
         errors.add(:sample,
                    "does not have the required metadata: #{missing_accession_tags.sort.to_sentence.dasherize}.")
       end
+
+      service_context = service.ena? ? :ENA : :EGA
+      unless sample.valid?(service_context)
+        sample.sample_metadata.errors.each do |error|
+          errors.add(:sample, "Sample #{error.attribute} #{error.message}")
+        end
+      end
     end
 
     def missing_accession_tags

--- a/lib/accession/sample.rb
+++ b/lib/accession/sample.rb
@@ -61,7 +61,7 @@ module Accession
       invalid_fields = missing_accession_tags
       raise Accession::InvalidFieldsError.new(error_message.upcase_first, invalid_fields) if invalid_fields.present?
 
-      raise Accession::InternalValidationError error_message.upcase_first
+      raise Accession::InternalValidationError, error_message.upcase_first
     end
 
     def build_xml(xml) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength

--- a/lib/accession/sample.rb
+++ b/lib/accession/sample.rb
@@ -50,7 +50,7 @@ module Accession
       return if valid?
 
       # Add errors from the accession sample to the underlying sample for user feedback
-      @sample.errors.add(:base, errors.full_messages.join(', '))
+      @sample.errors.merge!(sample.errors)
 
       error_message = "cannot be accessioned: #{errors.full_messages.join(', ')}"
 
@@ -122,7 +122,7 @@ module Accession
 
       unless missing_accession_tags.empty?
         errors.add(:sample,
-                   "does not have the required metadata: #{missing_accession_tags.sort.to_sentence.dasherize}.")
+                   "does not have the required metadata: #{missing_accession_tags.sort.to_sentence.dasherize}")
       end
 
       check_sample_for_service
@@ -144,7 +144,8 @@ module Accession
       service_context = service.ena? ? :ENA : :EGA
       unless sample.valid?(service_context)
         sample.sample_metadata.errors.each do |error|
-          errors.add(:sample, "Sample #{error.attribute} #{error.message}")
+          # ignore the presence errors as they are already handled by missing_accession_tags
+          errors.add(:sample, "#{error.attribute} #{error.message}") unless error.type == :blank
         end
       end
     end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe SamplesController do
         it 'displays an error message indicating the validation failure' do
           expect(flash[:error]).to eq(<<~MSG.squish)
             Sample metadata is invalid,
-            Sample metadata gender must be female, male, or unknown,
+            Sample metadata gender must be Female, Male, or Unknown,
             Sample metadata phenotype is required,
             Sample metadata donor is required
           MSG

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -205,8 +205,10 @@ RSpec.describe SamplesController do
 
         it 'displays an error message indicating the validation failure' do
           expect(flash[:error]).to eq(<<~MSG.squish)
-            Please fill in the required fields:
-            Sample does not have the required metadata: donor, gender, and phenotype
+            Sample metadata is invalid,
+            Sample metadata gender must be female, male, or unknown,
+            Sample metadata phenotype is required,
+            Sample metadata donor is required
           MSG
         end
       end

--- a/spec/controllers/samples_controller_spec.rb
+++ b/spec/controllers/samples_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe SamplesController do
         it 'displays an error message indicating the validation failure' do
           expect(flash[:error]).to eq(<<~MSG.squish)
             Please fill in the required fields:
-            Sample does not have the required metadata: donor, gender, and phenotype.
+            Sample does not have the required metadata: donor, gender, and phenotype
           MSG
         end
       end

--- a/spec/controllers/studies_controller_spec.rb
+++ b/spec/controllers/studies_controller_spec.rb
@@ -325,7 +325,8 @@ RSpec.describe StudiesController do
             status: 'failed',
             message: 'Cannot be accessioned: ' \
                      'Sample does not have the required metadata: ' \
-                     'donor, gender, phenotype, sample common name, and sample taxon.'
+                     'donor, gender, phenotype, sample common name, and sample taxon, ' \
+                     'Sample gender must be female, male, or unknown'
           )
         end
       end

--- a/spec/controllers/studies_controller_spec.rb
+++ b/spec/controllers/studies_controller_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe StudiesController do
             message: 'Cannot be accessioned: ' \
                      'Sample does not have the required metadata: ' \
                      'donor, gender, phenotype, sample common name, and sample taxon, ' \
-                     'Sample gender must be female, male, or unknown'
+                     'Sample gender must be Female, Male, or Unknown'
           )
         end
       end

--- a/spec/jobs/sample_accessioning_job_spec.rb
+++ b/spec/jobs/sample_accessioning_job_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe SampleAccessioningJob do
           expect(sample_status).to have_attributes(
             status: 'failed',
             message: 'Cannot be accessioned: ' \
-                     'Sample does not have the required metadata: sample taxon.'
+                     'Sample does not have the required metadata: sample taxon'
           )
         end
 
@@ -63,7 +63,7 @@ RSpec.describe SampleAccessioningJob do
           expect(Rails.logger).to have_received(:warn).with(
             "SampleAccessioningJob failed for sample '#{sample.name}': " \
             'Cannot be accessioned: ' \
-            'Sample does not have the required metadata: sample taxon.'
+            'Sample does not have the required metadata: sample taxon'
           )
         end
 
@@ -85,7 +85,7 @@ RSpec.describe SampleAccessioningJob do
           it 'sends a notification to the API' do
             expect(notification_client).to have_received(:create_notification).with(
               sample,
-              'Cannot be accessioned: Sample does not have the required metadata: sample taxon.',
+              'Cannot be accessioned: Sample does not have the required metadata: sample taxon',
               ['Invalid sample taxon']
             )
           end

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -90,6 +90,55 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         expect(described_class.new(tag_list, sample)).not_to be_valid
       end
 
+      it 'can have a gender of Female' do
+        sample.sample_metadata.gender = 'Female'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'cannot have a leading space in gender' do
+        sample.sample_metadata.gender = ' Female'
+        expect(described_class.new(tag_list, sample)).not_to be_valid
+      end
+
+      it 'cannot have a trailing space in gender' do
+        sample.sample_metadata.gender = 'Female '
+        expect(described_class.new(tag_list, sample)).not_to be_valid
+      end
+
+      it 'can have a gender of Male' do
+        sample.sample_metadata.gender = 'Male'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'can have a gender of Unknown' do
+        sample.sample_metadata.gender = 'Unknown'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'cannot have a gender of Mixed' do
+        sample.sample_metadata.gender = 'Mixed'
+        expect(described_class.new(tag_list, sample)).not_to be_valid
+      end
+
+      it 'cannot have a gender of Hermaphrodite' do
+        sample.sample_metadata.gender = 'Hermaphrodite'
+        expect(described_class.new(tag_list, sample)).not_to be_valid
+      end
+
+      it 'cannot have a gender of Not Applicable' do
+        sample.sample_metadata.gender = 'Not Applicable'
+        expect(described_class.new(tag_list, sample)).not_to be_valid
+      end
+
+      it 'provides a clear error message about valid gender options' do
+        sample.sample_metadata.gender = 'Invalid Gender'
+        accession_sample = described_class.new(tag_list, sample)
+        accession_sample.validate
+        expect(accession_sample.errors[:sample]).to include(
+          'Sample gender must be Female, Male or Unknown'
+        )
+      end
+
       it 'is required to define phenotype' do
         sample.sample_metadata.phenotype = nil
         expect(described_class.new(tag_list, sample)).not_to be_valid

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         accession_sample = described_class.new(tag_list, sample)
         accession_sample.validate
         expect(accession_sample.errors[:sample]).to include(
-          'Sample gender must be Female, Male or Unknown'
+          'gender must be female, male, or unknown'
         )
       end
 

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -169,6 +169,32 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         expect(described_class.new(tag_list, sample)).not_to be_valid
       end
     end
+
+    context 'when sample has missing required fields' do
+      let(:sample) { create(:sample_for_accessioning_with_managed_study, sample_metadata:) }
+
+      it 'raises Accession::InvalidFieldsError with missing fields message' do
+        sample.sample_metadata.gender = nil
+        accession_sample = described_class.new(tag_list, sample)
+
+        expect { accession_sample.validate! }.to raise_error(Accession::InvalidFieldsError,
+          /Cannot be accessioned: Sample does not have the required metadata: gender/i
+        )
+      end
+    end
+
+    context 'when sample has validation errors unrelated to missing tags' do
+      let(:sample) { create(:sample_for_accessioning_with_managed_study, sample_metadata:) }
+
+      it 'raises Accession::InternalValidationError with validation error message' do
+        sample.sample_metadata.gender = 'Not Applicable'
+        accession_sample = described_class.new(tag_list, sample)
+
+        expect { accession_sample.validate! }.to raise_error(Accession::InternalValidationError,
+          /Cannot be accessioned: sample gender must be female, male, or unknown/i
+        )
+      end
+    end
   end
 
   describe '#service' do

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         accession_sample = described_class.new(tag_list, sample)
         accession_sample.validate
         expect(accession_sample.errors[:sample]).to include(
-          'gender must be female, male, or unknown'
+          'gender must be Female, Male, or Unknown'
         )
       end
 
@@ -192,7 +192,7 @@ RSpec.describe Accession::Sample, :accession, type: :model do
 
         expect { accession_sample.validate! }
           .to raise_error(Accession::InternalValidationError,
-                          /Cannot be accessioned: sample gender must be female, male, or unknown/i)
+                          /Cannot be accessioned: sample gender must be Female, Male, or Unknown/i)
       end
     end
   end

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -177,9 +177,9 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         sample.sample_metadata.gender = nil
         accession_sample = described_class.new(tag_list, sample)
 
-        expect { accession_sample.validate! }.to raise_error(Accession::InvalidFieldsError,
-          /Cannot be accessioned: Sample does not have the required metadata: gender/i
-        )
+        expect { accession_sample.validate! }
+          .to raise_error(Accession::InvalidFieldsError,
+                          /Cannot be accessioned: Sample does not have the required metadata: gender/i)
       end
     end
 
@@ -190,9 +190,9 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         sample.sample_metadata.gender = 'Not Applicable'
         accession_sample = described_class.new(tag_list, sample)
 
-        expect { accession_sample.validate! }.to raise_error(Accession::InternalValidationError,
-          /Cannot be accessioned: sample gender must be female, male, or unknown/i
-        )
+        expect { accession_sample.validate! }
+          .to raise_error(Accession::InternalValidationError,
+                          /Cannot be accessioned: sample gender must be female, male, or unknown/i)
       end
     end
   end

--- a/spec/lib/accession/sample_spec.rb
+++ b/spec/lib/accession/sample_spec.rb
@@ -70,6 +70,26 @@ RSpec.describe Accession::Sample, :accession, type: :model do
         sample.sample_metadata.sample_common_name = nil
         expect(described_class.new(tag_list, sample)).not_to be_valid
       end
+
+      it 'is not required to define gender' do
+        sample.sample_metadata.gender = nil
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'can have a gender of Female' do
+        sample.sample_metadata.gender = 'Female'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'can have a gender of Male' do
+        sample.sample_metadata.gender = 'Male'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
+
+      it 'can have a gender of Not Applicable' do
+        sample.sample_metadata.gender = 'Not Applicable'
+        expect(described_class.new(tag_list, sample)).to be_valid
+      end
     end
 
     context 'with a managed study' do

--- a/spec/lib/accession/submission_spec.rb
+++ b/spec/lib/accession/submission_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Accession::Submission, :accession, type: :model do
       allow(described_class).to receive(:client).and_return(mock_client)
     end
 
-    context 'when th sample has not yet been accessioned' do
+    context 'when the sample has not yet been accessioned' do
       context 'when the submission is successful' do
         let(:accession_number) { 'EGA00001000240' }
         let(:mock_client) do

--- a/spec/lib/accession_spec.rb
+++ b/spec/lib/accession_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe Accession do
     context 'when accessioning is enabled', :accessioning_enabled, :un_delay_jobs do
       let(:event_user) { create(:user) }
 
-      context 'when sample fails internal validation' do
-        let(:sample_metadata) { create(:sample_metadata_for_accessioning, sample_taxon_id: nil) }
+      context 'when sample fails internal validation for a single reason' do
+        let(:sample_taxon_id) { nil }
+        let(:sample_metadata) { create(:sample_metadata_for_accessioning, sample_taxon_id:) }
         let(:invalid_sample) { create(:sample_for_accessioning_with_open_study, sample_metadata:) }
 
         it 'raises an error with debug information' do # rubocop:disable RSpec/MultipleExpectations
@@ -29,8 +30,25 @@ RSpec.describe Accession do
           expect_accession.to raise_error(Accession::InternalValidationError) do |error|
             expect(error.message).to eq(
               'Cannot be accessioned: ' \
-              'Sample does not have the required metadata: sample taxon., ' \
-              'Sample Sample sample_taxon_id is required'
+              'Sample does not have the required metadata: sample taxon'
+            )
+          end
+        end
+      end
+
+      context 'when sample fails internal validation for multiple reasons' do
+        let(:sample_taxon_id) { nil }
+        let(:gender) { 'Not Applicable' }
+        let(:sample_metadata) { create(:sample_metadata_for_accessioning, sample_taxon_id:, gender:) }
+        let(:invalid_sample) { create(:sample_for_accessioning_with_managed_study, sample_metadata:) }
+
+        it 'raises an error with debug information' do # rubocop:disable RSpec/MultipleExpectations
+          expect_accession = expect { described_class.accession_sample(invalid_sample, event_user) }
+          expect_accession.to raise_error(Accession::InternalValidationError) do |error|
+            expect(error.message).to eq(
+              'Cannot be accessioned: ' \
+              'Sample does not have the required metadata: sample taxon, ' \
+              'Sample gender must be female, male, or unknown'
             )
           end
         end

--- a/spec/lib/accession_spec.rb
+++ b/spec/lib/accession_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Accession do
             expect(error.message).to eq(
               'Cannot be accessioned: ' \
               'Sample does not have the required metadata: sample taxon, ' \
-              'Sample gender must be female, male, or unknown'
+              'Sample gender must be Female, Male, or Unknown'
             )
           end
         end

--- a/spec/lib/accession_spec.rb
+++ b/spec/lib/accession_spec.rb
@@ -20,16 +20,17 @@ RSpec.describe Accession do
     context 'when accessioning is enabled', :accessioning_enabled, :un_delay_jobs do
       let(:event_user) { create(:user) }
 
-      context 'when sample fails fields validation' do
+      context 'when sample fails internal validation' do
         let(:sample_metadata) { create(:sample_metadata_for_accessioning, sample_taxon_id: nil) }
         let(:invalid_sample) { create(:sample_for_accessioning_with_open_study, sample_metadata:) }
 
         it 'raises an error with debug information' do # rubocop:disable RSpec/MultipleExpectations
           expect_accession = expect { described_class.accession_sample(invalid_sample, event_user) }
-          expect_accession.to raise_error(Accession::InvalidFieldsError) do |error|
+          expect_accession.to raise_error(Accession::InternalValidationError) do |error|
             expect(error.message).to eq(
               'Cannot be accessioned: ' \
-              'Sample does not have the required metadata: sample taxon.'
+              'Sample does not have the required metadata: sample taxon., ' \
+              'Sample Sample sample_taxon_id is required'
             )
           end
         end


### PR DESCRIPTION
Addresses external validation errors like:
```
Sample: 61609112-fdcd-11f0-80eb-0242eb1badd5; Attribute: gender; Reason: must be equal to one of the allowed values: ["female","male","unknown"]; Failed to submit samples to BioSamples; No new BioSample was created for sample with alias 61609112-fdcd-11f0-80eb-0242eb1badd5
```

And prevents repeated accessioning notifications.

#### Changes proposed in this pull request

- Adds known-EGA-restricted genders: `EGA_GENDERS = %w[Female Male Unknown]`
- Validates their inclusion for EGA accessioned samples
- Should raise `Accession::InternalValidationError` instead of `Accession::ExternalValidationError` allowing faster validation and correction
- Reduces verbosity of accessioning validation error messages

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
