### PR TITLE
Y26-245 - [PR] 'Upsert' endpoint to create study or update it to be externally managed

### DIFF
--- a/app/controllers/api/v2/sapio/studies_controller.rb
+++ b/app/controllers/api/v2/sapio/studies_controller.rb
@@ -199,13 +199,33 @@ module Api
         end
 
         # Wraps the existing Study resource so it renders exactly like a
-        # freshly created resource.
+        # freshly created resource, marking it as externally managed if it
+        # is not already.
         #
         # @param id [Integer] the primary key of the existing Study.
         # @return [JSONAPI::ResourceOperationResult] the existing Study resource
         def existing_resource_result(id)
           resource = resource_klass.find_by_key(id, context:)
+          mark_externally_managed(resource._model)
           JSONAPI::ResourceOperationResult.new(:ok, resource)
+        end
+
+        # Marks +study+ as externally managed, unless it already is.
+        #
+        # @note This does not yet broadcast the change to mlwarehouse (see Y26-245).
+        #
+        # @param study [Study] model to mark as externally managed
+        # @return [void]
+        def mark_externally_managed(study)
+          return if study.externally_managed?
+
+          # Bypasses Study#prevent_updates_when_externally_managed, which would otherwise block this
+          # save as soon as externally_managed becomes true below. Api::V2::Sapio::StudyResource's own
+          # before_create/before_update hook sets this for the normal create/update flow, but this
+          # method saves the model directly, so it must be set here too.
+          study.skip_externally_managed_restriction = true
+          study.externally_managed = true
+          study.save!
         end
 
         # Looks up the id of the existing Study with the supplied uuid.

--- a/app/controllers/api/v2/sapio/studies_controller.rb
+++ b/app/controllers/api/v2/sapio/studies_controller.rb
@@ -32,9 +32,11 @@ module Api
           super
         end
 
-        # Creates a new externally managed Study.
-        #
-        # It should NOT be used to transfer an existing Sequencescape study to Sapio.
+        # Creates a new externally managed Study, or, when the
+        # +y26_245_sapio_study_upsert+ feature flag is enabled and the
+        # supplied uuid already belongs to an existing Study, marks that
+        # Study as externally managed instead
+        # (see StudyProcessor#create_resource).
         #
         # @return [void]
         def create

--- a/app/controllers/api/v2/sapio/studies_controller.rb
+++ b/app/controllers/api/v2/sapio/studies_controller.rb
@@ -145,10 +145,39 @@ module Api
       end
 
       class StudyProcessor < JSONAPI::Processor
+        before_create_resource :validate_uuid_presence
         before_create_resource :validate_uuid_format
         before_create_resource :validate_uuid_uniqueness
 
+        # Creates a new Study, unless the +y26_245_sapio_study_upsert+ feature
+        # flag is enabled and the supplied uuid already belongs to an existing
+        # Study, in which case that Study is returned as-is instead of raising
+        # a conflict.
+        #
+        # @note This is the first step towards full upsert behaviour
+        #   (see Y26-245). It does not yet mark the existing Study as
+        #   +externally_managed+ or broadcast it to mlwarehouse.
+        #
+        # @return [JSONAPI::ResourceOperationResult]
+        def create_resource
+          return existing_resource_result(existing_study_id) if upsert_enabled? && existing_study_id
+
+          super
+        end
+
         private
+
+        # Validates that a uuid was supplied, when the
+        # +y26_245_sapio_study_upsert+ feature flag is enabled. Without a uuid,
+        # Sequencescape has nothing to match against an existing Study, so the
+        # upsert behaviour (see #create_resource) cannot work.
+        #
+        # @raise [Errors::MissingUuid] if the uuid is missing and upsert is enabled.
+        def validate_uuid_presence
+          return if external_uuid.present? || !upsert_enabled?
+
+          raise Errors::MissingUuid
+        end
 
         # Validates that the provided UUID is in a valid format.
         def validate_uuid_format
