### PR TITLE
[dev] Add page visit helper and fix study information tests

### DIFF
--- a/spec/features/studies/view_study_request_links_spec.rb
+++ b/spec/features/studies/view_study_request_links_spec.rb
@@ -38,11 +38,15 @@ describe 'View study properties' do
 
   it 'No links to absent requests', :js do
     click_link sequencing_request_type.name
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+
     expect(page).to have_no_link(title: "#{library_tube.human_barcode} started")
   end
 
   it 'Single requests link directly to the request', :js do
     click_link sequencing_request_type.name
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+
     expect(page).to have_link('1', title: "#{library_tube.human_barcode} passed")
     click_link('1', title: "#{library_tube.human_barcode} passed")
     expect(page).to have_text('passed')
@@ -51,6 +55,8 @@ describe 'View study properties' do
 
   it 'Multiple requests link to the summary', :js do
     click_link sequencing_request_type.name
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+
     expect(page).to have_link('2', title: "#{library_tube.human_barcode} failed")
     click_link('2', title: "#{library_tube.human_barcode} failed")
     expect(page).to have_text("#{sequencing_request_type.name} Study 3871492")
@@ -58,6 +64,8 @@ describe 'View study properties' do
 
   it 'Filtering by asset type', :js do
     click_link 'Assets progress'
+    expect(page).to have_text 'Filter by'
+
     within '#summary' do
       expect(page).to have_text sample_tube.name
       expect(page).to have_text library_tube.name

--- a/spec/features/studies/view_study_request_links_spec.rb
+++ b/spec/features/studies/view_study_request_links_spec.rb
@@ -38,14 +38,14 @@ describe 'View study properties' do
 
   it 'No links to absent requests', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
 
     expect(page).to have_no_link(title: "#{library_tube.human_barcode} started")
   end
 
   it 'Single requests link directly to the request', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
 
     expect(page).to have_link('1', title: "#{library_tube.human_barcode} passed")
     click_link('1', title: "#{library_tube.human_barcode} passed")
@@ -55,7 +55,7 @@ describe 'View study properties' do
 
   it 'Multiple requests link to the summary', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.')
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
 
     expect(page).to have_link('2', title: "#{library_tube.human_barcode} failed")
     click_link('2', title: "#{library_tube.human_barcode} failed")
@@ -64,7 +64,7 @@ describe 'View study properties' do
 
   it 'Filtering by asset type', :js do
     click_link 'Assets progress'
-    expect(page).to have_text 'Filter by'
+    expect(page).to have_text('Filter by', wait: 10)
 
     within '#summary' do
       expect(page).to have_text sample_tube.name

--- a/spec/features/studies/view_study_request_links_spec.rb
+++ b/spec/features/studies/view_study_request_links_spec.rb
@@ -33,7 +33,7 @@ describe 'View study properties' do
       initial_study: study
     )
     login_user(user)
-    visit study_path(study)
+    visit_and_wait_for_title(study_path(study), "Information (#{study.name})")
   end
 
   it 'No links to absent requests', :js do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,7 @@ require 'capybara/rspec'
 require 'selenium/webdriver'
 require 'webmock/rspec'
 require 'support/user_login'
+require 'support/visit_helper'
 require 'jsonapi/resources/matchers'
 require 'aasm/rspec'
 require 'rspec/collection_matchers'
@@ -163,6 +164,7 @@ RSpec.configure do |config|
   config.order = :random
 
   config.include UserLogin
+  config.include VisitHelper, type: :feature
 
   config.around(:each, :warren) do |ex|
     Warren.handler.enable!

--- a/spec/support/user_login.rb
+++ b/spec/support/user_login.rb
@@ -4,12 +4,12 @@ module UserLogin
   # For use in feature tests. Login as either a new user, or an provided user
   #
   # @param [User] user The user to log in as, or nil to create a new user
-  # @return [TrueClass] true
   def login_user(user)
-    visit login_path
+    visit_and_wait_for_title(login_path, 'Login')
     fill_in 'Username', with: user.login
     fill_in 'Password', with: 'password'
     click_button 'Login'
-    true
+    expect(page).to have_css('#message_notice', text: 'Logged in successfully')
+    nil
   end
 end

--- a/spec/support/visit_helper.rb
+++ b/spec/support/visit_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module VisitHelper
+  # Navigates to a path and relies on Capybara's waiting behavior by asserting the page title.
+  # The title should be the text that follows the "Sequencescape | " prefix in the <title> tag.
+  def visit_and_wait_for_title(path, expected_title)
+    visit(path)
+    expect(page).to have_title("Sequencescape | #{expected_title}")
+  end
+end


### PR DESCRIPTION
Should fix some errors in feature tests

#### Changes proposed in this pull request

- Provide a title of the page you want to load and confirm that the page has loaded before continuing to the next step
  - See example in login_user: https://github.com/sanger/sequencescape/blob/81a477c0651c02cbbb0cba74b68180b6e5760eae/spec/support/user_login.rb#L8 
- Add checks that the study information page tabs have been loaded


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
