### PR TITLE
[ux] Limit of 10 messages per manifest upload

### DIFF
--- a/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
+++ b/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
@@ -43,15 +43,13 @@ class SampleManifestUploadWithTagSequencesController < ApplicationController
   def apply_warning_flash(rows) # rubocop:disable Metrics/AbcSize
     # There are more than 10 messages, truncate the list and add a note about it.
     # This is to prevent the flash from becoming too large and causing issues with cookies.
-    if rows.size > 10
+    row_messages = rows.flat_map { |row| row.warnings.full_messages }.uniq
+    if row_messages.size > 10
       # IfUnlessModifier doesn't improve readability
-      rows = rows.first(10) + ["and #{rows.size - 10} more..."]
+      row_messages = row_messages.first(10) + ["and #{row_messages.size - 10} more..."]
     end
 
-    flash[:warning] = {
-      'Sample manifest uploaded with warnings!':
-        rows.flat_map { |row| row.warnings.full_messages }.uniq
-    }
+    flash[:warning] = { 'Sample manifest uploaded with warnings!': row_messages }
 
     redirect_target = (@uploader.study.present? ? sample_manifests_study_path(@uploader.study) : sample_manifests_path)
     redirect_to redirect_target

--- a/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
+++ b/app/controllers/sample_manifest_upload_with_tag_sequences_controller.rb
@@ -40,7 +40,14 @@ class SampleManifestUploadWithTagSequencesController < ApplicationController
     end
   end
 
-  def apply_warning_flash(rows)
+  def apply_warning_flash(rows) # rubocop:disable Metrics/AbcSize
+    # There are more than 10 messages, truncate the list and add a note about it.
+    # This is to prevent the flash from becoming too large and causing issues with cookies.
+    if rows.size > 10
+      # IfUnlessModifier doesn't improve readability
+      rows = rows.first(10) + ["and #{rows.size - 10} more..."]
+    end
+
     flash[:warning] = {
       'Sample manifest uploaded with warnings!':
         rows.flat_map { |row| row.warnings.full_messages }.uniq

--- a/spec/controllers/sample_manifest_upload_with_tag_sequences_controller_spec.rb
+++ b/spec/controllers/sample_manifest_upload_with_tag_sequences_controller_spec.rb
@@ -68,6 +68,47 @@ RSpec.describe SampleManifestUploadWithTagSequencesController do
       end
     end
 
+    context 'when the upload succeeds with more than 10 warnings' do
+      let(:warning_rows) do
+        (1..12).map do |i|
+          double(warnings: double(full_messages: ["Row #{i} warning"]))
+        end
+      end
+
+      before do
+        allow(controller).to receive(:upload_manifest) do
+          controller.instance_variable_set(:@uploader, uploader)
+          true
+        end
+        allow(controller).to receive(:rows_with_warnings).and_return(warning_rows)
+        post :create, params: { upload: upload_file }
+      end
+
+      it 'sets warning flash message' do
+        expect(flash[:warning]).to eq(
+          {
+            'Sample manifest uploaded with warnings!': [
+              'Row 1 warning',
+              'Row 2 warning',
+              'Row 3 warning',
+              'Row 4 warning',
+              'Row 5 warning',
+              'Row 6 warning',
+              'Row 7 warning',
+              'Row 8 warning',
+              'Row 9 warning',
+              'Row 10 warning',
+              'and 2 more...'
+            ]
+          }
+        )
+      end
+
+      it 'redirects correctly' do
+        expect(response).to redirect_to(sample_manifests_path)
+      end
+    end
+
     context 'when the upload fails due to invalid data' do
       before do
         allow(uploader).to receive(:run!).and_raise(AccessionService::AccessionValidationFailed, 'Invalid data')


### PR DESCRIPTION
Fix for [#INC-59595](https://sanger.freshservice.com/a/tickets/59595?current_tab=details)

#### Changes proposed in this pull request

- Limit messages arising in manifest uploads


#### Screenshot

<img width="600" alt="Screenshot 2026-04-01 at 16 37 24" src="https://github.com/user-attachments/assets/634a9975-18ce-4862-acda-f011797b5707" />


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