@@ -157,9 +186,11 @@ module Api
           raise JSONAPI::Exceptions::InvalidFieldValue.new(:uuid, external_uuid)
         end
 
-        # Validate that the provided UUID is unique
+        # Validate that the provided UUID is unique, unless the
+        # +y26_245_sapio_study_upsert+ feature flag is enabled, in which case a
+        # duplicate uuid is handled by #create_resource instead of raising.
         def validate_uuid_uniqueness
-          return if external_uuid.blank?
+          return if external_uuid.blank? || upsert_enabled?
 
           # Validation for unique UUID against all Sequencescape UUIDs
           return if Uuid.find_id(external_uuid).blank?
@@ -167,6 +198,35 @@ module Api
           raise Errors::FieldValueConflict.new(:uuid, external_uuid)
         end
 
+        # Wraps the existing Study resource so it renders exactly like a
+        # freshly created resource.
+        #
+        # @param id [Integer] the primary key of the existing Study.
+        # @return [JSONAPI::ResourceOperationResult] the existing Study resource
+        def existing_resource_result(id)
+          resource = resource_klass.find_by_key(id, context:)
+          JSONAPI::ResourceOperationResult.new(:ok, resource)
+        end
+
+        # Looks up the id of the existing Study with the supplied uuid.
+        #
+        # @return [Integer, nil] the id of the existing Study, or nil.
+        def existing_study_id
+          return if external_uuid.blank?
+
+          Study.with_uuid(external_uuid).pick(:id)
+        end
+
+        # Checks whether the +y26_245_sapio_study_upsert+ feature flag is enabled.
+        #
+        # @return [Boolean] true if the feature flag is enabled, false otherwise.
+        def upsert_enabled?
+          Flipper.enabled?(:y26_245_sapio_study_upsert)
+        end
+
+        # The raw uuid string supplied in the request payload, if any.
+        #
+        # @return [String, nil]
         def external_uuid
           @external_uuid ||= params.dig(:data, :attributes, :uuid)
         end

--- a/app/controllers/api/v2/sapio/studies_controller.rb
+++ b/app/controllers/api/v2/sapio/studies_controller.rb
@@ -172,7 +172,8 @@ module Api
         # Sequencescape has nothing to match against an existing Study, so the
         # upsert behaviour (see #create_resource) cannot work.
         #
-        # @raise [Errors::MissingUuid] if the uuid is missing and upsert is enabled.
+        # @raise [Errors::MissingUuid] if the uuid is missing and upsert is
+        #   enabled.
         def validate_uuid_presence
           return if external_uuid.present? || !upsert_enabled?
 
@@ -210,22 +211,28 @@ module Api
           JSONAPI::ResourceOperationResult.new(:ok, resource)
         end
 
-        # Marks +study+ as externally managed, unless it already is.
+        # Marks +study+ as externally managed, unless it already is, and
+        # broadcasts the change to mlwarehouse.
         #
-        # @note This does not yet broadcast the change to mlwarehouse (see Y26-245).
+        # @note The broadcast only happens on the false-to-true transition.
+        #   Once a Study is already externally managed, re-broadcasting on
+        #   subsequent calls risks overwriting data mlwarehouse has received.
         #
         # @param study [Study] model to mark as externally managed
         # @return [void]
         def mark_externally_managed(study)
           return if study.externally_managed?
 
-          # Bypasses Study#prevent_updates_when_externally_managed, which would otherwise block this
-          # save as soon as externally_managed becomes true below. Api::V2::Sapio::StudyResource's own
-          # before_create/before_update hook sets this for the normal create/update flow, but this
-          # method saves the model directly, so it must be set here too.
+          # Bypasses Study#prevent_updates_when_externally_managed, which
+          # would otherwise block this save as soon as externally_managed
+          # becomes true below. Api::V2::Sapio::StudyResource's own
+          # before_create/before_update hook sets this for the normal
+          # create/update flow, but this method saves the model directly,
+          # so it must be set here too.
           study.skip_externally_managed_restriction = true
           study.externally_managed = true
           study.save!
