### PR TITLE
[dev] Include study names in accession error messages

### DIFF
--- a/app/jobs/sample_accessioning_job.rb
+++ b/app/jobs/sample_accessioning_job.rb
@@ -120,9 +120,11 @@ SampleAccessioningJob =
     def notify_developers(error, submission) # rubocop:disable Metrics/CyclomaticComplexity
       sample_name = submission.sample.sample.name
       message = "SampleAccessioningJob failed for sample '#{sample_name}': #{error.message}"
+      study_names = submission.sample.sample.studies_for_accessioning.map(&:name).join(', ')
       data = {
         message: message,
         sample_name: sample_name,
+        study_names: study_names,
         service_provider: submission.service&.provider.to_s,
         user: event_user&.login
       }

--- a/spec/jobs/sample_accessioning_job_spec.rb
+++ b/spec/jobs/sample_accessioning_job_spec.rb
@@ -6,8 +6,11 @@ require 'rails_helper'
 RSpec.describe SampleAccessioningJob do
   include AccessionV1ClientHelper
 
+  let(:first_open_study) { create(:open_study, accession_number: 'ENA123') }
+  let(:second_open_study) { create(:open_study, accession_number: 'ENA124') }
+  let(:studies) { [first_open_study, second_open_study] }
   let(:sample_metadata) { create(:sample_metadata_for_accessioning) }
-  let(:sample) { create(:sample_for_accessioning_with_open_study, sample_metadata:) }
+  let(:sample) { create(:sample_for_accessioning, sample_metadata:, studies:) }
   let(:accessionable) { create(:accession_sample, sample:) }
   let(:job) { described_class.new(accessionable) }
 
@@ -79,6 +82,7 @@ RSpec.describe SampleAccessioningJob do
                          "Sample '#{sample_name}' cannot be accessioned: " \
                          'Sample does not have the required metadata: sample-taxon-id.',
                 sample_name: sample_name,
+                study_names: "#{first_open_study.name}, #{second_open_study.name}",
                 service_provider: 'ENA',
                 user: nil
               }
@@ -166,6 +170,7 @@ RSpec.describe SampleAccessioningJob do
               message: "SampleAccessioningJob failed for sample '#{sample.name}': " \
                        'Failed to process accessioning response',
               sample_name: sample.name, # 'Sample 1',
+              study_names: "#{first_open_study.name}, #{second_open_study.name}",
               service_provider: 'ENA',
               user: nil
             }

--- a/spec/lib/accession_spec.rb
+++ b/spec/lib/accession_spec.rb
@@ -132,11 +132,13 @@ RSpec.describe Accession do
               end
 
               sample_name = accessionable_sample.name # 'Sample1'
+              study_name = accessionable_sample.studies.first.name # 'Study1: Open'
               expect(ExceptionNotifier).to have_received(:notify_exception)
                 .with(instance_of(Accession::ExternalValidationError),
                       data: { message: "SampleAccessioningJob failed for sample '#{sample_name}': " \
                                        'Failed to process accessioning response',
                               sample_name: sample_name,
+                              study_names: study_name,
                               service_provider: 'ENA',
                               user: event_user.login })
             end


### PR DESCRIPTION
Provide more helpful detail in accession error messages to aid immediate triage.

#### Changes proposed in this pull request

- Add the study names for a sample in the accession exception notification:
  ```
  {
    message: "SampleAccessioningJob failed for sample 'Sample1': Sample 'Sample1' cannot be accessioned: Sample does not have the required metadata: sample-taxon-id.",
    sample_name: "Sample1",
    service_provider: "ENA",
    study_names: "Study1: Open, Study2: Open",
    user: nil
  }
  ```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
