### PR TITLE
fix: permits HashWithIndifferentAccess for descriptors

### DIFF
--- a/lib/acts_as_descriptable.rb
+++ b/lib/acts_as_descriptable.rb
@@ -33,7 +33,13 @@ module ActsAsDescriptable # :nodoc:
   require 'active_support/hash_with_indifferent_access'
 
   def self.included(base)
-    base.class_eval { serialize :descriptors, coder: YAML }
+    base.class_eval do
+      serialize :descriptors, coder: YAML, yaml: {
+        permitted_classes: [
+          'HashWithIndifferentAccess'
+        ]
+      }
+    end
   end
 
   def descriptors


### PR DESCRIPTION
Fixes production errors for 
```
  Tried to load unspecified class: HashWithIndifferentAccess
  lib/acts_as_descriptable.rb:52:in 'ActsAsDescriptable#descriptor_hash'
```

#### Changes proposed in this pull request

- Adds HashWithIndifferentAccess to descriptors permitted_classes

#### Instructions for Reviewers

To reproduce the error:
- Remove changes from this branch
- Connect to training db locally
- LabEvent.find(59833).descriptors