### PR TITLE
[dev] Add mock accessioning server

### DIFF
--- a/mock_accessioning_server.py
+++ b/mock_accessioning_server.py
@@ -1,0 +1,163 @@
+"""
+Mock ENA/EGA accessioning server for local development and testing.
+
+Listens on http://localhost:9999 and responds to POST requests with XML receipts
+that mimic the ENA/EGA submission service. Accession numbers are auto-incremented
+starting from EGA000010001.
+
+Usage:
+    python mock_accessioning_server.py [--always-succeed | --always-fail]
+
+Modes:
+    (no flag)          Randomly succeed or fail each request (mix of 200/400/500/403 status codes)
+    --always-succeed   Always return a success receipt (200 OK with success="true")
+    --always-fail      Always return a failure receipt (randomly 200/500/403)
+
+Examples:
+    python mock_accessioning_server.py
+    python mock_accessioning_server.py --always-succeed
+    python mock_accessioning_server.py --always-fail
+
+The server detects MODIFY actions in the request body and returns a modify receipt
+instead of an add receipt when appropriate.
+"""
+
+import random
+import sys
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from datetime import datetime, timezone
+
+
+def parse_flags():
+    always_succeed = "--always-succeed" in sys.argv
+    always_fail = "--always-fail" in sys.argv
+    return always_succeed, always_fail
+
+
+ALWAYS_SUCCEED, ALWAYS_FAIL = parse_flags()
+
+
+def generate_success_response(receipt_date, accession_number):
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<RECEIPT receiptDate="{receipt_date}" success="true">
+  <SUBMISSION accession="SUB0000001" alias="submission_1"/>
+  <STUDY accession="STD0000001"/>
+  <SAMPLE accession="{accession_number}"/>
+  <ACTIONS>ADD</ACTIONS>
+</RECEIPT>
+"""
+
+
+def generate_modify_response(receipt_date, accession_number):
+    return f"""
+    <?xml version="1.0" encoding="UTF-8"?>
+    <?xml-stylesheet type="text/xsl" href="receipt.xsl"?>
+    <RECEIPT receiptDate="{receipt_date}" success="true">
+        <SAMPLE accession="{accession_number}" alias="submission_1" status="PRIVATE" holdUntilDate="2028-01-08Z">
+            <EXT_ID accession="SAMEA131896906" type="biosample"/>
+        </SAMPLE>
+        <SUBMISSION accession="" alias="submission_1-2026-01-08T14:28:09Z"/>
+        <MESSAGES>
+            <INFO>This submission is a TEST submission and will be discarded within 24 hours</INFO>
+        </MESSAGES>
+        <ACTIONS>MODIFY</ACTIONS>
+        <ACTIONS>HOLD</ACTIONS>
+    </RECEIPT>
+    """
+
+
+def generate_failure_response(receipt_date):
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<RECEIPT receiptDate="{receipt_date}" success="false">
+  <MESSAGES>
+    <ERROR>Houston, we've had a problem.</ERROR>
+    <ERROR>We've had a Main B Bus Undervolt.</ERROR>
+  </MESSAGES>
+</RECEIPT>
+"""
+
+
+class MockAccessionHandler(BaseHTTPRequestHandler):
+    accession_counter = 1  # Start at 1 for EGA000010001
+
+    def respond_with_modify(self, receipt_date, accession_number):
+        modify_response = generate_modify_response(receipt_date, accession_number)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/xml")
+        self.end_headers()
+        self.wfile.write(modify_response.encode("utf-8"))
+
+    def respond_with_success(self, receipt_date, accession_number):
+        # Success: 200 OK
+        success_response = generate_success_response(receipt_date, accession_number)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/xml")
+        self.end_headers()
+        self.wfile.write(success_response.encode("utf-8"))
+
+    def respond_with_failure(self, receipt_date):
+        failure_response = generate_failure_response(receipt_date)
+        error_type = random.choice(["400", "500", "403"])
+        if error_type == "400":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/xml")
+            self.end_headers()
+            self.wfile.write(failure_response.encode("utf-8"))
+        elif error_type == "500":
+            self.send_response(500)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"Internal Server Error")
+        else:
+            self.send_response(403)
+            self.wfile.write(b"")
+
+    def do_POST(self):
+        # Log incoming request
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b""
+        print(f"\n--- Incoming Request ---")
+        print(f"Path: {self.path}")
+        print("Headers:")
+        for k, v in self.headers.items():
+            print(f"  {k}: {v}")
+        print(f"Body:\n{body.decode('utf-8', errors='replace')}")
+        print(f"-----------------------\n")
+
+        # Get current timestamp in the required format
+        now = datetime.now(timezone.utc)
+        receipt_date = now.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        # Increment accession number for each request
+        accession_number = f"EGA00001000{MockAccessionHandler.accession_counter}"
+        MockAccessionHandler.accession_counter += 1
+
+        if ALWAYS_SUCCEED:
+            content = body.decode("utf-8", errors="replace")
+            if content.find("<ACTIONS>MODIFY</ACTIONS>") != -1:
+                self.respond_with_modify(receipt_date, accession_number)
+            else:
+                self.respond_with_success(receipt_date, accession_number)
+        elif ALWAYS_FAIL:
+            self.respond_with_failure(receipt_date)
+        else:
+            if random.choice([True, False]):
+                self.respond_with_success(receipt_date, accession_number)
+            else:
+                self.respond_with_failure(receipt_date)
+
+
+if __name__ == "__main__":
+    server_address = ("", 9999)
+    httpd = HTTPServer(server_address, MockAccessionHandler)
+    print("Mock accession server running")
+    if ALWAYS_SUCCEED:
+        print("  (configured to always succeed)")
+    elif ALWAYS_FAIL:
+        print("  (configured to always fail)")
+    print(f"Listening on http://localhost:{server_address[1]}")
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down")
+        httpd.server_close()


