### PR TITLE
feat(aviti): adds additional option for quant_method_used

### DIFF
--- a/config/default_records/descriptors/002_element_aviti_descriptors.yml
+++ b/config/default_records/descriptors/002_element_aviti_descriptors.yml
@@ -7,6 +7,7 @@ Quant method used:
   selection:
     Tapestation: Tapestation
     Tapestation & qPCR: Tapestation & qPCR
+    Not applicable: Not applicable
   required: true
   sorter: 0
 Pipette Carousel:


### PR DESCRIPTION
#### Changes proposed in this pull request

- Adds 'Not applicable' as an option for aviti quant_method_used.

Will manually add on prod:
```
d = Descriptor.find_by(name:"Quant method used")
d.selection = {"Tapestation" => "Tapestation", "Tapestation & qPCR" => "Tapestation & qPCR", "Not applicable" => "Not applicable"}
d.save!
```

