### PR TITLE
Y26-105 [PR] feature flag for descriptor required

### DIFF
--- a/app/models/descriptor.rb
+++ b/app/models/descriptor.rb
@@ -17,9 +17,11 @@ class Descriptor < ApplicationRecord
 
   # Returns an array of validation errors for the submitted descriptor value.
   # The value comes from the Task Details form for a workflow task on a batch.
-  # @return [Array] An array of error messages, empty if the value is valid
+  # @return [Array<String>] An array of error messages, empty if the value is valid
   def validate_value(submitted_value)
-    return ["#{name} is required"] if submitted_value.blank? && is_required?
+    if is_required? && submitted_value.blank? && Flipper.enabled?(:y25_105_validate_descriptor_required_field)
+      return ["#{name} is required"]
+    end
     return [] if submitted_value.blank?
     return validate_date_value(submitted_value) if kind == 'Date'
 
@@ -30,7 +32,7 @@ class Descriptor < ApplicationRecord
 
   # Validates that the submitted value is a valid date string in the format
   # YYYY-MM-DD, and that the year is within a reasonable range.
-  # @return [Array] An array of error messages, empty if the value is valid
+  # @return [Array<String>] An array of error messages, empty if the value is valid
   def validate_date_value(submitted_value)
     unless submitted_value.match?(/\A\d{4}-\d{2}-\d{2}\z/)
       return ["'#{submitted_value}' is not a valid date for #{name} (expected YYYY-MM-DD)"]

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -9,9 +9,10 @@ y24_052_enable_data_release_timing_validation: Enables server-side validation th
 
 y25_442_make_api_key_mandatory: Makes API key mandatory for all API requests
 
+y25_105_validate_descriptor_required_field: Enables validation of batch workflow task descriptor required field
+
 # Accessioning
 y25_706_enable_accessioning: Enables the accessioning feature in the application
 y25_714_skip_accessioning_tag_validation: Skips internal validation of accessioning tags prior to sample accessioning
 y25_705_notify_on_internal_accessioning_validation_failures: Sends email to developers when internal validation fails during accessioning
 y25_705_notify_on_external_accessioning_validation_failures: Sends email to developers when external validation fails during accessioning
-y25_105_validate_descriptor_required_field: Enables validation of batch workflow task descriptor required field

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -14,3 +14,4 @@ y25_706_enable_accessioning: Enables the accessioning feature in the application
 y25_714_skip_accessioning_tag_validation: Skips internal validation of accessioning tags prior to sample accessioning
 y25_705_notify_on_internal_accessioning_validation_failures: Sends email to developers when internal validation fails during accessioning
 y25_705_notify_on_external_accessioning_validation_failures: Sends email to developers when external validation fails during accessioning
+y25_105_validate_descriptor_required_field: Enables validation of batch workflow task descriptor required field

--- a/spec/models/descriptor_spec.rb
+++ b/spec/models/descriptor_spec.rb
@@ -6,9 +6,16 @@ RSpec.describe Descriptor do
   describe '#validate_value' do
     subject(:errors) { descriptor.validate_value(value) }
 
+    let(:feature) { :y25_105_validate_descriptor_required_field }
+
+    before do
+      # By default, disable the feature flag
+      allow(Flipper).to receive(:enabled?).with(feature).and_return(false)
+    end
+
     context 'when kind is Date' do
       context 'when required is true' do
-        let(:descriptor) { described_class.new(name: 'OTR carrier expiry', kind: 'Date', required: true) }
+        let(:descriptor) { described_class.new(name: 'Some expiry', kind: 'Date', required: true) }
 
         context 'with a valid ISO 8601 date' do
           let(:value) { '2026-06-01' }
@@ -19,7 +26,21 @@ RSpec.describe Descriptor do
         context 'with a blank value' do
           let(:value) { '' }
 
-          it { is_expected.to contain_exactly('OTR carrier expiry is required') }
+          context 'when the feature flag is enabled' do
+            before do
+              allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+            end
+
+            it { is_expected.to contain_exactly('Some expiry is required') }
+          end
+
+          context 'when the feature flag is disabled' do
+            before do
+              allow(Flipper).to receive(:enabled?).with(feature).and_return(false)
+            end
+
+            it { is_expected.to be_empty }
+          end
         end
 
         context 'with an invalid date string' do