+          study.broadcast
         end
 
         # Looks up the id of the existing Study with the supplied uuid.
@@ -237,9 +244,11 @@ module Api
           Study.with_uuid(external_uuid).pick(:id)
         end
 
-        # Checks whether the +y26_245_sapio_study_upsert+ feature flag is enabled.
+        # Checks whether the +y26_245_sapio_study_upsert+ feature flag is
+        # enabled.
         #
-        # @return [Boolean] true if the feature flag is enabled, false otherwise.
+        # @return [Boolean] true if the feature flag is enabled, false
+        #   otherwise.
         def upsert_enabled?
           Flipper.enabled?(:y26_245_sapio_study_upsert)
         end

--- a/app/models/api/study_io.rb
+++ b/app/models/api/study_io.rb
@@ -45,6 +45,7 @@ class Api::StudyIo < Api::Base
 
   extra_json_attributes do |object, json_attributes|
     json_attributes['abbreviation'] = object.abbreviation
+    json_attributes['is_current'] = !object.externally_managed?
 
     object.roles.each do |role|
       role_key = role.name.downcase.gsub(/\s+/, '_')

--- a/app/resources/api/v2/sapio/errors.rb
+++ b/app/resources/api/v2/sapio/errors.rb
@@ -51,6 +51,20 @@ module Api::V2::Sapio::Errors
     end
   end
 
