### PR TITLE
[dev] Add CSP report endpoint and generalise policy

### DIFF
--- a/app/controllers/content_security_policy_reports_controller.rb
+++ b/app/controllers/content_security_policy_reports_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Controller to handle Content Security Policy violation reports sent by browsers.
+#
+# These reports are sent as JSON payloads to the specified report URI when a CSP violation occurs.
+# The controller logs the received reports for further analysis and debugging.
+#
+# For more details, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/report-to
+class ContentSecurityPolicyReportsController < ApplicationController
+  skip_before_action :login_required
+
+  # Record violation reports in the application logs
+  def create
+    Rails.logger.warn "[csp-report] #{request.body.read}"
+
+    # Respond with a 204 No Content to acknowledge receipt of the report
+    head :no_content
+  end
+end

--- a/app/views/layouts/sessions.html.erb
+++ b/app/views/layouts/sessions.html.erb
@@ -10,7 +10,7 @@
     <link rel="icon" href="/<%= favicon %>" type="image/x-icon" />
     <link rel="apple-touch-icon-precomposed" href="/<%= apple_icon %>" type="image/png" />
 
-    <style>
+    <style nonce="<%= content_security_policy_nonce %>">
       .sessions {
         background-image:
           url('<%= vite_asset_url "images/sanger-pattern-corner.svg" %>'),

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,32 +11,11 @@ Rails.application.configure do
 #     policy.img_src     :self, :https, :data
 #     policy.object_src  :none
 #     policy.script_src  :self, :https
-
-  # Allow @vite/client to hot reload style changes
-  if Rails.env.development? || Rails.env.test?
-    asset_hosts = [
-      "http://#{ViteRuby.config.host_with_port}",
-      'http://localhost:3000',
-      'http://127.0.0.1:3000'
-    ].uniq
-
-    policy.script_src(*policy.script_src, :unsafe_eval, :data, *asset_hosts)
-    policy.script_src_elem(*policy.script_src_elem, :unsafe_eval, :data, :blob, *asset_hosts)
-    policy.style_src(*policy.style_src, :unsafe_inline, *asset_hosts)
-    policy.style_src_elem(*policy.style_src_elem, :unsafe_inline, *asset_hosts)
-  end
-
-  # You may need to enable this in production as well depending on your setup.
-  policy.script_src *policy.script_src, :blob
-
 #     policy.style_src   :self, :https
-  # Allow @vite/client to hot reload style changes in development
-  policy.style_src *policy.style_src, :unsafe_inline if Rails.env.development?
-
 #     # Specify URI for violation reports
 #     # policy.report_uri "/csp-violation-report-endpoint"
   end
-#
+
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w(script-src style-src)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self, :https, :data
     policy.style_src   :self, :https
+    policy.connect_src :self, :https
 
    # Specify URI for violation reports
     policy.report_uri "/csp-reports"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,19 +6,23 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https, :data
+    policy.style_src   :self, :https
+
+   # Specify URI for violation reports
+    policy.report_uri "/csp-reports"
   end
 
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # Nonces are also required for Vite resources tags:
+  # See ViteRailsNoncePatch at config/initializers/vite_rails_nonce_patch.rb for more information.
 
   # Report CSP violations to a specified URI
   # For further information see the following documentation:

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,12 +6,18 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
+    # CSP policy declarations
+    # NOTE:
+    # style_src      - fallback
+    # style_src_elem - linked stylesheets and inline style, eg: <link rel="stylesheet" href="..."> and <style>...</style>
+    # style_src_attr - inline style attributes, eg: <div style="color: red;">...</div>
     policy.default_src :none
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none
     policy.script_src  :self, :https, :data
-    policy.style_src   :self, :https, :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
+    policy.style_src   :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
+    policy.style_src_elem :self, :https
     policy.style_src_attr :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
     policy.connect_src :self, :https
 
@@ -21,7 +27,8 @@ Rails.application.configure do
 
    # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w(script-src style-src)
+  # add 'style-src' to the array below to generate nonces for styles
+  config.content_security_policy_nonce_directives = %w(script-src style_src_elem)
 
   # Nonces are also required for Vite resources tags:
   # See ViteRailsNoncePatch at config/initializers/vite_rails_nonce_patch.rb for more information.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self, :https, :data
     policy.style_src   :self, :https
+    policy.style_src_attr :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
     policy.connect_src :self, :https
 
    # Specify URI for violation reports

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,9 +16,13 @@ Rails.application.configure do
     policy.img_src     :self, :https, :data
     policy.object_src  :none
     policy.script_src  :self, :https, :data
-    policy.style_src   :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
-    policy.style_src_elem :self, :https
-    policy.style_src_attr :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
+    # Make styles maximally permissive to allow for inline styles and style attributes
+    # This is not good practice and effectively undoes the benefits of using a CSP
+    # Next step, reduce the scopes to :self, :https and tackle the warning messages in the console
+    policy.style_src   "*", :self, :http, :https, :data, :blob, :unsafe_inline, :unsafe_hashes
+    policy.style_src_elem "*", :self, :http, :https, :data, :blob, :unsafe_inline, :unsafe_hashes
+    policy.style_src_attr "*", :unsafe_inline
+
     policy.connect_src :self, :https
 
    # Specify URI for violation reports
@@ -27,8 +31,7 @@ Rails.application.configure do
 
    # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  # add 'style-src' to the array below to generate nonces for styles
-  config.content_security_policy_nonce_directives = %w(script-src style_src_elem)
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
 
   # Nonces are also required for Vite resources tags:
   # See ViteRailsNoncePatch at config/initializers/vite_rails_nonce_patch.rb for more information.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,7 +6,7 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.default_src :self, :https
+    policy.default_src :none
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
     policy.img_src     :self, :https, :data
     policy.object_src  :none
     policy.script_src  :self, :https, :data
-    policy.style_src   :self, :https
+    policy.style_src   :self, :https, :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
     policy.style_src_attr :unsafe_inline # WARNING: this is not good practice and undoes the benefits of using a CSP
     policy.connect_src :self, :https
 

--- a/config/initializers/vite_rails_nonce_patch.rb
+++ b/config/initializers/vite_rails_nonce_patch.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Automatically add a nonce to the Vite external resource tags for use with the Content Security Policy.
+module ViteRailsNoncePatch
+  def vite_javascript_tag(*names, **options)
+    options[:nonce] = true unless options.key?(:nonce)
+
+    super
+  end
+
+  def vite_stylesheet_tag(*names, **options)
+    options[:nonce] = true unless options.key?(:nonce)
+
+    super
+  end
+end
+
+ViteRails::TagHelpers.prepend(ViteRailsNoncePatch)

--- a/config/initializers/vite_rails_nonce_patch.rb
+++ b/config/initializers/vite_rails_nonce_patch.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # Automatically add a nonce to the Vite external resource tags for use with the Content Security Policy.
+#
+# The content security policy itself is defined in config/initializers/content_security_policy.rb
 module ViteRailsNoncePatch
   def vite_javascript_tag(*names, **options)
     options[:nonce] = true unless options.key?(:nonce)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
   get 'authentication/open'
   get 'authentication/restricted'
 
+  # Content Security Policy report endpoint
+  post '/csp-reports' => 'content_security_policy_reports#create', :as => :csp_reports
+
   # Feature flags
   user_is_admin = ->(req) { User.find_by(id: req.session[:user])&.administrator? }
   mount Flipper::UI.app => '/flipper', :constraints => user_is_admin

--- a/spec/controllers/content_security_policy_reports_controller_spec.rb
+++ b/spec/controllers/content_security_policy_reports_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ContentSecurityPolicyReportsController do
+  describe 'POST #create' do
+    context 'when a CSP violation report is sent' do
+      let(:report) do
+        { 'csp-report':
+         {
+           'document-uri': 'http://localhost:3000/test-url',
+           referrer: 'http://localhost:3000/referrer-url',
+           'violated-directive': 'script-src-elem',
+           'effective-directive': 'script-src-elem',
+           'original-policy': "default-src 'self' https:; object-src 'none'; report-uri /csp-reports",
+           disposition: 'report',
+           'blocked-uri': 'data',
+           'status-code': 200,
+           'script-sample': ''
+         } }
+      end
+
+      it 'logs the report' do
+        allow(Rails.logger).to receive(:warn)
+
+        post :create, body: report.to_json, as: :json
+
+        expect(Rails.logger).to have_received(:warn).with("[csp-report] #{report.to_json}")
+      end
+
+      it 'responds with a 204 No Content status' do
+        post :create, body: report.to_json, as: :json
+
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/sanger/sequencescape/pull/5713

#### Changes proposed in this pull request

- Add nonce tags to Vite resources
- Create a Content Security Policy controller to log CSP violation reports
- Remove specific exceptions from CSP and use better general settings instead
- Generates logs whenever a policy is violated:
  ```log
  [WARN] [csp-report] {"csp-report":{"document-uri":"http://localhost:3000/admin/accessioning_tools","referrer":"http://localhost:3000/admin","violated-directive":"script-src-elem","effective-directive":"script-src-elem","original-policy":"default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; report-uri /csp-reports","disposition":"report","blocked-uri":"data","status-code":200,"script-sample":""}}
  ```
- Logs can be parsed and analysed in Kibana


> [!WARNING]
> The policy `policy.style_src_attr :unsafe_inline` opens a hole in the CSP layer negating many of the benefits that a content security policy brings.
It is strongly recommended that any instances of inline `style` attributes be converted to Bootstrap classes or stylesheets.
Usages can be found using:
>```sh
>grep -rI --include=\*.html\* --exclude=\*.svg 'style=' app/ > style_src_attr.txt  
>```
>For more detail see https://centralcsp.com/docs/style-src-attr.

#### Informative resources

##### Official Rails Guide
- https://edgeguides.rubyonrails.org/security.html#content-security-policy-header
##### Useful background
- https://upgraderuby.com/articles/improving-frontend-security-strict-csp-rails-8/
##### Specifications
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints
- https://content-security-policy.com/
- https://w3c.github.io/reporting/#intro

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