@@ -27,7 +48,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              "'not-a-date' is not a valid date for OTR carrier expiry (expected YYYY-MM-DD)"
+              "'not-a-date' is not a valid date for Some expiry (expected YYYY-MM-DD)"
             )
           }
         end
@@ -37,7 +58,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              "'01/06/2026' is not a valid date for OTR carrier expiry (expected YYYY-MM-DD)"
+              "'01/06/2026' is not a valid date for Some expiry (expected YYYY-MM-DD)"
             )
           }
         end
@@ -47,7 +68,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              'Date year for OTR carrier expiry must be between 1990 and 2100 (got 1989)'
+              'Date year for Some expiry must be between 1990 and 2100 (got 1989)'
             )
           }
         end
@@ -57,7 +78,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              'Date year for OTR carrier expiry must be between 1990 and 2100 (got 2101)'
+              'Date year for Some expiry must be between 1990 and 2100 (got 2101)'
             )
           }
         end
@@ -67,14 +88,14 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              "'62026-06-01' is not a valid date for OTR carrier expiry (expected YYYY-MM-DD)"
+              "'62026-06-01' is not a valid date for Some expiry (expected YYYY-MM-DD)"
             )
           }
         end
       end
 
       context 'when required is false' do
-        let(:descriptor) { described_class.new(name: 'OTR carrier expiry', kind: 'Date', required: false) }
+        let(:descriptor) { described_class.new(name: 'Some expiry', kind: 'Date', required: false) }
 
         context 'with a blank value' do
           let(:value) { '' }
@@ -93,7 +114,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              "'not-a-date' is not a valid date for OTR carrier expiry (expected YYYY-MM-DD)"
+              "'not-a-date' is not a valid date for Some expiry (expected YYYY-MM-DD)"
             )
           }
         end
@@ -103,7 +124,7 @@ RSpec.describe Descriptor do
 
           it {
             is_expected.to contain_exactly(
-              "'62026-06-01' is not a valid date for OTR carrier expiry (expected YYYY-MM-DD)"
+              "'62026-06-01' is not a valid date for Some expiry (expected YYYY-MM-DD)"
             )
           }
         end

--- a/spec/models/descriptor_spec.rb
+++ b/spec/models/descriptor_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Descriptor do
   describe '#validate_value' do
     subject(:errors) { descriptor.validate_value(value) }
 
-    let(:feature) { :y25_105_validate_descriptor_required_field }
+    let(:feature_flag) { :y25_105_validate_descriptor_required_field }
 
     before do
       # By default, disable the feature flag
-      allow(Flipper).to receive(:enabled?).with(feature).and_return(false)
+      allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(false)
     end
 
     context 'when kind is Date' do
@@ -28,7 +28,7 @@ RSpec.describe Descriptor do
 
           context 'when the feature flag is enabled' do
             before do
-              allow(Flipper).to receive(:enabled?).with(feature).and_return(true)
+              allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(true)
             end
 
             it { is_expected.to contain_exactly('Some expiry is required') }
@@ -36,7 +36,7 @@ RSpec.describe Descriptor do
 
           context 'when the feature flag is disabled' do
             before do
-              allow(Flipper).to receive(:enabled?).with(feature).and_return(false)
+              allow(Flipper).to receive(:enabled?).with(feature_flag).and_return(false)
             end
 
             it { is_expected.to be_empty }


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Adds the feature flag to enable the validation of the required field on the submitted values of batch workflow task descriptors: y25_105_validate_descriptor_required_field

Note that descriptors define what parameters should be rendered dynamically in task details forms of batches.They have a required field but it was never enforced historically; it just rendered a * (yellow star) in the label using CSS if required is set true in record loader files.

Recently, we have added a simple validation on the date fields and enable validation of the required field as well. See Story: https://github.com/sanger/General-Backlog-Items/issues/715 . This PR is attaches a feature flag for the required field to avoid breaking the existing behaviour and allows contacting stakeholders for discussion of whether to enforce the validation of such fields or not.

Test descriptor label changes are to avoid confusion in case a real descriptor was defined differently in the record files. I have used a generic name instead (Some expiry).

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