### PR DESCRIPTION
A vanilla Python implementation of a the ENA accessioning service for development and testing purposes.

- Can be set to always fail, always succeed, or to succeed or fail with random HTTP status codes
- Specifically developed to work with the [ENA Webin REST V1](https://ena-docs.readthedocs.io/en/latest/submit/general-guide/webin-v1.html) API, a [version 2](https://ena-docs.readthedocs.io/en/latest/submit/general-guide/programmatic.html) is recommended for new projects
- Displays the sent payloads for debugging
- Works out the box with Sequencescape's development config: `python mock_accessioning_server.py`

Usage example:
```sh
$ python mock_accessioning_server.py --always-succeed
Mock accession server running
  (configured to always succeed)
Listening on http://localhost:9999

--- Incoming Request ---
Path: /accession_service/
Headers:
  User-Agent: Sequencescape Accessioning V1 Client
  Content-Type: multipart/form-data; boundary=-----------RubyMultipartPost-a4c26aa3f520b5b8c9b83a1b23a9691c
  Content-Length: 1781
  Authorization: Basic ZXJhX2FjY2Vzc2lvbl9sb2dpbjplcmFfYWNjZXNzaW9uX3Bhc3N3b3Jk
  Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
  Accept: */*
  Host: localhost:9999
Body:
-------------RubyMultipartPost-a4c26aa3f520b5b8c9b83a1b23a9691c
Content-Disposition: form-data; name="SUBMISSION"; filename="da4021c2-3a5b-11f1-8097-060cfcc4e09f-2026-08-18T124819Z.submission.xml"
Content-Length: 413
Content-Type: text/plain
Content-Transfer-Encoding: binary

<?xml version="1.0" encoding="UTF-8"?><SUBMISSION xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" center_name="SC" broker_name="" alias="da4021c2-3a5b-11f1-8097-060cfcc4e09f-2026-08-18T12:48:19Z" submission_date="2026-08-18T12:48:19Z"><ACTIONS><ACTION><ADD source="da4021c2-3a5b-11f1-8097-060cfcc4e09f-2026-08-18T124819Z.sample.xml" schema="sample"/></ACTION><ACTION><HOLD/></ACTION></ACTIONS></SUBMISSION>

-------------RubyMultipartPost-a4c26aa3f520b5b8c9b83a1b23a9691c
Content-Disposition: form-data; name="SAMPLE"; filename="da4021c2-3a5b-11f1-8097-060cfcc4e09f-2026-08-18T124819Z.sample.xml"
Content-Length: 739
Content-Type: text/plain
Content-Transfer-Encoding: binary

<?xml version="1.0" encoding="UTF-8"?><SAMPLE_SET xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><SAMPLE alias="da4021c2-3a5b-11f1-8097-060cfcc4e09f"><TITLE>sample_1_SQPD-9873_B1</TITLE><SAMPLE_NAME><TAXON_ID>9606</TAXON_ID><COMMON_NAME>Homo sapiens</COMMON_NAME></SAMPLE_NAME><SAMPLE_ATTRIBUTES><SAMPLE_ATTRIBUTE><TAG>geographic location (country and/or sea)</TAG><VALUE>not provided</VALUE></SAMPLE_ATTRIBUTE><SAMPLE_ATTRIBUTE><TAG>collection date</TAG><VALUE>not provided</VALUE></SAMPLE_ATTRIBUTE><SAMPLE_ATTRIBUTE><TAG>sample description</TAG><VALUE>SD-SQPD-9873</VALUE></SAMPLE_ATTRIBUTE><SAMPLE_ATTRIBUTE><TAG>ArrayExpress-SPECIES</TAG><VALUE>Homo sapiens</VALUE></SAMPLE_ATTRIBUTE></SAMPLE_ATTRIBUTES></SAMPLE></SAMPLE_SET>

-------------RubyMultipartPost-a4c26aa3f520b5b8c9b83a1b23a9691c--

-----------------------

127.0.0.1 - - [18/Aug/2026 13:48:19] "POST /accession_service/ HTTP/1.1" 200 -
```

#### Changes proposed in this pull request

- Add a local accessioning server for development use

**TODO**: decide which directory it should live in - or if the repository root is fine.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
