### PR TITLE
Y26-261 - [PR][BUG] Study Search returns two results for an exact match

### DIFF
--- a/app/resources/api/v2/sapio/study_search_query.rb
+++ b/app/resources/api/v2/sapio/study_search_query.rb
@@ -74,8 +74,8 @@ module Api
           # - unquoted `*` as `%`
           # - unquoted `?` as `_`
           #
-          # Any `%`, `_`, or `\` characters inside literal text are escaped so they
-          # are treated as data, not LIKE metacharacters.
+          # Any `%`, `_`, or `\` characters inside literal text are escaped so
+          # they are treated as data, not LIKE metacharacters.
           #
           # @param records [ActiveRecord::Relation] The base study relation to filter.
           # @param query [String] The search string, potentially containing quoted
@@ -113,20 +113,30 @@ module Api
         end
 
         class_methods do
-          # Filters studies by name using exact match, partial match, and phonetic match.
-          # If the query is quoted, the quotes are stripped before matching and the
-          # search term is treated as literal text.
+          # Filters studies by name using exact match, partial match, and,
+          # where appropriate, phonetic match.
+          # If the query is quoted, the quotes are stripped before matching and
+          # the search term is treated as literal text.
+          #
+          # Phonetic (SOUNDEX) matching is skipped for quoted "exact phrase"
+          # queries, and for any query containing digits. MySQL's SOUNDEX()
+          # ignores all non-alphabetic characters, so it cannot distinguish
+          # names that differ only numerically (e.g. "v0.2.1" vs "v0.3.1"),
+          # which would otherwise cause both to match a search for either one.
           #
           # @param records [ActiveRecord::Relation] The base study relation to filter.
           # @param query [String] The search string to match against study names.
           # @return [ActiveRecord::Relation] A relation filtered by exact, partial, or
           #   phonetic name matching.
           def contains_name_scope(records, query)
-            query = query[1..-2].squish if query.start_with?('"') && query.end_with?('"')
+            quoted = query.start_with?('"') && query.end_with?('"')
+            query = query[1..-2].squish if quoted
             escaped_query = sql_escape(query)
+
             condition = 'studies.name = :exact OR ' \
-                        "studies.name LIKE :partial ESCAPE '\\\\' OR " \
-                        'SOUNDEX(studies.name) = SOUNDEX(:query)'
+                        "studies.name LIKE :partial ESCAPE '\\\\'"
+            condition += ' OR SOUNDEX(studies.name) = SOUNDEX(:query)' unless quoted || query.match?(/\d/)
+
             records.where(condition, exact: query, partial: "%#{escaped_query}%", query: query)
           end
         end

--- a/app/resources/api/v2/sapio/study_search_query.rb
+++ b/app/resources/api/v2/sapio/study_search_query.rb
@@ -69,6 +69,20 @@ module Api
         end
 
         class_methods do
