### PR TITLE
fix(labwhere-client): handle request timeouts

### DIFF
--- a/lib/lab_where_client.rb
+++ b/lib/lab_where_client.rb
@@ -26,13 +26,13 @@ module LabWhereClient
 
     def get(instance, target)
       parse_json(RestClient.get(path_to(instance, target)))
-    rescue Errno::ECONNREFUSED, RestClient::NotFound => e
+    rescue Errno::ECONNREFUSED, RestClient::NotFound, RestClient::RequestTimeout => e
       raise LabwhereException.new(e), 'LabWhere service is down', e.backtrace
     end
 
     def post(instance, target, payload)
       parse_json(RestClient.post(path_to(instance, target), payload))
-    rescue Errno::ECONNREFUSED, RestClient::NotFound => e
+    rescue Errno::ECONNREFUSED, RestClient::NotFound, RestClient::RequestTimeout => e
       raise LabwhereException.new(e), 'LabWhere service is down', e.backtrace
     rescue RestClient::UnprocessableEntity => e
       parse_json(e.response)
@@ -40,7 +40,7 @@ module LabWhereClient
 
     def put(instance, target, payload)
       parse_json(RestClient.put(path_to(instance, target), payload))
-    rescue Errno::ECONNREFUSED, RestClient::NotFound => e
+    rescue Errno::ECONNREFUSED, RestClient::NotFound, RestClient::RequestTimeout => e
       raise LabwhereException.new(e), 'LabWhere service is down', e.backtrace
     end
   end

--- a/spec/lib/lab_where_client_spec.rb
+++ b/spec/lib/lab_where_client_spec.rb
@@ -4,6 +4,10 @@ require 'lab_where_client'
 
 RSpec.describe LabWhereClient do
   describe LabWhereClient::Scan do
+    before { configatron.labwhere_api = 'https://labwhere.example.com/api' }
+    # Reset the configatron value after the test to avoid affecting other tests
+    after { configatron.labwhere_api = nil }
+
     let(:scan_params) { { 'message' => 'Scan successful', 'errors' => nil } }
     let(:scan) { described_class.new(scan_params) }
 
@@ -41,10 +45,26 @@ RSpec.describe LabWhereClient do
         )
       end
 
-      it 'raises an error when Labwhere is down' do
-        labwhere = instance_double(LabWhereClient::LabWhere)
-        allow(LabWhereClient::LabWhere).to receive(:new).and_return(labwhere)
-        allow(labwhere).to receive(:post).and_raise(LabWhereClient::LabwhereException.new, 'LabWhere service is down')
+      it 'propagates labwhere errors when receieving unprocessible entity errors' do
+        error_response = RestClient::UnprocessableEntity.new
+        allow(error_response).to receive(:response).and_return({ errors: 'Invalid data' }.to_json)
+        allow(RestClient).to receive(:post).and_raise(error_response)
+
+        scan = described_class.create(location_barcode: '123', user_code: '456', labware_barcodes: ['789'])
+        expect(scan.valid?).to be false
+        expect(scan.errors).to eq('Invalid data')
+      end
+
+      it 'raises an error when Labwhere is unreachable' do
+        allow(RestClient).to receive(:post).and_raise(Errno::ECONNREFUSED)
+
+        expect do
+          described_class.create(location_barcode: '123', user_code: '456', labware_barcodes: ['789'])
+        end.to raise_error(LabWhereClient::LabwhereException, 'LabWhere service is down')
+      end
+
+      it 'raises an error on other rest client error types' do
+        allow(RestClient).to receive(:post).and_raise(RestClient::Exceptions::OpenTimeout)
 
         expect do
           described_class.create(location_barcode: '123', user_code: '456', labware_barcodes: ['789'])


### PR DESCRIPTION
Closes #5685

#### Changes proposed in this pull request

- Handle request timeouts to prevent 500 errors when labwhere is unresponsive.
