### PR TITLE
Y26-140 [PR] Assign adapter type for tag set

### DIFF
--- a/lib/record_loader/tag_group_loader.rb
+++ b/lib/record_loader/tag_group_loader.rb
@@ -6,20 +6,76 @@
 # across different environments
 # @see https://rubydoc.info/github/sanger/record_loader/
 module RecordLoader
-  # Creates the specified tag groups if they are not present
+  # Creates or updates the specified tag groups.
   class TagGroupLoader < ApplicationRecordLoader
     config_folder 'tag_groups'
 
-    def create_or_update!(name, options)
-      tags = options.delete('tags') || []
-
+    # Creates or updates a TagGroup with the given section name and options.
+    # - If the name for the TagGroup is not provided in options, it defaults to
+    #   the YAML section name, which must be unique in config_folder.
+    # - If the TagGroup does not have tags, it creates the associated tags based
+    #   on the provided options.
+    # - If the TagGroup exists and has a different adapter_type_id, it updates
+    #   the adapter_type_id using the adapter_type_name provided in options.
+    #
+    # @param section_name [String] The default name for the TagGroup if not provided in options.
+    # @param options [Hash] The attributes for the TagGroup.
+    # @return [TagGroup] The found or newly created TagGroup record.
+    # @raise [ActiveRecord::RecordInvalid] if creation or update fails validation.
+    def create_or_update!(section_name, options)
+      options['name'] ||= section_name
+      resolve_adapter_type_id!(options)
       TagGroup
-        .create_with(options)
-        .find_or_create_by!(name:)
+        .create_with(options.except('tags'))
+        .find_or_create_by!(name: options['name'])
         .tap do |tag_group|
-          tag_attributes = tags.map { |map_id, oligo| { map_id:, oligo: } }
-          tag_group.tags.import(tag_attributes) if tag_group.tags.empty?
+          create_tags(tag_group, options)
+          update_adapter_type_id!(tag_group, options)
         end
+    end
+
+    private
+
+    # Resolves the adapter_type_id for the TagGroup based on the provided
+    # adapter_type_name in options. It deletes the adapter_type_name from
+    # options and adds the corresponding adapter_type_id.
+    #
+    # @param options [Hash] The options hash containing 'adapter_type_name' key.
+    # @return [void]
+    def resolve_adapter_type_id!(options)
+      adapter_type_name = options.delete('adapter_type_name')
+      return unless adapter_type_name
+
+      adapter_type = TagGroup::AdapterType.find_by!(name: adapter_type_name)
+      options['adapter_type_id'] = adapter_type.id
+    end
+
+    # Creates tags for the given TagGroup based on the provided options if the
+    # TagGroup does not already have tags. It expects the options to contain a
+    # 'tags' hash where the keys are map_ids and the values are oligo sequences.
+    #
+    # @param tag_group [TagGroup] The TagGroup for which to create tags.
+    # @param options [Hash] The options hash containing 'tags' key.
+    # @return [void]
+    def create_tags(tag_group, options)
+      return unless tag_group.tags.empty?
+
+      tags = options['tags'] || []
+      tag_attributes = tags.map { |map_id, oligo| { map_id:, oligo: } }
+      tag_group.tags.import(tag_attributes)
+    end
+
+    # Updates the adapter_type_id of the TagGroup if it differs from the
+    # adapter_type_id in options. It expects options to contain an
+    # 'adapter_type_id' key, resolved from 'adapter_type_name'.
+    #
+    # @param tag_group [TagGroup] The TagGroup to update.
+    # @param options [Hash] The options hash containing 'adapter_type_id' key.
+    # @return [void]
+    def update_adapter_type_id!(tag_group, options)
+      return if options['adapter_type_id'] == tag_group.adapter_type_id
+
+      tag_group.update!(adapter_type_id: options['adapter_type_id'])
     end
   end
 end

--- a/lib/tasks/record_loader/tag_set.rake
+++ b/lib/tasks/record_loader/tag_set.rake
@@ -3,7 +3,7 @@
 # This file was automatically generated via `rails g record_loader`
 namespace :record_loader do
   desc 'Automatically generate TagSet through TagSetLoader'
-  task tag_set: :environment do
+  task tag_set: [:environment, 'record_loader:tag_group'] do
     RecordLoader::TagSetLoader.new.create!
   end
 end

--- a/spec/lib/record_loader/tag_group_loader_spec.rb
+++ b/spec/lib/record_loader/tag_group_loader_spec.rb
@@ -40,4 +40,70 @@ RSpec.describe RecordLoader::TagGroupLoader, :loader, type: :model do
       expect(TagGroup.first).to have_attributes(expected_attributes)
     end
   end
+
+  describe '#create_or_update!' do
+    let(:adapter_type) { create(:adapter_type) }
+    let(:other_adapter_type) { create(:adapter_type) }
+    let(:section_name) { 'TestGroup' }
+    let(:tags) { { 1 => 'ATCG', 2 => 'GCTA' } }
+    let(:loader) { described_class.new }
+
+    it 'sets the TagGroup name to section_name if not provided in options' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect(tag_group.name).to eq(section_name)
+    end
+
+    it 'uses the name from options if provided' do
+      options = { 'name' => 'CustomName', 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect(tag_group.name).to eq('CustomName')
+    end
+
+    it 'assigns the correct adapter_type' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect(tag_group.adapter_type).to eq(adapter_type)
+    end
+
+    it 'creates the correct number of tags' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect(tag_group.tags.count).to eq(2)
+    end
+
+    it 'creates tags with the correct oligos' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect(tag_group.tags.pluck(:oligo)).to match_array(%w[ATCG GCTA])
+    end
+
+    it 'does not duplicate tags if already present' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect do
+        loader.create_or_update!(section_name, options)
+      end.not_to(change { tag_group.tags.count })
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'updates adapter_type_id if different' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      # Now update to a different adapter_type
+      options = { 'adapter_type_name' => other_adapter_type.name }
+      loader.create_or_update!(section_name, options)
+      tag_group.reload
+      expect(tag_group.adapter_type).to eq(other_adapter_type)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'does nothing if adapter_type_id is the same' do
+      options = { 'tags' => tags, 'adapter_type_name' => adapter_type.name }
+      tag_group = loader.create_or_update!(section_name, options)
+      expect do
+        loader.create_or_update!(section_name, options)
+      end.not_to(change { tag_group.reload.adapter_type_id })
+    end
+  end
 end


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Allow adapter_type_id of tag groups to be updated via record loader to satisfy the validation requiring both tag_groups in a tag set to have the same adapter_type_id. Note that adapter_type_id is used only for filtering tag groups and tag sets in SS and Limber.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