+          # Splits a query into quoted-phrase and unquoted-chunk tokens.
+          # A quoted-phrase token includes its surrounding quotes.
+          #
+          # @param query [String] The search string, potentially containing quoted phrases.
+          # @return [Array<String>] The tokens, in order.
+          def tokenize_query(query)
+            # "[^"\\]*(?:\\.[^"\\]*)*" : Quoted token
+            # |                        : OR
+            # [^"]+                    : Unquoted chunk
+            query.scan(/"[^"\\]*(?:\\.[^"\\]*)*"|[^"]+/)
+          end
+        end
+
+        class_methods do
           # Builds a SQL LIKE pattern from the query, supporting:
           # - quoted phrases as literal text
           # - unquoted `*` as `%`
@@ -83,12 +97,7 @@ module Api
           # @return [ActiveRecord::Relation] A relation filtered by the translated
           #   LIKE pattern.
           def wildcard_name_scope(records, query)
-            # "[^"\\]*(?:\\.[^"\\]*)*" : Quoted token
-            # |                        : OR
-            # [^"]+                    : Unquoted chunk
-            tokens = query.scan(/"[^"\\]*(?:\\.[^"\\]*)*"|[^"]+/)
-
-            translated_pattern = tokens.map do |token|
+            translated_pattern = tokenize_query(query).map do |token|
               if token.start_with?('"') && token.end_with?('"')
                 # Inside quotes: strip delimiters, treat content as literal
                 sql_escape(token[1..-2])
@@ -99,6 +108,21 @@ module Api
             end.join
 
             records.where("studies.name LIKE :pattern ESCAPE '\\\\'", pattern: translated_pattern)
+          end
+        end
+
+        class_methods do
+          # Strips quote delimiters from every quoted phrase in the query,
+          # treating quoted content as literal text wherever it appears (even
+          # when only part of the query is quoted, e.g. `MAVE_SGE "v0.2.1"`).
+          #
+          # @param query [String] The search string, potentially containing quoted phrases.
+          # @return [String] The query with quote delimiters removed.
+          def strip_quotes(query)
+            tokenize_query(query)
+              .map { |token| token.start_with?('"') && token.end_with?('"') ? token[1..-2] : token }
+              .join
+              .squish
           end
         end
 
@@ -115,14 +139,16 @@ module Api
         class_methods do
           # Filters studies by name using exact match, partial match, and,
           # where appropriate, phonetic match.
-          # If the query is quoted, the quotes are stripped before matching and
-          # the search term is treated as literal text.
+          # Quoted phrases are stripped of their quotes and treated as literal
+          # text, even when only part of the query is quoted (e.g.
+          # `MAVE_SGE "v0.2.1"`).
           #
-          # Phonetic (SOUNDEX) matching is skipped for quoted "exact phrase"
-          # queries, and for any query containing digits. MySQL's SOUNDEX()
-          # ignores all non-alphabetic characters, so it cannot distinguish
-          # names that differ only numerically (e.g. "v0.2.1" vs "v0.3.1"),
-          # which would otherwise cause both to match a search for either one.
+          # Phonetic (SOUNDEX) matching is skipped when the whole query is one
+          # quoted "exact phrase", and for any query containing digits.
+          # MySQL's SOUNDEX() ignores all non-alphabetic characters, so it
+          # cannot distinguish names that differ only numerically (e.g.
+          # "v0.2.1" vs "v0.3.1"), which would otherwise cause both to match
+          # a search for either one.
           #
           # @param records [ActiveRecord::Relation] The base study relation to filter.
           # @param query [String] The search string to match against study names.
@@ -130,7 +156,7 @@ module Api
           #   phonetic name matching.
           def contains_name_scope(records, query)
             quoted = query.start_with?('"') && query.end_with?('"')
-            query = query[1..-2].squish if quoted
+            query = strip_quotes(query)
             escaped_query = sql_escape(query)
 
             condition = 'studies.name = :exact OR ' \

--- a/spec/requests/api/v2/sapio/studies_spec.rb
+++ b/spec/requests/api/v2/sapio/studies_spec.rb
@@ -574,6 +574,29 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
       end
     end
 
+    context 'with names differing only numerically' do
+      # Regression test: SOUNDEX() ignores digits, so previously a search for
+      # either name would phonetically match both, returning two studies.
+      before do
+        create(:study, name: 'MAVE_SGE v0.2.1')
+        create(:study, name: 'MAVE_SGE v0.3.1')
+      end
+
+      it 'returns only the exact match for an unquoted query', :aggregate_failures do
+        api_get "#{base_endpoint}?filter[name]=MAVE_SGE v0.2.1"
+        expect(response).to have_http_status(:success)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
+      end
+
+      it 'returns only the exact match for a quoted query', :aggregate_failures do
+        api_get "#{base_endpoint}?filter[name]=\"MAVE_SGE v0.2.1\""
+        expect(response).to have_http_status(:success)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
+      end
+    end
+
     context 'with multiple wildcards and exact phrases in query' do
       before do
         create(:study, name: 'Genome assembly for Haemophilus influenzae strains')

--- a/spec/requests/api/v2/sapio/studies_spec.rb
+++ b/spec/requests/api/v2/sapio/studies_spec.rb
@@ -595,6 +595,27 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
         expect(json['data'].length).to eq(1)
         expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
       end
+
+      it 'returns only the exact match for a partially quoted query', :aggregate_failures do
+        api_get "#{base_endpoint}?filter[name]=MAVE_SGE \"v0.2.1\""
+        expect(response).to have_http_status(:success)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
+      end
+
+      it 'returns only the exact match for a wildcard query mixing ? and a quoted phrase', :aggregate_failures do
+        api_get "#{base_endpoint}?filter[name]=MAVE_SGE v?.\"2.1\""
+        expect(response).to have_http_status(:success)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
+      end
+
+      it 'returns only the exact match for a non-wildcard query split across a quoted phrase', :aggregate_failures do
+        api_get "#{base_endpoint}?filter[name]=MAVE_SGE v0.\"2.1\""
+        expect(response).to have_http_status(:success)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('MAVE_SGE v0.2.1')
+      end
     end
 
     context 'with multiple wildcards and exact phrases in query' do


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Fixed `contains_name_scope` returning extra matches via `SOUNDEX`: MySQL's `SOUNDEX()` ignores digits, so a search like MAVE_SGE v0.2.1 was phonetically matching MAVE_SGE v0.3.1 too - now skipped for quoted or digit-containing queries.
- Generalised quote-stripping to handle partially-quoted queries (e.g. MAVE_SGE "v0.2.1"), which previously matched nothing because only a fully-quoted whole query had its quotes removed.
- Extracted a shared `tokenize_query` helper (used by both `wildcard_name_scope` and the new `strip_quotes`) to avoid duplicating the quoted/unquoted token regex.
- Added regression tests covering unquoted, fully-quoted, and partially-quoted variants of the search term.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
