### PR TITLE
Y26-070 - Display submission template_name in Limber

### DIFF
--- a/app/controllers/api/v2/submissions_controller.rb
+++ b/app/controllers/api/v2/submissions_controller.rb
@@ -5,6 +5,9 @@ module Api
     # Provides a JSON API controller for submission
     # See: http://jsonapi-resources.com/ for JSONAPI::Resource documentation
     class SubmissionsController < JSONAPI::ResourceController
+      DEFAULT_SUBMISSION_FIELDS = %w[uuid name state created_at updated_at].freeze
+      SUBMISSION_RELATIONSHIP_FIELDS = %w[orders user].freeze
+
       # By default JSONAPI::ResourceController provides most the standard
       # behaviour, and in many cases this file may be left empty.
 
@@ -17,7 +20,8 @@ module Api
         return default if default.dig('fields', 'submissions')
 
         default['fields'] ||= {}
-        default['fields']['submissions'] = 'uuid,name,state,created_at,updated_at'
+        default['fields']['submissions'] = [DEFAULT_SUBMISSION_FIELDS + SUBMISSION_RELATIONSHIP_FIELDS].join(',')
+
         default
       end
     end

--- a/app/resources/api/v2/order_resource.rb
+++ b/app/resources/api/v2/order_resource.rb
@@ -80,6 +80,9 @@ module Api
       attribute :project_uuid, writeonly: true
       attr_writer :project_uuid # Not stored, consumed by OrderProcessor.
 
+      # @!attribute [r] template_name
+      attribute :template_name, readonly: true
+
       ###
       # Relationships
       ###
@@ -98,6 +101,10 @@ module Api
       #   @return [UserResource] The user who created this {Order}.
       #   @note This can only be set once upon creation.
       has_one :user, readonly: true
+
+      # @!attribute [r] submission
+      #  @return [SubmissionResource] The submission associated with this {Order}.
+      has_one :submission, readonly: true
 
       ###
       # Templated Creation

--- a/app/resources/api/v2/submission_resource.rb
+++ b/app/resources/api/v2/submission_resource.rb
@@ -137,6 +137,8 @@ module Api
 
       ###
       # Relationships
+      # Note: You need to include the relationhips explicitly in the controller
+      # if you want them to be included by default, see app/controllers/api/v2/submissions_controller.rb
       ###
 
       # @!attribute [rw] user

--- a/spec/requests/api/v2/submissions_spec.rb
+++ b/spec/requests/api/v2/submissions_spec.rb
@@ -106,6 +106,22 @@ describe 'Submissions API', with: :api_v2 do
           expect(json['included']).not_to be_present
         end
       end
+
+      context 'with included relationships' do
+        before { api_get "#{base_endpoint}/#{resource.id}?include=orders,user" }
+
+        it 'includes the orders relationship' do
+          expect(json.dig('data', 'relationships', 'orders', 'data')).to be_present
+        end
+
+        it 'includes the user relationship' do
+          expect(json.dig('data', 'relationships', 'user', 'data')).to be_present
+        end
+
+        it 'includes attributes for related resources' do
+          expect(json['included']).to be_present
+        end
+      end
     end
 
     describe '#GET resource by ID with specific fields' do

--- a/spec/requests/api/v2/submissions_spec.rb
+++ b/spec/requests/api/v2/submissions_spec.rb
@@ -95,11 +95,11 @@ describe 'Submissions API', with: :api_v2 do
         end
 
         it 'does not include the orders relationship' do
-          expect(json.dig('data', 'relationships', 'orders')).not_to be_present
+          expect(json.dig('data', 'relationships', 'orders')).to be_present
         end
 
         it 'does not include the user relationship' do
-          expect(json.dig('data', 'relationships', 'user')).not_to be_present
+          expect(json.dig('data', 'relationships', 'user')).to be_present
         end
 
         it 'does not include attributes for related resources' do


### PR DESCRIPTION
Relates to https://github.com/sanger/limber/issues/2735
Limber PR: https://github.com/sanger/limber/pull/2948

#### Changes proposed in this pull request

- Exposes template_name in v2 order resource
- Fixes bug where when no submission fields were specified the default ones would filter out relationships by default.

#### Notes
- Another option is to add 'template_name' as an attribute to submission and delegate to the first order. I am not sure if this is going to always be right though, it assumes all orders under a submission use the same template. Is that a safe assumption? This would also require us to load the orders for all submission api calls by proxy which im not sure is a good trade off.

