### PR TITLE
[dev] Set accessioning_enabled across tests in SampleAccessioningJob

### DIFF
--- a/spec/jobs/sample_accessioning_job_spec.rb
+++ b/spec/jobs/sample_accessioning_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 # See additional related tests in spec/models/sample_spec.rb
 
-RSpec.describe SampleAccessioningJob do
+RSpec.describe SampleAccessioningJob, :accessioning_enabled do
   include AccessionV1ClientHelper
 
   let(:first_open_study) { create(:open_study, accession_number: 'ENA123') }
@@ -25,7 +25,7 @@ RSpec.describe SampleAccessioningJob do
     allow(ExceptionNotifier).to receive(:notify_exception)
   end
 
-  describe '#perform', :accessioning_enabled do
+  describe '#perform' do
     # An accession sample status is created when the job is queued
 
     context 'when the submission fails validation' do
@@ -330,7 +330,7 @@ RSpec.describe SampleAccessioningJob do
     end
   end
 
-  describe '#success', :accessioning_enabled do
+  describe '#success' do
     before do
       create(:accession_sample_status, sample: sample, status: 'failed')
       create(:accession_sample_status, sample: sample, status: 'failed')


### PR DESCRIPTION
Fixes flaky tests in develop after merging in #5996 

#### Changes proposed in this pull request

- Add the `:accessioning_enabled` helper to _all_ tests in `spec/jobs/sample_accessioning_job_spec.rb` so that config is loaded before tests, no matter the running order.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