+  class MissingUuid < JSONAPI::Exceptions::Error
+    def errors
+      [
+        JSONAPI::Error.new(
+          status: :bad_request,
+          title: 'Missing Uuid',
+          code: 'MISSING_UUID',
+          detail: 'A uuid is required to upsert a Study via this endpoint.',
+          source: { pointer: '/data/attributes/uuid' }
+        )
+      ]
+    end
+  end
+
   class MissingSearchParam < JSONAPI::Exceptions::Error
     def errors
       [

--- a/app/resources/api/v2/sapio/study_resource.rb
+++ b/app/resources/api/v2/sapio/study_resource.rb
@@ -79,6 +79,23 @@ module Api
       #     }
       #   }
       #
+      # @example POST request that upserts an existing Study
+      #   (y26_245_sapio_study_upsert enabled)
+      #   POST /api/v2/sapio/studies
+      #   Content-Type: application/json
+      #   X-Sequencescape-Client-Id: <integration_hub_api_key>
+      #   {
+      #     "data": {
+      #       "type": "studies",
+      #       "attributes": {
+      #         "name": "Ignored - the existing Study's name is not changed",
+      #         "uuid": "11111111-2222-3333-4444-555555666666"
+      #       }
+      #     }
+      #   }
+      #   # Returns 200 OK with the existing Study, now externally_managed,
+      #   # instead of 201 Created.
+      #
       # == Updating an Existing Study
       #
       # Existing studies can be updated using the PATCH method. Only studies that have been marked

--- a/app/resources/api/v2/sapio/study_resource.rb
+++ b/app/resources/api/v2/sapio/study_resource.rb
@@ -45,11 +45,23 @@ module Api
       #
       # == Creating a New Externally Managed Study
       #
-      # The POST method creates a new {Study} that is managed externally, granting ownership to the
-      # requesting user.
+      # The POST method creates a new {Study} that is managed externally,
+      # granting ownership to the requesting user.
       #
-      # This method is intended exclusively for creating *new* studies that originate in an external
-      # LIMS. It should NOT be used to transfer an existing Sequencescape study to the external LIMS.
+      # @note When the +y26_245_sapio_study_upsert+ feature flag is enabled,
+      #   this method behaves as an upsert based on the supplied +uuid+: if
+      #   Sequencescape does not already have a Study with that uuid, a new
+      #   Study is created as described above; if it already has one, that
+      #   Study is instead marked +externally_managed+ (if not already) and
+      #   broadcast to mlwarehouse, rather than raising a conflict. No other
+      #   attributes on the existing Study are changed by this. This means
+      #   the method CAN be used to transfer an existing Sequencescape study
+      #   to the external LIMS, once this flag is enabled. When this feature
+      #   flag is disabled, this method is intended exclusively for creating
+      #   *new* studies that originate in an external LIMS, and should NOT be
+      #   used to transfer an existing Sequencescape study to the external
+      #   LIMS - supplying a uuid that already exists will return a
+      #   **409 Conflict** instead.
       #
       # If a UUID is not provided, one will be generated automatically.
       #

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -25,3 +25,4 @@ y25_442_make_api_key_mandatory: Makes API key mandatory for all API requests
 y26_170_sapio_studies_endpoint: Enables the Sapio studies endpoint
 y26_172_enable_externally_managed_study_restrictions: Blocks UI/API updates to externally_managed studies except Integration Hub and explicit console bypass
 y26_192_prevent_ui_study_creation: Prevents users from creating studies in the UI, only allowing study creation via API
+y26_245_sapio_study_upsert: Enables upsert behaviour on the Sapio study creation endpoint for uuids that already exist

--- a/spec/models/api/study_io_spec.rb
+++ b/spec/models/api/study_io_spec.rb
@@ -65,4 +65,26 @@ RSpec.describe Api::StudyIo do
   end
 
   it_behaves_like('an IO object')
+
+  describe 'is_current' do
+    let(:study) { subject }
+    let(:rendered_json) { described_class.to_hash(study) }
+
+    context 'when the study is not externally managed' do
+      it 'is true' do
+        expect(rendered_json['is_current']).to be(true)
+      end
+    end
+
+    context 'when the study is externally managed' do
+      before do
+        study.skip_externally_managed_restriction = true
+        study.update!(externally_managed: true)
+      end
+
+      it 'is false' do
+        expect(rendered_json['is_current']).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v2/sapio/studies_spec.rb
+++ b/spec/requests/api/v2/sapio/studies_spec.rb
@@ -856,16 +856,32 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
           end
 
           context 'when the existing study is not already externally managed' do
+            before { allow(Warren.handler).to receive(:<<) }
+
             it 'sets externally_managed to true on the existing study' do
               expect { perform_request }.to(change { existing_study.reload.externally_managed }.from(false).to(true))
+            end
+
+            it 'broadcasts the existing study' do
+              perform_request
+
+              expect(Warren.handler).to have_received(:<<).with(an_instance_of(Warren::Message::Full))
             end
           end
 
           context 'when the existing study is already externally managed' do
             let(:existing_study) { create(:study, name: 'Existing Sapio Study', externally_managed: true) }
 
+            before { allow(Warren.handler).to receive(:<<) }
+
             it 'does not change externally_managed on the existing study' do
               expect { perform_request }.not_to(change { existing_study.reload.externally_managed })
+            end
+
+            it 'does not broadcast the existing study' do
+              perform_request
+
+              expect(Warren.handler).not_to have_received(:<<)
             end
           end
         end

--- a/spec/requests/api/v2/sapio/studies_spec.rb
+++ b/spec/requests/api/v2/sapio/studies_spec.rb
@@ -796,19 +796,87 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
           }
         end
 
-        before { api_post base_endpoint, duplicate_uuid_payload, headers: integration_hub_headers }
+        let(:perform_request) { api_post base_endpoint, duplicate_uuid_payload, headers: integration_hub_headers }
 
-        it 'returns 409 Conflict' do
-          expect(response).to have_http_status(:conflict)
+        context 'when the sapio study upsert feature flag is disabled', :sapio_study_upsert_disabled do
+          before { perform_request }
+
+          it 'returns 409 Conflict' do
+            expect(response).to have_http_status(:conflict)
+          end
+
+          it 'returns a uuid validation error' do
+            expect(json['errors']).to eq(
+              [{
+                'title' => 'Conflict',
+                'detail' => "The value #{existing_study.uuid} for the field uuid conflicts with an existing record.",
+                'code' => 'FIELD_VALUE_CONFLICT',
+                'status' => '409',
+                'source' => {
+                  'pointer' => '/data/attributes/uuid'
+                }
+              }]
+            )
+          end
+
+          it 'does not create a study' do
+            expect(Study.find_by(name: 'Sapio Created Study')).to be_nil
+          end
         end
 
