### PR TITLE
Y26-192 - Fix for add menu result render

### DIFF
--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -12,9 +12,7 @@
 <!-- Internal Links -->
 <% add :menu, 'Create Submission'           => new_submission_path %>
 <% add :menu, 'Create Bulk Submission'      => bulk_submissions_path %>
-<% unless Flipper.enabled?(:y26_192_prevent_ui_study_creation) %>
-  <%= add :menu, 'Create Study' => new_study_path %>
-<% end %>
+<% add :menu, 'Create Study'                => new_study_path unless Flipper.enabled?(:y26_192_prevent_ui_study_creation) %>
 <% add :menu, 'Create Project'              => new_project_path %>
 <% add :menu, 'Plate Summaries'             => plate_summaries_path %>
 <% add :menu, 'Create Custom Pools'         => new_pooling_path %>

--- a/app/views/sdb/sample_manifests/_side_links.html.erb
+++ b/app/views/sdb/sample_manifests/_side_links.html.erb
@@ -9,7 +9,5 @@
 <% add :menu, "Create supplier" => new_supplier_path %>
 <% add :menu, "View all suppliers" => suppliers_path %>
 <% add :menu, "&nbsp;" => '' -%>
-<% unless Flipper.enabled?(:y26_192_prevent_ui_study_creation) %>
-  <%= add :menu, 'Create Study' => new_study_path %>
-<% end %>
+<% add :menu, 'Create Study' => new_study_path unless Flipper.enabled?(:y26_192_prevent_ui_study_creation) %>
 <% add :menu, "Create Project" => new_project_path() %>


### PR DESCRIPTION
Closes https://psd-team.slack.com/archives/C095N1K4W80/p1783432258024579?thread_ts=1783432048.493399&cid=C095N1K4W80

>If you visit https://training.sequencescape.psd.sanger.ac.uk, you see   
  #&lt;Informatics::View::Menu::list:0x00007f8c9d219fe0>

#### Changes proposed in this pull request

- Replace expression output `<%=` with expression evaluate only `<-`
- Refactor for readability


Before:
<img width="424" height="331" alt="Screenshot 2026-07-07 at 15 46 33" src="https://github.com/user-attachments/assets/12e1ea71-8fe8-49e9-844a-b433322e23bf" />


After:
<img width="422" height="297" alt="Screenshot 2026-07-07 at 15 46 09" src="https://github.com/user-attachments/assets/86561e4d-565d-45fa-9b96-a622b8b387d0" />


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
