### PR TITLE
Y25-483 - Add stamp_index attribute to API v2 Qcable

### DIFF
--- a/app/resources/api/v2/qcable_resource.rb
+++ b/app/resources/api/v2/qcable_resource.rb
@@ -76,7 +76,7 @@ module Api
 
       # @!attribute [r] stamp_index
       #   @return [Integer] the index of this {Qcable} in the {Lot} it is associated with, if any.
-      attribute :stamp_index
+      attribute :stamp_index, readonly: true
 
       # @!attribute [r] state
       #   @return [String] a string representation of the state this {Qcable} is in.

--- a/app/resources/api/v2/qcable_resource.rb
+++ b/app/resources/api/v2/qcable_resource.rb
@@ -74,6 +74,10 @@ module Api
         }
       end
 
+      # @!attribute [r] stamp_index
+      #   @return [Integer] the index of this {Qcable} in the {Lot} it is associated with, if any.
+      attribute :stamp_index
+
       # @!attribute [r] state
       #   @return [String] a string representation of the state this {Qcable} is in.
       #     The state is changed by a state machine via events that occur as the {Qcable} is processed.

--- a/spec/resources/api/v2/qcable_resource_spec.rb
+++ b/spec/resources/api/v2/qcable_resource_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Api::V2::QcableResource, type: :resource do
 
   # Attributes
   it { is_expected.to have_readonly_attribute :labware_barcode }
+  it { is_expected.to have_readonly_attribute :stamp_index }
   it { is_expected.to have_readonly_attribute :state }
   it { is_expected.to have_readonly_attribute :uuid }
 


### PR DESCRIPTION
Fixes deployment bug encountered with the [latest Gatekeeper release](https://github.com/sanger/gatekeeper/pull/661). 

#### Changes proposed in this pull request

- Add `stamp_index` attribute to API v2 `Qcable`
- Add test 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