-        it 'returns a uuid validation error' do
+        context 'when the sapio study upsert feature flag is enabled', :sapio_study_upsert_enabled do
+          before { existing_study } # ensure the study exists before measuring changes caused by perform_request
+
+          it 'returns 200 OK' do
+            perform_request
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'does not return any errors in the response' do
+            perform_request
+            expect(json['errors']).to be_nil
+          end
+
+          it 'does not create a new study' do
+            expect { perform_request }.not_to change(Study, :count)
+          end
+
+          it 'returns the existing study id' do
+            perform_request
+            expect(json.dig('data', 'id')).to eq(existing_study.id.to_s)
+          end
+
+          it 'returns the existing study uuid' do
+            perform_request
+            expect(json.dig('data', 'attributes', 'uuid')).to eq(existing_study.uuid)
+          end
+
+          it 'does not change the existing study name' do
+            expect { perform_request }.not_to(change { existing_study.reload.name })
+          end
+
+          it 'does not change externally_managed on the existing study' do
+            expect { perform_request }.not_to(change { existing_study.reload.externally_managed })
+          end
+        end
+      end
+
+      context 'with no uuid in payload', :sapio_study_upsert_enabled do
+        let(:perform_request) { api_post base_endpoint, valid_payload, headers: integration_hub_headers }
+
+        it 'returns 400 Bad Request' do
+          perform_request
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it 'returns a missing uuid error' do
+          perform_request
           expect(json['errors']).to eq(
             [{
-              'title' => 'Conflict',
-              'detail' => "The value #{existing_study.uuid} for the field uuid conflicts with an existing record.",
-              'code' => 'FIELD_VALUE_CONFLICT',
-              'status' => '409',
+              'title' => 'Missing Uuid',
+              'detail' => 'A uuid is required to create or take ownership of a Study via this endpoint.',
+              'code' => 'MISSING_UUID',
+              'status' => '400',
               'source' => {
                 'pointer' => '/data/attributes/uuid'
               }
@@ -817,7 +885,7 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
         end
 
         it 'does not create a study' do
-          expect(Study.find_by(name: 'Sapio Created Study')).to be_nil
+          expect { perform_request }.not_to change(Study, :count)
         end
       end
 

--- a/spec/requests/api/v2/sapio/studies_spec.rb
+++ b/spec/requests/api/v2/sapio/studies_spec.rb
@@ -855,8 +855,18 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
             expect { perform_request }.not_to(change { existing_study.reload.name })
           end
 
-          it 'does not change externally_managed on the existing study' do
-            expect { perform_request }.not_to(change { existing_study.reload.externally_managed })
+          context 'when the existing study is not already externally managed' do
+            it 'sets externally_managed to true on the existing study' do
+              expect { perform_request }.to(change { existing_study.reload.externally_managed }.from(false).to(true))
+            end
+          end
+
+          context 'when the existing study is already externally managed' do
+            let(:existing_study) { create(:study, name: 'Existing Sapio Study', externally_managed: true) }
+
+            it 'does not change externally_managed on the existing study' do
+              expect { perform_request }.not_to(change { existing_study.reload.externally_managed })
+            end
           end
         end
       end
@@ -874,7 +884,7 @@ describe 'Sapio Studies API', :sapio_studies_endpoint_enabled, with: :api_v2 do
           expect(json['errors']).to eq(
             [{
               'title' => 'Missing Uuid',
-              'detail' => 'A uuid is required to create or take ownership of a Study via this endpoint.',
+              'detail' => 'A uuid is required to upsert a Study via this endpoint.',
               'code' => 'MISSING_UUID',
               'status' => '400',
               'source' => {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -266,6 +266,26 @@ RSpec.configure do |config|
     Flipper.enable(:y26_172_enable_externally_managed_study_restrictions, externally_managed_restrictions_enabled)
   end
 
+  # Add sapio_study_upsert_enabled to a spec to automatically:
+  # - Set y26_245_sapio_study_upsert to true before the test
+  # - Roll the feature flag back to its original state afterward
+  config.around(:each, :sapio_study_upsert_enabled) do |example|
+    sapio_study_upsert_enabled = Flipper.enabled?(:y26_245_sapio_study_upsert)
+    Flipper.enable(:y26_245_sapio_study_upsert)
+    example.run
+    Flipper.enable(:y26_245_sapio_study_upsert, sapio_study_upsert_enabled)
+  end
+
+  # Add sapio_study_upsert_disabled to a spec to automatically:
+  # - Set y26_245_sapio_study_upsert to false before the test
+  # - Roll the feature flag back to its original state afterward
+  config.around(:each, :sapio_study_upsert_disabled) do |example|
+    sapio_study_upsert_enabled = Flipper.enabled?(:y26_245_sapio_study_upsert)
+    Flipper.disable(:y26_245_sapio_study_upsert)
+    example.run
+    Flipper.enable(:y26_245_sapio_study_upsert, sapio_study_upsert_enabled)
+  end
+
   config.before do
     # Reset the all sequences at the beginning of each
     # test to reduce the impact test order has on test execution


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

## Summary

Implements Y26-245: `POST /api/v2/sapio/studies` now behaves as an upsert based on the supplied uuid, so the Integration Hub can call the same "create study" endpoint whether or not Sequencescape already knows about the study.

- Adds a new feature flag, `y26_245_sapio_study_upsert`, gating all of the below.
- If the uuid is unknown, behaviour is unchanged (Y26-173's existing create flow).
- If the uuid already belongs to an existing Study, that Study is returned instead of raising a 409 Conflict, and is marked `externally_managed = true` if it isn't already (no-op, no broadcast, if it's already managed - see note on idempotency below).
- On the actual `false -> true` transition, the Study is broadcast to mlwarehouse via the same mechanism `Study#rebroadcast` already uses (`Warren::Message::Full`, immediate/synchronous), bypassing the usual
  `broadcast_except_externally_managed` suppression for externally managed studies.
- `Api::StudyIo` (controls the warehouse message payload for Study) now includes `is_current`, derived as `!externally_managed?`
- When upsert is enabled, a uuid is now required - a missing uuid returns a new `MissingUuid` (400) error rather than silently falling back to an auto-generated uuid, since upsert has nothing to match against without one.
- Updated the endpoint's docs (`Api::V2::Sapio::StudyResource` and the controller's `create` action) to describe the new dual behaviour, including for when the flag is disabled.

## Design notes

- The broadcast only fires on the real `false -> true` transition, not on every repeated call. Once a Study is externally managed, Sequencescape is no longer the authority on its data, so re-broadcasting on every subsequent upsert call risked overwriting data mlwarehouse has since received directly from Sapio.
- A repeated upsert call on an already-managed Study is a no-op success (200, unchanged), not an error - chosen for safety under retries/at-least-once delivery from Integration Hub, rather than rejecting it outright.
- Chose a direct/synchronous broadcast over the `Warren::Message::Short` + `QueueBroadcastConsumer` async pattern . See comparison at https://github.com/sanger/sequencescape/issues/5999#issuecomment-5618984860

## Open questions

- Confirm the client can handle a `200` vs `201` response depending on whether the uuid was new or already known.
- Confirm the `is_current` mapping (`is_current = !externally_managed`) matches what mlwarehouse expect (Test it in UAT)
- Does IH always give a UUID, i.e. should we create a new Study instead of returning a missing uuid error?
- Does the message need a different `id_lims` for broadcasting?

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
