### PR TITLE
Y26-189 - [BUG] [PR] Revert incorrect id_sample_tmp mapping in well stock resource messages (reverts PR #5082)

### DIFF
--- a/app/models/api/messages/well_stock_resource_io.rb
+++ b/app/models/api/messages/well_stock_resource_io.rb
@@ -31,10 +31,7 @@ class Api::Messages::WellStockResourceIo < Api::Base
   end
 
   with_nested_has_many_association(:aliquots, as: 'samples') do
-    with_association(:sample) do
-      map_attribute_to_json_attribute(:id, 'id_sample_tmp')
-      map_attribute_to_json_attribute(:uuid, 'sample_uuid')
-    end
+    with_association(:sample) { map_attribute_to_json_attribute(:uuid, 'sample_uuid') }
     with_association(:study) { map_attribute_to_json_attribute(:uuid, 'study_uuid') }
   end
 end

--- a/spec/models/api/messages/well_stock_resource_io_spec.rb
+++ b/spec/models/api/messages/well_stock_resource_io_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Api::Messages::WellStockResourceIo do
   after { Timecop.return }
 
   let(:sample) { create(:sample) }
-  let(:sample2) { create(:sample) }
   let(:plate_barcode) { build(:plate_barcode) }
   let(:well) do
     create(
@@ -23,19 +22,14 @@ RSpec.describe Api::Messages::WellStockResourceIo do
   end
   let(:study) { create(:study) }
   let(:aliquot) { create(:aliquot, study: study, sample: sample, receptacle: well) }
-  let(:aliquot2) { create(:aliquot, study: study, sample: sample2, receptacle: well) }
 
-  before do # rubocop:todo RSpec/ScatteredSetup
-    aliquot
-    aliquot2
-  end
+  before { aliquot } # rubocop:todo RSpec/ScatteredSetup
 
   let(:expected_json) do
     {
       'created_at' => '2012-03-11T10:22:42+00:00',
       'updated_at' => '2012-03-11T10:22:42+00:00',
-      'samples' => [{ 'id_sample_tmp' => sample.id, 'sample_uuid' => sample.uuid, 'study_uuid' => study.uuid },
-                    { 'id_sample_tmp' => sample2.id, 'sample_uuid' => sample2.uuid, 'study_uuid' => study.uuid }],
+      'samples' => [{ 'sample_uuid' => sample.uuid, 'study_uuid' => study.uuid }],
       'stock_resource_id' => well.id,
       'stock_resource_uuid' => well.uuid,
       'machine_barcode' => plate_barcode.barcode,


### PR DESCRIPTION
#### Changes proposed in this pull request

id_sample_tmp is an internal MLWH identifier that is managed and populated
by the warehouse itself. Sequencescape should not explicitly set this field
in stock_resource messages.

PR #5082 introduced this mapping to fix a composite uniqueness constraint
failure in MLWH when a well has multiple aliquots for the same sample
(e.g. same sample with different tags in a pool). However, this was the
wrong fix: id_sample_tmp is not Sequencescape's field to populate, and
doing so risks associating stock_resource records with incorrect samples
in MLWH.

The correct approach is to ensure stock_resource messages do not contain
duplicate sample entries by deduplicating on sample_uuid before sending.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
