### PR TITLE
ci: only run test ci on push on develop/master

### DIFF
--- a/.github/workflows/cucumber_tests.yml
+++ b/.github/workflows/cucumber_tests.yml
@@ -17,6 +17,9 @@ env:
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
     types:
       # defaults

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
     types:
       # defaults

--- a/.github/workflows/rake_tests.yml
+++ b/.github/workflows/rake_tests.yml
@@ -14,6 +14,9 @@ env:
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
     types:
       # defaults

--- a/.github/workflows/rspec_feature_tests.yml
+++ b/.github/workflows/rspec_feature_tests.yml
@@ -17,6 +17,9 @@ env:
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
     types:
       # defaults

--- a/.github/workflows/rspec_unit_tests.yml
+++ b/.github/workflows/rspec_unit_tests.yml
@@ -17,6 +17,9 @@ env:
 
 on:
   push:
+    branches:
+      - develop
+      - master
   pull_request:
     types:
       # defaults

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,8 @@
 codecov:
   notify:
     # do not notify until at least n builds have been uploaded from the CI pipeline
-    # rake_tests (push)
     # rake_tests (pull_request)
-    # rspec_unit_tests x4 (push)
     # rspec_unit_tests x4 (pull_request)
-    # rspec_feature_tests x2 (push)
     # rspec_feature_tests x2 (pull_request)
-    # cucumber_tests x2 (push)
     # cucumber_tests x2 (pull_request)
-    after_n_builds: 18
+    after_n_builds: 9


### PR DESCRIPTION
#### Changes proposed in this pull request

- Prevents running CI on every non trunk push.
    - This will prevent duplicate actions running when we push and have a PR open. (half our CI usage for SS)
