### PR TITLE
Y26-204 - Remove MySQL 8.0 references

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -16,7 +16,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -10,7 +10,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/.github/workflows/cucumber_tests.yml
+++ b/.github/workflows/cucumber_tests.yml
@@ -39,7 +39,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/.github/workflows/rake_tests.yml
+++ b/.github/workflows/rake_tests.yml
@@ -36,7 +36,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/.github/workflows/rspec_feature_tests.yml
+++ b/.github/workflows/rspec_feature_tests.yml
@@ -39,7 +39,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/.github/workflows/rspec_unit_tests.yml
+++ b/.github/workflows/rspec_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following tools are required for development:
 - node (`brew install node@<version>` version defined in the `.nvmrc`, ensure node is in your PATH)
 - mysql client libraries - if you do not want to install mysql server on your machine, consider
   using mysql-client: `brew install mysql-client`. Alternatively, to install the MySQL required by
-  Sequencescape (currently 8.0)
+  Sequencescape (currently 8.4)
 
 ## Getting started (using Docker)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       retries: 5
 
   mysql_server:
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD="yes"
     healthcheck:


### PR DESCRIPTION
Relates to https://github.com/sanger/General-Backlog-Items/issues/738

#### Changes proposed in this pull request

- Removes mysql 8.0 from CI matrices 


Extension of work from https://github.com/sanger/sequencescape/pull/5702