### PR TITLE
Revert "🚨 [security] [ruby] Update net-imap 0.6.3 → 0.6.4 (minor)"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,7 +339,7 @@ GEM
       bigdecimal
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.3)
       date
       net-protocol
     net-ldap (0.20.0)


### PR DESCRIPTION
Reverts sanger/sequencescape#5751

Int-suite fails with:

```  
A JsonApiClient::Errors::ConnectionError occurred in plate_creation#create:
  Net::ReadTimeout with #<TCPSocket:(closed)>
  app/integrations/sequencescape/api/v2.rb:55:in 'Sequencescape::Api::V2.plate_for_presenter'

An ActionView::Template::Error occurred in tube_creation#new:
  Net::ReadTimeout with #<TCPSocket:(closed)>
  app/integrations/sequencescape/api/v2/plate.rb:43:in 'Sequencescape::Api::V2::Plate.find_all'
```