### PR TITLE
[dev] Increase requests link load timouts to 15s

### DIFF
--- a/spec/features/studies/view_study_request_links_spec.rb
+++ b/spec/features/studies/view_study_request_links_spec.rb
@@ -38,14 +38,14 @@ describe 'View study properties' do
 
   it 'No links to absent requests', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 15)
 
     expect(page).to have_no_link(title: "#{library_tube.human_barcode} started")
   end
 
   it 'Single requests link directly to the request', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 15)
 
     expect(page).to have_link('1', title: "#{library_tube.human_barcode} passed")
     click_link('1', title: "#{library_tube.human_barcode} passed")
@@ -55,7 +55,7 @@ describe 'View study properties' do
 
   it 'Multiple requests link to the summary', :js do
     click_link sequencing_request_type.name
-    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 10)
+    expect(page).to have_text('Identifies the asset, and the number of requests directly from it.', wait: 15)
 
     expect(page).to have_link('2', title: "#{library_tube.human_barcode} failed")
     click_link('2', title: "#{library_tube.human_barcode} failed")


### PR DESCRIPTION
Tries to fix some failing tests for https://github.com/sanger/General-Backlog-Items/issues/681

#### Changes proposed in this pull request

- Change timeout of request loading in `spec/features/studies/view_study_request_links_spec.rb` to 15 seconds 🤞 

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
